### PR TITLE
Add list spread support in list literals

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -271,6 +271,11 @@ class ListLiteral(Node):
 
 
 @dataclass
+class Spread(Node):
+    expr: Node
+
+
+@dataclass
 class ListPattern(Node):
     items: list[Node]
 
@@ -387,6 +392,13 @@ class IrList(IrNode):
     """List literal with lowered items."""
 
     items: list[IrNode]
+
+
+@dataclass
+class IrSpread(IrNode):
+    """List spread element in a list literal."""
+
+    expr: IrNode
 
 
 class IrPattern:
@@ -514,6 +526,8 @@ def lower_node(node: Node) -> IrNode:
         return IrBlock([lower_node(expr) for expr in node.exprs])
     if isinstance(node, ListLiteral):
         return IrList([lower_node(item) for item in node.items])
+    if isinstance(node, Spread):
+        return IrSpread(lower_node(node.expr))
     if isinstance(node, CaseExpr):
         return IrCase(
             [
@@ -1070,7 +1084,11 @@ class Parser:
         items: list[Node] = []
         if not self.at("RBRACK"):
             while True:
-                items.append(self.parse_expr())
+                if self.at("DOTDOT"):
+                    self.eat("DOTDOT")
+                    items.append(Spread(self.parse_expr()))
+                else:
+                    items.append(self.parse_expr())
                 if not self.maybe("COMMA"):
                     break
         self.eat("RBRACK")
@@ -1457,7 +1475,16 @@ class Evaluator:
         if isinstance(node, IrLiteral):
             return node.value
         if isinstance(node, IrList):
-            return [self.eval(item) for item in node.items]
+            result: list[Any] = []
+            for item in node.items:
+                if isinstance(item, IrSpread):
+                    value = self.eval(item.expr)
+                    if not isinstance(value, list):
+                        raise TypeError("Cannot spread non-list")
+                    result.extend(value)
+                else:
+                    result.append(self.eval(item))
+            return result
         if isinstance(node, IrVar):
             return self.env.get(node.name)
         if isinstance(node, IrUnary):

--- a/tests/test_lists_and_patterns.py
+++ b/tests/test_lists_and_patterns.py
@@ -21,3 +21,17 @@ def test_rest_pattern_and_wildcard(run):
     head([9, 8, 7])
     '''
     assert run(src) == 9
+
+
+def test_list_spread_literal(run):
+    assert run("[..[1,2]]") == [1, 2]
+    assert run("[1, ..[2,3]]") == [1, 2, 3]
+    assert run("[..[1,2], ..[3,4]]") == [1, 2, 3, 4]
+    assert run("[0, ..[1,2], 3]") == [0, 1, 2, 3]
+
+
+def test_list_spread_literal_requires_list(run):
+    import pytest
+
+    with pytest.raises(TypeError, match="Cannot spread non-list"):
+        run("[..1]")


### PR DESCRIPTION
### Motivation
- Support expression-level list spread syntax (`..expr`) in list literals to allow one-level list concatenation/flattening like JavaScript/Python (not pattern matching).
- Preserve existing pattern/rest semantics so `..` in patterns remains unchanged.

### Description
- Introduce a new AST node `Spread(expr)` and a corresponding IR node `IrSpread(expr)` to represent expression-level spread elements (file: `src/genia/interpreter.py`).
- Update `parse_list_literal` to accept `..expr` as a list item (begin/middle/end/multiple spreads supported) while keeping pattern parsing untouched.
- Extend the lowering pipeline to translate `Spread` into `IrSpread` and allow list literals to contain spread elements.
- Modify the evaluator to flatten one level for `IrSpread` elements by extending the result with the evaluated value, and raise `TypeError("Cannot spread non-list")` when a non-list is spread.
- Add tests covering spreads at start/middle/multiple positions and an error case for spreading a non-list (file: `tests/test_lists_and_patterns.py`).

### Testing
- Ran the targeted tests with `PYTHONPATH=src pytest -q tests/test_lists_and_patterns.py`, which passed (`5 passed`).
- Ran the full suite with `PYTHONPATH=src pytest -q`, which passed (`105 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a14291288329bc57f4dfc11600c4)