### PR TITLE
Add transactional refs with atomic update and blocking read

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -38,6 +38,7 @@ import math
 from pathlib import Path
 import re
 import sys
+import threading
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional
 
@@ -644,6 +645,43 @@ class TailCall:
     args: tuple[Any, ...]
 
 
+_UNSET = object()
+
+
+class GeniaRef:
+    def __init__(self, initial: Any = _UNSET):
+        self._condition = threading.Condition()
+        self._value = initial
+        self._is_set = initial is not _UNSET
+
+    def get(self) -> Any:
+        with self._condition:
+            while not self._is_set:
+                self._condition.wait()
+            return self._value
+
+    def set(self, value: Any) -> Any:
+        with self._condition:
+            self._value = value
+            self._is_set = True
+            self._condition.notify_all()
+            return value
+
+    def update(self, fn: Any) -> Any:
+        with self._condition:
+            while not self._is_set:
+                self._condition.wait()
+            self._value = fn(self._value)
+            self._condition.notify_all()
+            return self._value
+
+    def __repr__(self) -> str:
+        with self._condition:
+            if self._is_set:
+                return f"<ref {self._value!r}>"
+            return "<ref <unset>>"
+
+
 def eval_with_tco(fn: Any, args: tuple[Any, ...]) -> Any:
     current_fn = fn
     current_args = args
@@ -1013,6 +1051,31 @@ Commands:
   :help   show this help
 """.strip()
         )
+
+    def ref_fn(*args: Any) -> GeniaRef:
+        if len(args) == 0:
+            return GeniaRef()
+        if len(args) == 1:
+            return GeniaRef(args[0])
+        raise TypeError(f"ref expected 0 or 1 args, got {len(args)}")
+
+    def ref_get_fn(ref_value: Any) -> Any:
+        if not isinstance(ref_value, GeniaRef):
+            raise TypeError("ref_get expected a ref")
+        return ref_value.get()
+
+    def ref_set_fn(ref_value: Any, value: Any) -> Any:
+        if not isinstance(ref_value, GeniaRef):
+            raise TypeError("ref_set expected a ref as first argument")
+        return ref_value.set(value)
+
+    def ref_update_fn(ref_value: Any, updater: Any) -> Any:
+        if not isinstance(ref_value, GeniaRef):
+            raise TypeError("ref_update expected a ref as first argument")
+        if not callable(updater):
+            raise TypeError("ref_update expected a function as second argument")
+        return ref_value.update(updater)
+
     env.set("log", log)
     env.set("print", print_fn)
     env.set("input", input_fn)
@@ -1023,6 +1086,10 @@ Commands:
     env.set("true", True)
     env.set("false", False)
     env.set("nil", None)
+    env.set("ref", ref_fn)
+    env.set("ref_get", ref_get_fn)
+    env.set("ref_set", ref_set_fn)
+    env.set("ref_update", ref_update_fn)
 
     env.register_autoload("reduce", 3, "std/prelude/list.genia")
     env.register_autoload("count", 1, "std/prelude/list.genia")

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,0 +1,42 @@
+import threading
+import time
+
+from genia import make_global_env, run_source
+
+
+def test_ref_holds_initial_value(run):
+    src = '''
+    r = ref(41)
+    ref_get(r)
+    '''
+    assert run(src) == 41
+
+
+def test_ref_update_is_atomic_function_application(run):
+    src = '''
+    r = ref(1)
+    ref_update(r, (x) -> x + 41)
+    ref_get(r)
+    '''
+    assert run(src) == 42
+
+
+def test_ref_get_blocks_until_set():
+    env = make_global_env([])
+    run_source("r = ref()", env)
+
+    result: dict[str, object] = {}
+
+    def waiting_reader():
+        result["value"] = run_source("ref_get(r)", env)
+
+    reader = threading.Thread(target=waiting_reader)
+    reader.start()
+
+    time.sleep(0.05)
+    assert reader.is_alive()
+
+    run_source("ref_set(r, 99)", env)
+    reader.join(timeout=1)
+
+    assert result["value"] == 99


### PR DESCRIPTION
### Motivation
- Provide a small transactional reference primitive to hold mutable state and support atomic transformations and blocking reads as a foundation for a promise abstraction. 

### Description
- Add a `GeniaRef` runtime type in `src/genia/interpreter.py` with an `_UNSET` sentinel, a `threading.Condition` for synchronization, and methods `get()`, `set(value)`, `update(fn)` and `__repr__` to inspect refs. 
- Expose language builtins `ref()`, `ref_get(ref)`, `ref_set(ref, value)`, and `ref_update(ref, fn)` with argument validation so Genia programs can create and manipulate refs. 
- Import `threading` and wire the new functions into the global environment returned by `make_global_env`. 
- Add `tests/test_refs.py` exercising initial value reading, atomic functional updates via `ref_update`, and blocking `ref_get` behavior that unblocks after `ref_set`.

### Testing
- Ran `pytest -q` in this environment without adjusting `PYTHONPATH`, which failed to import the package (`ModuleNotFoundError`), as expected in a source-layout repo. 
- Ran the full test suite with `PYTHONPATH=src pytest -q`, and the suite passed including the new tests (`73 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54bc282308329921d9ec07aa26122)