### PR TITLE
Add stdio JSON debug transport and runtime debug controller

### DIFF
--- a/src/genia/__init__.py
+++ b/src/genia/__init__.py
@@ -1,4 +1,5 @@
 from .interpreter import make_global_env as make_global_env
+from .interpreter import run_debug_stdio as run_debug_stdio
 from .interpreter import run_source as run_source
 
-__all__ = ["make_global_env", "run_source"]
+__all__ = ["make_global_env", "run_source", "run_debug_stdio"]

--- a/src/genia/debug_controller.py
+++ b/src/genia/debug_controller.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, TextIO
+
+from .debug_protocol import read_json_line, write_json_line
+from .interpreter import DebugHooks, Env, GeniaRef, SourceSpan
+
+
+class DebugDisconnect(Exception):
+    pass
+
+
+@dataclass
+class LogicalFrame:
+    id: int
+    name: str
+    env: Env
+    file: str
+    line: int
+    column: int
+
+
+class StdioDebugSession(DebugHooks):
+    def __init__(self, command_stream: TextIO, event_stream: TextIO, *, filename: str) -> None:
+        self.command_stream = command_stream
+        self.event_stream = event_stream
+        self.main_filename = filename
+        self.breakpoints: set[tuple[str, int]] = set()
+        self.frames: list[LogicalFrame] = []
+        self.env_to_frame: dict[int, LogicalFrame] = {}
+        self.next_frame_id = 1
+        self.step_mode = "continue"
+        self.step_depth = 0
+        self.resume_skip_key: tuple[str, int, int] | None = None
+
+    def run(self, execute: Callable[[], Any], *, error_stream: TextIO) -> int:
+        self.emit({"event": "initialized"})
+        try:
+            self.pause(reason="entry", file=self.main_filename, line=1, column=1)
+            execute()
+            self.emit({"event": "terminated", "exitCode": 0})
+            return 0
+        except DebugDisconnect:
+            self.emit({"event": "terminated", "exitCode": 0})
+            return 0
+        except Exception as exc:  # noqa: BLE001
+            self.emit({"event": "error", "message": str(exc)})
+            self.emit({"event": "terminated", "exitCode": 1})
+            print(exc, file=error_stream)
+            return 1
+
+    def emit(self, payload: dict[str, Any]) -> None:
+        write_json_line(self.event_stream, payload)
+
+    def emit_stdout_output(self, output: str) -> None:
+        self.emit({"event": "output", "category": "stdout", "output": output})
+
+    def normalize_file(self, filename: str) -> str:
+        return str(Path(filename).resolve())
+
+    def on_function_enter(
+        self,
+        fn_name: str,
+        args: tuple[Any, ...],  # noqa: ARG002
+        env: Env,
+        span: SourceSpan | None,
+    ) -> None:
+        file = self.main_filename
+        line = 1
+        column = 1
+        if span is not None:
+            file = span.filename
+            line = span.line
+            column = span.column
+        frame = LogicalFrame(
+            id=self.next_frame_id,
+            name=fn_name,
+            env=env,
+            file=file,
+            line=line,
+            column=column,
+        )
+        self.next_frame_id += 1
+        self.frames.append(frame)
+        self.env_to_frame[id(env)] = frame
+        if self.step_mode in {"step_in", "step_over", "step_out"}:
+            self.pause(reason="step", file=file, line=line, column=column)
+
+    def on_function_exit(
+        self,
+        fn_name: str,  # noqa: ARG002
+        result: Any,  # noqa: ARG002
+        env: Env,
+        span: SourceSpan | None,  # noqa: ARG002
+    ) -> None:
+        frame = self.env_to_frame.pop(id(env), None)
+        if frame is not None and self.frames and self.frames[-1].id == frame.id:
+            self.frames.pop()
+
+    def before_node(self, node: Any, env: Env) -> None:
+        span = getattr(node, "span", None)
+        if span is None:
+            return
+        frame = self._frame_for_env(env)
+        frame.file = span.filename
+        frame.line = span.line
+        frame.column = span.column
+
+        if type(node).__name__ not in {"IrExprStmt", "IrCall", "IrAssign"}:
+            return
+
+        depth = len(self.frames)
+        location_key = (self.normalize_file(span.filename), span.line, depth)
+        if self.resume_skip_key == location_key:
+            self.resume_skip_key = None
+            return
+
+        if (self.normalize_file(span.filename), span.line) in self.breakpoints:
+            self.pause(reason="breakpoint", file=span.filename, line=span.line, column=span.column)
+            return
+
+        if self.step_mode == "step_in":
+            self.pause(reason="step", file=span.filename, line=span.line, column=span.column)
+        elif self.step_mode == "step_over" and depth <= self.step_depth:
+            self.pause(reason="step", file=span.filename, line=span.line, column=span.column)
+        elif self.step_mode == "step_out" and depth < self.step_depth:
+            self.pause(reason="step", file=span.filename, line=span.line, column=span.column)
+
+    def after_node(self, node: Any, env: Env, result: Any) -> None:  # noqa: ARG002
+        pass
+
+    def pause(self, *, reason: str, file: str, line: int, column: int) -> None:
+        frame = self.frames[-1]
+        self.emit({
+            "event": "stopped",
+            "reason": reason,
+            "file": file,
+            "line": line,
+            "frameId": frame.id,
+        })
+        while True:
+            raw = self._read_command()
+            if raw is None:
+                raise DebugDisconnect()
+            if not raw:
+                continue
+            command = raw.get("command")
+            if command == "setBreakpoints":
+                self._set_breakpoints(raw)
+                self.emit({"responseTo": "setBreakpoints", "breakpoints": sorted(self.breakpoints)})
+                continue
+            if command == "stackTrace":
+                self.emit({"responseTo": "stackTrace", "frames": self._stack_trace()})
+                continue
+            if command == "scopes":
+                self.emit({"responseTo": "scopes", "scopes": [{"name": "locals"}, {"name": "globals"}]})
+                continue
+            if command == "variables":
+                scope = str(raw.get("scope", "locals"))
+                frame_id = int(raw.get("frameId", frame.id))
+                self.emit({"responseTo": "variables", "variables": self._variables(scope, frame_id)})
+                continue
+            if command == "continue":
+                self.step_mode = "continue"
+                self.resume_skip_key = (self.normalize_file(file), line, len(self.frames))
+                return
+            if command == "stepIn":
+                self.step_mode = "step_in"
+                self.resume_skip_key = (self.normalize_file(file), line, len(self.frames))
+                return
+            if command == "stepOver":
+                self.step_mode = "step_over"
+                self.step_depth = len(self.frames)
+                self.resume_skip_key = (self.normalize_file(file), line, len(self.frames))
+                return
+            if command == "stepOut":
+                self.step_mode = "step_out"
+                self.step_depth = len(self.frames)
+                self.resume_skip_key = (self.normalize_file(file), line, len(self.frames))
+                return
+            if command == "disconnect":
+                raise DebugDisconnect()
+            self.emit({"event": "error", "message": f"Unknown command: {command}"})
+
+    def _set_breakpoints(self, command: dict[str, Any]) -> None:
+        entries = command.get("breakpoints", [])
+        new_set: set[tuple[str, int]] = set()
+        for entry in entries:
+            if isinstance(entry, dict) and "file" in entry and "line" in entry:
+                new_set.add((self.normalize_file(str(entry["file"])), int(entry["line"])))
+        self.breakpoints = new_set
+
+    def _read_command(self) -> dict[str, Any] | None:
+        try:
+            return read_json_line(self.command_stream)
+        except Exception as exc:  # noqa: BLE001
+            self.emit({"event": "error", "message": f"Invalid JSON command: {exc}"})
+            return {}
+
+    def _frame_for_env(self, env: Env) -> LogicalFrame:
+        current: Env | None = env
+        while current is not None:
+            found = self.env_to_frame.get(id(current))
+            if found is not None:
+                return found
+            current = current.parent
+        return self.frames[0]
+
+    def _stack_trace(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": frame.id,
+                "name": frame.name,
+                "file": frame.file,
+                "line": frame.line,
+                "column": frame.column,
+            }
+            for frame in reversed(self.frames)
+        ]
+
+    def _variables(self, scope: str, frame_id: int) -> list[dict[str, str]]:
+        frame = next((item for item in self.frames if item.id == frame_id), self.frames[-1])
+        values: dict[str, Any]
+        if scope == "globals":
+            values = frame.env.root().values
+        else:
+            values = frame.env.values
+        return [self._variable(name, value) for name, value in sorted(values.items())]
+
+    def _variable(self, name: str, value: Any) -> dict[str, str]:
+        return {
+            "name": name,
+            "value": self._safe_value(value),
+            "type": self._value_type(value),
+        }
+
+    def _safe_value(self, value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        try:
+            return repr(value)
+        except Exception:  # noqa: BLE001
+            return "<unrepresentable>"
+
+    def _value_type(self, value: Any) -> str:
+        if value is None:
+            return "nil"
+        if isinstance(value, bool):
+            return "bool"
+        if isinstance(value, (int, float)):
+            return "number"
+        if isinstance(value, str):
+            return "string"
+        if isinstance(value, list):
+            return "list"
+        if isinstance(value, GeniaRef):
+            return "ref"
+        if callable(value):
+            return "function"
+        if isinstance(value, dict):
+            return "object"
+        return "unknown"
+
+    def ensure_root_frame(self, env: Env) -> None:
+        if self.frames:
+            return
+        frame = LogicalFrame(
+            id=self.next_frame_id,
+            name="<module>",
+            env=env.root(),
+            file=self.main_filename,
+            line=1,
+            column=1,
+        )
+        self.next_frame_id += 1
+        self.frames.append(frame)
+        self.env_to_frame[id(frame.env)] = frame

--- a/src/genia/debug_protocol.py
+++ b/src/genia/debug_protocol.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from typing import Any, TextIO
+
+
+def read_json_line(stream: TextIO) -> dict[str, Any] | None:
+    line = stream.readline()
+    if line == "":
+        return None
+    text = line.strip()
+    if not text:
+        return {}
+    value = json.loads(text)
+    if not isinstance(value, dict):
+        raise ValueError("Debug command must be a JSON object")
+    return value
+
+
+def write_json_line(stream: TextIO, payload: dict[str, Any]) -> None:
+    stream.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    stream.flush()

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -38,6 +38,7 @@ import math
 import os
 import bisect
 from pathlib import Path
+import argparse
 import re
 import sys
 import threading
@@ -1521,9 +1522,13 @@ class Evaluator:
                 callee = node.fn.name if isinstance(node.fn, IrVar) else "function"
                 available = ", ".join(f"{callee}/{n}" for n in sorted(fn))
                 raise TypeError(f"No matching function: {callee}/{arity}. Available: {available}")
-            return TailCall(target, tuple(args)) if tail_position else target(*args)
+            if tail_position and not self.debug_mode:
+                return TailCall(target, tuple(args))
+            return target(*args)
 
-        return TailCall(fn, tuple(args)) if tail_position else fn(*args)
+        if tail_position and not self.debug_mode:
+            return TailCall(fn, tuple(args))
+        return fn(*args)
 
     def match_pattern(self, pattern: IrPattern, args: tuple[Any, ...]) -> Optional[dict[str, Any]]:
         # full parameter tuple matching
@@ -1734,17 +1739,26 @@ def make_global_env(
     stdin_provider: Optional[Callable[[], list[str]]] = None,
     debug_hooks: DebugHooks | None = None,
     debug_mode: bool = False,
+    output_handler: Optional[Callable[[str], None]] = None,
 ) -> Env:
     env = Env()
     env.debug_hooks = debug_hooks or NOOP_DEBUG_HOOKS
     env.debug_mode = debug_mode
 
     def log(*args: Any) -> Any:
-        print(*args)
+        output = " ".join(str(arg) for arg in args) + "\n"
+        if output_handler is None:
+            print(*args)
+        else:
+            output_handler(output)
         return args[-1] if args else None
 
     def print_fn(*args: Any) -> Any:
-        print(*args)
+        output = " ".join(str(arg) for arg in args) + "\n"
+        if output_handler is None:
+            print(*args)
+        else:
+            output_handler(output)
         return args[-1] if args else None
 
     def input_fn(prompt: str = "") -> str:
@@ -1954,12 +1968,47 @@ def repl() -> None:
             print(f"Error: {e}", file=sys.stderr)
 
 
-if __name__ == "__main__":
-    if len(sys.argv) > 1:
+def run_debug_stdio(
+    program_path: str,
+    *,
+    command_stream: Any = None,
+    event_stream: Any = None,
+    error_stream: Any = None,
+) -> int:
+    from .debug_controller import StdioDebugSession
+
+    command_stream = command_stream or sys.stdin
+    event_stream = event_stream or sys.stdout
+    error_stream = error_stream or sys.stderr
+    resolved_path = str(Path(program_path).resolve())
+    source = Path(program_path).read_text(encoding="utf-8")
+    session = StdioDebugSession(command_stream, event_stream, filename=resolved_path)
+    env = make_global_env(debug_hooks=session, debug_mode=True, output_handler=session.emit_stdout_output)
+    session.ensure_root_frame(env)
+    return session.run(lambda: run_source(source, env, filename=resolved_path, debug_hooks=session, debug_mode=True), error_stream=error_stream)
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="genia.interpreter")
+    parser.add_argument("program", nargs="?")
+    parser.add_argument("--debug-stdio", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.debug_stdio:
+        if args.program is None:
+            parser.error("--debug-stdio requires a program path")
+        return run_debug_stdio(args.program)
+    if args.program is not None:
         env = make_global_env()
-        with open(sys.argv[1], "r", encoding="utf-8") as f:
-            result = run_source(f.read(), env, filename=str(Path(sys.argv[1]).resolve()))
+        with open(args.program, "r", encoding="utf-8") as f:
+            result = run_source(f.read(), env, filename=str(Path(args.program).resolve()))
         if result is not None:
             print(repr(result))
-    else:
-        repl()
+        return 0
+
+    repl()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_debug_stdio.py
+++ b/tests/test_debug_stdio.py
@@ -1,0 +1,128 @@
+import io
+import json
+from pathlib import Path
+
+from genia.interpreter import run_debug_stdio
+
+
+def run_session(tmp_path: Path, source: str, commands: list[dict]) -> tuple[int, list[dict], str]:
+    program = tmp_path / "program.genia"
+    program.write_text(source, encoding="utf-8")
+    stdin = io.StringIO("\n".join(json.dumps(cmd) for cmd in commands) + "\n")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = run_debug_stdio(str(program), command_stream=stdin, event_stream=stdout, error_stream=stderr)
+    events = [json.loads(line) for line in stdout.getvalue().splitlines() if line.strip()]
+    return code, events, stderr.getvalue()
+
+
+def stopped_events(events: list[dict]) -> list[dict]:
+    return [event for event in events if event.get("event") == "stopped"]
+
+
+def test_entry_stop_and_initialized(tmp_path: Path):
+    code, events, _ = run_session(tmp_path, "x = 1\nx\n", [{"command": "continue"}])
+    assert code == 0
+    assert events[0] == {"event": "initialized"}
+    assert events[1]["event"] == "stopped"
+    assert events[1]["reason"] == "entry"
+
+
+def test_breakpoint_hit_and_termination(tmp_path: Path):
+    source = "x = 1\nx = 2\nx\n"
+    code, events, _ = run_session(
+        tmp_path,
+        source,
+        [
+            {"command": "setBreakpoints", "breakpoints": [{"file": str((tmp_path / 'program.genia').resolve()), "line": 2}]},
+            {"command": "continue"},
+            {"command": "continue"},
+        ],
+    )
+    assert code == 0
+    stops = stopped_events(events)
+    assert any(stop["reason"] == "breakpoint" and stop["line"] == 2 for stop in stops)
+    assert events[-1] == {"event": "terminated", "exitCode": 0}
+
+
+def test_step_in_and_step_over(tmp_path: Path):
+    source = "inc(x) = x + 1\ninc(4)\n"
+    code, events, _ = run_session(
+        tmp_path,
+        source,
+        [
+            {"command": "setBreakpoints", "breakpoints": [{"file": str((tmp_path / 'program.genia').resolve()), "line": 2}]},
+            {"command": "continue"},
+            {"command": "stepIn"},
+            {"command": "stepOver"},
+            {"command": "disconnect"},
+        ],
+    )
+    assert code == 0
+    stops = stopped_events(events)
+    assert any(stop["reason"] == "step" for stop in stops)
+    breakpoint_stop = next(stop for stop in stops if stop["reason"] == "breakpoint")
+    step_stop = next(stop for stop in stops if stop["reason"] == "step")
+    assert step_stop["frameId"] != breakpoint_stop["frameId"]
+
+
+def test_stack_trace_and_scopes_variables(tmp_path: Path):
+    source = "g(x) = x + 1\nf(x) = g(x)\nf(5)\n"
+    frame_probe = {"command": "scopes", "frameId": 0}
+    locals_probe = {"command": "variables", "scope": "locals", "frameId": 0}
+    globals_probe = {"command": "variables", "scope": "globals", "frameId": 0}
+    code, events, _ = run_session(
+        tmp_path,
+        source,
+        [
+            {"command": "setBreakpoints", "breakpoints": [{"file": str((tmp_path / 'program.genia').resolve()), "line": 3}]},
+            {"command": "continue"},
+            {"command": "stepIn"},
+            {"command": "stackTrace"},
+            frame_probe,
+            locals_probe,
+            globals_probe,
+            {"command": "disconnect"},
+        ],
+    )
+    assert code == 0
+
+    stack = next(event for event in events if event.get("responseTo") == "stackTrace")
+    frame_names = [frame["name"] for frame in stack["frames"]]
+    assert "f" in frame_names
+
+    scopes = next(event for event in events if event.get("responseTo") == "scopes")
+    assert {scope["name"] for scope in scopes["scopes"]} == {"locals", "globals"}
+
+    locals_vars = [event for event in events if event.get("responseTo") == "variables" and any(v["name"] == "x" for v in event["variables"])]
+    assert locals_vars
+    globals_vars = [event for event in events if event.get("responseTo") == "variables" and any(v["name"] == "f" for v in event["variables"])]
+    assert globals_vars
+
+
+def test_autoloaded_file_stop_location(tmp_path: Path):
+    source = "count([1, 2, 3])\n"
+    code, events, _ = run_session(
+        tmp_path,
+        source,
+        [
+            {"command": "setBreakpoints", "breakpoints": [{"file": str((tmp_path / 'program.genia').resolve()), "line": 1}]},
+            {"command": "continue"},
+            {"command": "stepIn"},
+            {"command": "disconnect"},
+        ],
+    )
+    assert code == 0
+    stops = stopped_events(events)
+    assert any("std/prelude/list.genia" in stop["file"] for stop in stops)
+
+
+def test_output_event_is_emitted(tmp_path: Path):
+    code, events, _ = run_session(
+        tmp_path,
+        'print("hello")\n',
+        [{"command": "continue"}],
+    )
+    assert code == 0
+    outputs = [event for event in events if event.get("event") == "output"]
+    assert outputs and outputs[0]["output"] == "hello\n"


### PR DESCRIPTION
### Motivation
- Provide a minimal, stable runtime-side debug transport over stdin/stdout using newline-delimited JSON so a future debug adapter (e.g. VS Code DAP wrapper) can talk to the Genia runtime. 
- Expose runtime pause/continue/step, breakpoints by file+line, and basic inspection (stack/scopes/variables) without implementing full DAP or any editor UI yet. 

### Description
- Add a tiny JSON-lines transport helper with `read_json_line` / `write_json_line` in `src/genia/debug_protocol.py` to keep framing minimal and stable. 
- Implement `StdioDebugSession` in `src/genia/debug_controller.py` which implements `DebugHooks` and emits events (`initialized`, `stopped`, `terminated`, `output`, `error`) and responds to commands (`setBreakpoints`, `continue`, `stepIn`, `stepOver`, `stepOut`, `stackTrace`, `scopes`, `variables`, `disconnect`) using logical Genia frames and file+line breakpoints. 
- Integrate a debug stdio entrypoint: `run_debug_stdio(...)` and a CLI flag `--debug-stdio` in `src/genia/interpreter.py`, and route `print`/`log` through the debug session via an `output_handler` so `output` events are emitted when debugging. 
- Make a small debug-mode tradeoff so tail-call flattening is bypassed when `debug_mode` is enabled (`tail_position` uses `not self.debug_mode`), preserving logical call stacks for clearer stepping and inspection. 
- Export `run_debug_stdio` from the package top-level (`src/genia/__init__.py`) and add tests `tests/test_debug_stdio.py` that exercise entry stop, breakpoints, stepping, stack/scopes/variables, autoload span locations, output forwarding, and termination behavior. 

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_debug_stdio.py tests/test_debug_foundation.py` and observed all tests pass (`12 passed`). 
- Ran `PYTHONPATH=src pytest -q tests/test_tco.py` and observed all TCO-related tests pass (`5 passed`). 
- Added focused unit tests in `tests/test_debug_stdio.py` which exercise the new stdio protocol and controller behavior and ran them successfully in-process against `run_debug_stdio`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5ad37d5a88329be318b7cad044de2)