### PR TITLE
Add list spread expansion to function-call arguments

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -396,7 +396,7 @@ class IrList(IrNode):
 
 @dataclass
 class IrSpread(IrNode):
-    """List spread element in a list literal."""
+    """List spread element in expression contexts (list literals and call args)."""
 
     expr: IrNode
 
@@ -1099,7 +1099,11 @@ class Parser:
         args: list[Node] = []
         if not self.at("RPAREN"):
             while True:
-                args.append(self.parse_expr())
+                if self.at("DOTDOT"):
+                    self.eat("DOTDOT")
+                    args.append(Spread(self.parse_expr()))
+                else:
+                    args.append(self.parse_expr())
                 if not self.maybe("COMMA"):
                     break
         self.eat("RPAREN")
@@ -1358,7 +1362,15 @@ class Evaluator:
         return self.eval(node)
 
     def eval_call(self, node: IrCall, tail_position: bool) -> Any:
-        args = [self.eval(a) for a in node.args]
+        args: list[Any] = []
+        for arg_node in node.args:
+            if isinstance(arg_node, IrSpread):
+                value = self.eval(arg_node.expr)
+                if not isinstance(value, list):
+                    raise TypeError("Cannot spread non-list into function arguments")
+                args.extend(value)
+            else:
+                args.append(self.eval(arg_node))
 
         if isinstance(node.fn, IrVar):
             name = node.fn.name

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,6 +1,8 @@
 from genia.interpreter import (
+    IrCall,
     IrCase,
     IrFuncDef,
+    IrSpread,
     IrListTraversalLoop,
     IrPatBind,
     IrPatList,
@@ -79,3 +81,12 @@ def test_non_matching_recursion_is_not_rewritten():
     fn = ir_nodes[0]
     assert isinstance(fn, IrFuncDef)
     assert isinstance(fn.body, IrCase)
+
+
+def test_call_spread_lowers_to_ir_spread_arg():
+    ast_nodes = Parser(lex("f(..[1, 2])")).parse_program()
+    ir_nodes = lower_program(ast_nodes)
+
+    expr_stmt = ir_nodes[0]
+    assert isinstance(expr_stmt.expr, IrCall)
+    assert isinstance(expr_stmt.expr.args[0], IrSpread)

--- a/tests/test_lists_and_patterns.py
+++ b/tests/test_lists_and_patterns.py
@@ -35,3 +35,57 @@ def test_list_spread_literal_requires_list(run):
 
     with pytest.raises(TypeError, match="Cannot spread non-list"):
         run("[..1]")
+
+
+def test_call_spread_basic(run):
+    src = """
+    add(a, b) = a + b
+    add(..[1, 2])
+    """
+    assert run(src) == 3
+
+
+def test_call_spread_mixed(run):
+    src = """
+    pack(a, b, c, d) = [a, b, c, d]
+    pack(0, ..[1, 2], 3)
+    """
+    assert run(src) == [0, 1, 2, 3]
+
+
+def test_call_spread_multiple(run):
+    src = """
+    pack4(a, b, c, d) = [a, b, c, d]
+    pack4(..[1, 2], ..[3, 4])
+    """
+    assert run(src) == [1, 2, 3, 4]
+
+
+def test_call_spread_empty_list_preserves_arity_behavior(run):
+    import pytest
+
+    src = """
+    pair(a, b) = [a, b]
+    pair(..[], 9)
+    """
+    with pytest.raises(TypeError, match="No matching function: pair/1"):
+        run(src)
+
+
+def test_call_spread_requires_list(run):
+    import pytest
+
+    src = """
+    add(a, b) = a + b
+    add(..1)
+    """
+    with pytest.raises(TypeError, match="Cannot spread non-list into function arguments"):
+        run(src)
+
+
+def test_ordinary_call_still_works(run):
+    src = """
+    add(a, b) = a + b
+    add(1, 2)
+    """
+    assert run(src) == 3


### PR DESCRIPTION
### Motivation
- Extend the existing list-spread syntax so it can be used inside function-call argument lists (e.g. `f(..xs)`, `f(0, ..xs, 9)`), expanding a list into positional args. 
- Keep semantics narrow and safe: only lists may be spread and spreading a non-list should raise a runtime error. 
- Preserve existing list-literal spread and list-pattern rest parsing semantics and avoid touching pattern parsing.

### Description
- Parser: `finish_call` now recognizes `DOTDOT expr` anywhere in a call arg list and wraps it in the existing `Spread` AST node, allowing spreads at begin/middle/end and multiple spreads. (modifies call-argument parsing behavior). 
- AST / IR: reuses the existing `Spread` AST node and `IrSpread` IR node (docstring updated); lowering continues to map `Spread -> IrSpread` so `IrCall.args` may contain `IrSpread`. 
- Evaluator: `eval_call` now iterates `IrCall.args` and expands `IrSpread` values by evaluating `expr`, verifying the result is a `list`, extending positional args, and raising `TypeError("Cannot spread non-list into function arguments")` for invalid spreads. Arity dispatch and tail-call logic are preserved after expansion. 
- Tests: added unit tests covering basic call spread, mixed ordinary and spread args, multiple spreads, empty spread and arity interactions, non-list spread error, ordinary-call regression, and an IR lowering test that verifies `IrSpread` appears in `IrCall.args`. 
- Files changed: `src/genia/interpreter.py`, `tests/test_lists_and_patterns.py`, `tests/test_ir.py`.

### Testing
- Ran targeted tests with `PYTHONPATH=src pytest -q tests/test_lists_and_patterns.py tests/test_ir.py` and they passed. 
- Ran full test suite with `PYTHONPATH=src pytest -q` and all tests passed (`112 passed`). 
- The new tests exercise both parsing-to-IR lowering and runtime semantics, including error cases for non-list spreads and arity behavior when spreading an empty list.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a790c85c8329af757121989c6bb9)