### PR TITLE
fix(debugger): pin vscode debug packages to published ^1.68.0

### DIFF
--- a/vscode/genia-debugger/package.json
+++ b/vscode/genia-debugger/package.json
@@ -78,7 +78,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@vscode/debugadapter": "^1.69.0",
-    "@vscode/debugprotocol": "^1.69.0"
+    "@vscode/debugadapter": "^1.68.0",
+    "@vscode/debugprotocol": "^1.68.0"
   }
 }


### PR DESCRIPTION
### Motivation
- The genia VS Code debugger requested `@vscode/debugadapter` and `@vscode/debugprotocol` at `^1.69.0`, a range that is not published and produced `npm ERR! ETARGET`, so the ranges were adjusted to a published version.

### Description
- Update `vscode/genia-debugger/package.json` to change `@vscode/debugadapter` and `@vscode/debugprotocol` from `^1.69.0` to `^1.68.0`.

### Testing
- Attempted `npm install --package-lock-only` in `vscode/genia-debugger`, but package resolution could not be completed due to registry access restrictions (`E403`), so full install validation was blocked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5b1a9ea4c8329881b44f5f8720d98)