### PR TITLE
Make stdin lazy and callable in Genia runtime

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -40,7 +40,7 @@ import re
 import sys
 import threading
 from dataclasses import dataclass
-from typing import Any, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 BASE_DIR = Path(__file__).resolve().parents[2] if "__file__" in globals() else Path.cwd()
 
@@ -1204,7 +1204,10 @@ def truthy(value: Any) -> bool:
 # Builtins / REPL
 # -----------------------------
 
-def make_global_env(stdin_data: Optional[list[str]] = None) -> Env:
+def make_global_env(
+    stdin_data: Optional[list[str]] = None,
+    stdin_provider: Optional[Callable[[], list[str]]] = None,
+) -> Env:
     env = Env()
 
     def log(*args: Any) -> Any:
@@ -1217,6 +1220,19 @@ def make_global_env(stdin_data: Optional[list[str]] = None) -> Env:
 
     def input_fn(prompt: str = "") -> str:
         return input(prompt)
+
+    stdin_cache: Optional[list[str]] = None
+
+    def stdin_fn() -> list[str]:
+        nonlocal stdin_cache
+        if stdin_cache is None:
+            if stdin_provider is not None:
+                stdin_cache = stdin_provider()
+            elif stdin_data is not None:
+                stdin_cache = stdin_data
+            else:
+                stdin_cache = sys.stdin.read().splitlines()
+        return stdin_cache
 
     def help_fn() -> None:
         print(
@@ -1245,7 +1261,7 @@ Examples:
     (x, 0) -> x |
     (x, y) -> x + y
 
-  print(stdin)
+  print(stdin())
   count([1, 2, 3])
   print([1, 2, 3])
 
@@ -1291,7 +1307,7 @@ Commands:
     env.set("log", log)
     env.set("print", print_fn)
     env.set("input", input_fn)
-    env.set("stdin", [] if stdin_data is None else stdin_data)
+    env.set("stdin", stdin_fn)
     env.set("help", help_fn)
     env.set("pi", math.pi)
     env.set("e", math.e)
@@ -1396,8 +1412,7 @@ def repl() -> None:
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
-        stdin_data = sys.stdin.read().splitlines()
-        env = make_global_env(stdin_data)
+        env = make_global_env()
         with open(sys.argv[1], "r", encoding="utf-8") as f:
             result = run_source(f.read(), env)
         if result is not None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -17,3 +17,30 @@ def test_input_builtin_passes_prompt(run, monkeypatch):
     monkeypatch.setattr("builtins.input", fake_input)
     assert run('input("Enter value: ")') == "ok"
     assert prompts == ["Enter value: "]
+
+
+def test_stdin_builtin_is_callable_and_returns_lines():
+    from genia import make_global_env, run_source
+
+    env = make_global_env(stdin_data=["a", "b"])
+    assert run_source("stdin()", env) == ["a", "b"]
+
+
+def test_stdin_builtin_is_lazy():
+    calls = 0
+
+    def provider():
+        nonlocal calls
+        calls += 1
+        return ["x", "y"]
+
+    from genia import make_global_env, run_source
+
+    env = make_global_env(stdin_provider=provider)
+    assert calls == 0
+    assert run_source("1 + 1", env) == 2
+    assert calls == 0
+    assert run_source("stdin()", env) == ["x", "y"]
+    assert calls == 1
+    assert run_source("stdin()", env) == ["x", "y"]
+    assert calls == 1


### PR DESCRIPTION
### Motivation
- Prevent program startup from blocking on `sys.stdin.read()` and provide a more ergonomic `stdin()` API for scripts and the REPL.
- Allow tests and embedding code to supply stdin lazily via a provider instead of pre-populating a list at environment creation.

### Description
- Changed `make_global_env` signature to accept an optional `stdin_provider` and added `stdin_data` backward-compatible parameter as before.
- Implemented a cached `stdin_fn()` that lazily acquires lines from `stdin_provider`, `stdin_data`, or `sys.stdin.read()` on first call and returns the same list on subsequent calls, and exposed it as the `stdin` builtin (`env.set("stdin", stdin_fn)`).
- Updated REPL help text to show `stdin()` usage and removed the eager `sys.stdin.read()` call from `__main__` script path so startup no longer blocks.
- Added tests to `tests/test_basic.py` verifying that `stdin()` returns configured lines and that a provided `stdin_provider` is evaluated lazily and cached.

### Testing
- Ran `PYTHONPATH=src pytest -q`, which executed the test suite and reported `83 passed`.
- Running plain `pytest -q` without `PYTHONPATH` failed to import the package (`ModuleNotFoundError`) in this environment, and `uv run pytest -q` failed due to network dependency fetching; these are environmental issues, not regressions in the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56a2f4ce88329b00f32e70adfed68)