### PR TITLE
Add built-in input(prompt) function

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -23,7 +23,7 @@ Implemented subset:
 - single-argument pattern shorthand: 0 -> 1 is treated like (0) -> 1
 - guards: pattern ? condition -> result
 - blocks with newline or ; expression separators
-- builtins: log(...), help()
+- builtins: log(...), print(...), input(prompt), help()
 
 Not yet implemented:
 - lambdas
@@ -950,6 +950,9 @@ def make_global_env(stdin_data: Optional[list[str]] = None) -> Env:
         print(*args)
         return args[-1] if args else None
 
+    def input_fn(prompt: str = "") -> str:
+        return input(prompt)
+
     def help_fn() -> None:
         print(
             """
@@ -997,6 +1000,7 @@ Commands:
         )
     env.set("log", log)
     env.set("print", print_fn)
+    env.set("input", input_fn)
     env.set("stdin", [] if stdin_data is None else stdin_data)
     env.set("help", help_fn)
     env.set("pi", math.pi)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,2 +1,19 @@
 def test_basic(run):
     assert run("1+2") == 3
+
+
+def test_input_builtin_returns_user_text(run, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda prompt="": "typed value")
+    assert run('input("Prompt: ")') == "typed value"
+
+
+def test_input_builtin_passes_prompt(run, monkeypatch):
+    prompts: list[str] = []
+
+    def fake_input(prompt=""):
+        prompts.append(prompt)
+        return "ok"
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    assert run('input("Enter value: ")') == "ok"
+    assert prompts == ["Enter value: "]


### PR DESCRIPTION
### Motivation
- Expose a simple `input(prompt)` builtin so Genia programs can prompt the user and receive typed text, matching the REPL behavior and other builtins like `log` and `print`.

### Description
- Add `input_fn(prompt: str = "")` that forwards to Python's `input(prompt)` and register it in the global environment via `env.set("input", input_fn)` in `make_global_env` in `src/genia/interpreter.py`.
- Update the interpreter builtins overview comment to include `input(prompt)` for documentation consistency.
- Add tests in `tests/test_basic.py` that verify the builtin returns the typed text and that the given prompt string is forwarded to the underlying `input` call.

### Testing
- Ran `pytest -q` (without `PYTHONPATH=src`) which failed in this environment due to import path setup (`ModuleNotFoundError: No module named 'genia'`).
- Ran `PYTHONPATH=src pytest -q` which executed the test suite and reported `69 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4532be8ec8329abaede6d08e855b6)