### PR TITLE
Clarify lexer symbol/operator rules and deterministic identifier tokenization

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -50,6 +50,16 @@ BASE_DIR = Path(__file__).resolve().parents[2] if "__file__" in globals() else P
 # Lexer
 # -----------------------------
 
+# Single source of truth for symbol/operator policy:
+# - These characters are always token delimiters/operators in Genia.
+# - Clojure-style symbol punctuation that we allow in names is listed below.
+# - `name?` and `name!` are ordinary identifiers (no special lexer semantics).
+# - `/` is reserved for division and is not allowed inside identifier names.
+ALWAYS_OPERATOR_DELIMITERS = frozenset({"+", "-", "*", "/", "%", "=", "<", ">", "|", ",", ";", "(", ")", "{", "}", "[", "]"})
+ALLOWED_SYMBOL_PUNCTUATION = frozenset({"_", "?", "!", ".", ":", "$"})
+IDENT_START_RE = re.compile(r"[A-Za-z_]")
+IDENT_BODY_RE = re.compile(r"[A-Za-z0-9]")
+
 TOKEN_SPEC = [
     ("NUMBER", r"\d+(?:\.\d+)?"),
     ("STRING", r'"([^"\\]|\\.)*"|\'([^\'\\]|\\.)*\''),
@@ -115,13 +125,16 @@ PUNCTUATION_TOKENS = [
     ("COMMA", ","),
     ("SEMI", ";"),
 ]
-TOKEN_BOUNDARIES = [text for _, text in PUNCTUATION_TOKENS] + ["#"]
-IDENT_TOKEN_BOUNDARIES = [boundary for boundary in TOKEN_BOUNDARIES if boundary != "?"]
+def _is_identifier_start(ch: str) -> bool:
+    return bool(IDENT_START_RE.fullmatch(ch))
 
 
-def _starts_token_boundary(source: str, pos: int, *, for_identifier: bool = False) -> bool:
-    boundaries = IDENT_TOKEN_BOUNDARIES if for_identifier else TOKEN_BOUNDARIES
-    return any(source.startswith(boundary, pos) for boundary in boundaries)
+def _is_identifier_part(ch: str) -> bool:
+    if IDENT_BODY_RE.fullmatch(ch):
+        return True
+    if ch in ALWAYS_OPERATOR_DELIMITERS:
+        return False
+    return ch in ALLOWED_SYMBOL_PUNCTUATION
 
 
 @dataclass
@@ -167,6 +180,14 @@ def lex(source: str) -> list[Token]:
             pos += len(text)
             continue
 
+        if _is_identifier_start(ch):
+            ident_start = pos
+            pos += 1
+            while pos < length and _is_identifier_part(source[pos]):
+                pos += 1
+            tokens.append(Token("IDENT", source[ident_start:pos], ident_start))
+            continue
+
         matched_punctuation = False
         for kind, text in PUNCTUATION_TOKENS:
             if source.startswith(text, pos):
@@ -175,13 +196,6 @@ def lex(source: str) -> list[Token]:
                 matched_punctuation = True
                 break
         if matched_punctuation:
-            continue
-
-        ident_start = pos
-        while pos < length and not source[pos].isspace() and not _starts_token_boundary(source, pos, for_identifier=True):
-            pos += 1
-        if pos > ident_start:
-            tokens.append(Token("IDENT", source[ident_start:pos], ident_start))
             continue
         raise SyntaxError(f"Unexpected character {source[pos]!r} at {pos}")
 

--- a/tests/test_lexer_symbols.py
+++ b/tests/test_lexer_symbols.py
@@ -1,0 +1,35 @@
+from genia.interpreter import lex
+
+
+def _kinds_texts(src: str) -> list[tuple[str, str]]:
+    return [(t.kind, t.text) for t in lex(src) if t.kind != "EOF"]
+
+
+def test_name_suffix_qmark_and_bang_are_plain_identifiers():
+    tokens = _kinds_texts("ready? = true\nsave! = false")
+    assert tokens == [
+        ("IDENT", "ready?"),
+        ("ASSIGN", "="),
+        ("IDENT", "true"),
+        ("NEWLINE", "\n"),
+        ("IDENT", "save!"),
+        ("ASSIGN", "="),
+        ("IDENT", "false"),
+    ]
+
+
+def test_plus_minus_and_slash_are_always_operators_not_identifier_chars():
+    tokens = _kinds_texts("foo-bar + a+b + ns/name")
+    assert tokens == [
+        ("IDENT", "foo"),
+        ("MINUS", "-"),
+        ("IDENT", "bar"),
+        ("PLUS", "+"),
+        ("IDENT", "a"),
+        ("PLUS", "+"),
+        ("IDENT", "b"),
+        ("PLUS", "+"),
+        ("IDENT", "ns"),
+        ("SLASH", "/"),
+        ("IDENT", "name"),
+    ]


### PR DESCRIPTION
### Motivation
- Provide a single source of truth near `TOKEN_SPEC` that documents which characters are always operators/delimiters, which Clojure-style punctuation is allowed in names, that `name?`/`name!` are ordinary identifiers, and that `/` is reserved for division. 
- Remove ambiguity in the lexer where `-`, `+`, and `/` could be interpreted either as operators or as identifier characters so tokenization is deterministic.

### Description
- Added module-level policy constants: `ALWAYS_OPERATOR_DELIMITERS`, `ALLOWED_SYMBOL_PUNCTUATION`, `IDENT_START_RE`, and `IDENT_BODY_RE` to declare the rules near `TOKEN_SPEC`. 
- Replaced the previous boundary-driven identifier scanning with explicit `_is_identifier_start` and `_is_identifier_part` helpers that disallow operator delimiters inside identifiers while permitting selected punctuation like `?` and `!`. 
- Updated `lex()` to use the new identifier predicates (scan identifiers first, then match punctuation tokens) and removed the old `_starts_token_boundary` logic so `+`, `-`, and `/` are consistently tokenized as operators. 
- Added `tests/test_lexer_symbols.py` to assert that `ready?`/`save!` are plain identifiers and that `+`, `-`, and `/` are always operator tokens (and cannot appear inside identifiers).

### Testing
- Ran `pytest -q tests/test_lexer_symbols.py tests/test_core.py` which failed in the bare environment due to `ModuleNotFoundError: No module named 'genia'` (missing `PYTHONPATH`).
- Ran `PYTHONPATH=src pytest -q tests/test_lexer_symbols.py tests/test_core.py` and the test suite passed with `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5975b56248329bdd4bbfa0343b309)