### PR TITLE
Add minimal VS Code language support for .genia files

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,19 @@ Genia intentionally keeps the core small. These are **not yet part of the langua
 
 ---
 
+## 🧰 VS Code Extension
+
+A minimal VS Code extension lives at `vscode/genia-debugger` and now includes:
+
+* `.genia` file recognition
+* Syntax highlighting
+* Basic editor language configuration (comments, brackets, indentation)
+* Debugging support via the `genia` launch configuration
+
+To run it in dev mode, see `vscode/genia-debugger/README.md`.
+
+---
+
 ## 🧪 Running Tests
 
 ```bash

--- a/vscode/genia-debugger/README.md
+++ b/vscode/genia-debugger/README.md
@@ -1,6 +1,23 @@
 # Genia Debugger (VS Code)
 
-This is the first minimal VS Code extension for the Genia project. It adds a `genia` debugger that bridges VS Code DAP requests to the Genia runtime's JSON-over-stdio debug transport.
+This VS Code extension provides two things for Genia:
+
+- A minimal `genia` debugger that bridges VS Code DAP requests to the Genia runtime's JSON-over-stdio debug transport.
+- Basic language support for `.genia` files.
+
+## Language support for `.genia`
+
+The extension now contributes a `genia` language with:
+
+- Automatic file recognition for `*.genia`
+- Syntax highlighting (TextMate grammar)
+- Bracket matching for `()`, `[]`, `{}`
+- Line comments with `#`
+- Basic indentation behavior around `{` and `}`
+
+This is intentionally minimal and does **not** include LSP features (autocomplete, hover, go-to-definition, rename, semantic analysis, formatting, linting, etc.).
+
+## Debugging support
 
 ## What this extension supports today
 
@@ -10,6 +27,7 @@ This is the first minimal VS Code extension for the Genia project. It adds a `ge
 - Stack trace
 - Local and global scopes
 - Variable inspection (name / value / type)
+- Launching from `.genia` files via the `genia` debugger configuration
 
 ## What this extension does **not** support yet
 
@@ -20,7 +38,7 @@ This is the first minimal VS Code extension for the Genia project. It adds a `ge
 - Data breakpoints
 - Debug console REPL integration
 - Inline values
-- Any language features (syntax highlighting, snippets, LSP, hover, completion)
+- Language server features (autocomplete, hover, go-to-definition, etc.)
 
 ## Runtime assumptions
 
@@ -64,21 +82,22 @@ Optional fields:
 - `runtimeArgs`
 - `stopOnEntry`
 
-## Run in Extension Development Host
+## Run in Extension Development Host (dev mode)
 
 1. `cd vscode/genia-debugger`
 2. `npm install`
 3. `npm run build`
 4. Open this folder in VS Code.
 5. Press `F5` with the **Run Genia Debugger Extension** launch config.
-6. In the Extension Development Host window, create/use a `.genia` file and run the **Launch Genia File** debug configuration.
+6. In the Extension Development Host window, open `example.genia` (or any `.genia` file) to validate highlighting/comments/brackets.
+7. Run the **Launch Genia File** debug configuration.
 
 ## Architecture (minimal)
 
 - `src/extension.ts`: registers a debug adapter descriptor factory for debugger type `genia`.
 - `src/geniaDebugAdapter.ts`: standalone debug adapter process using `@vscode/debugadapter`.
-- Adapter launches Genia runtime as a child process and exchanges JSON lines over stdio.
-- DAP requests are translated to Genia commands; Genia events/responses are translated back to DAP events/responses.
+- `language-configuration.json`: basic editing behavior (comments, brackets, pairs, indentation).
+- `syntaxes/genia.tmLanguage.json`: regex-based TextMate highlighting rules.
 
 ## Next logical milestone
 

--- a/vscode/genia-debugger/example.genia
+++ b/vscode/genia-debugger/example.genia
@@ -1,0 +1,7 @@
+add(a, b) = a + b
+
+xs = [1, 2, 3]
+
+result = add(1, 2)
+
+print(result)

--- a/vscode/genia-debugger/language-configuration.json
+++ b/vscode/genia-debugger/language-configuration.json
@@ -1,0 +1,28 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "indentationRules": {
+    "increaseIndentPattern": ".*\\{[^}]*$",
+    "decreaseIndentPattern": "^\\s*\\}"
+  }
+}

--- a/vscode/genia-debugger/package.json
+++ b/vscode/genia-debugger/package.json
@@ -19,7 +19,9 @@
       {
         "type": "genia",
         "label": "Genia Debugger",
-        "languages": [],
+        "languages": [
+          "genia"
+        ],
         "configurationAttributes": {
           "launch": {
             "required": [
@@ -64,6 +66,26 @@
             "stopOnEntry": true
           }
         ]
+      }
+    ],
+    "languages": [
+      {
+        "id": "genia",
+        "aliases": [
+          "Genia",
+          "genia"
+        ],
+        "extensions": [
+          ".genia"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "genia",
+        "scopeName": "source.genia",
+        "path": "./syntaxes/genia.tmLanguage.json"
       }
     ]
   },

--- a/vscode/genia-debugger/syntaxes/genia.tmLanguage.json
+++ b/vscode/genia-debugger/syntaxes/genia.tmLanguage.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Genia",
+  "scopeName": "source.genia",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#strings" },
+    { "include": "#function-definition" },
+    { "include": "#keywords" },
+    { "include": "#numbers" },
+    { "include": "#spread" },
+    { "include": "#pattern-operators" },
+    { "include": "#operators" },
+    { "include": "#identifiers" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.number-sign.genia",
+          "match": "#.*$"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.genia",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.genia",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "constant.language.genia",
+          "match": "\\b(?:true|false|nil)\\b"
+        }
+      ]
+    },
+    "function-definition": {
+      "patterns": [
+        {
+          "name": "meta.function.definition.genia",
+          "match": "\\b([A-Za-z_][A-Za-z0-9_]*)\\s*(\\()\\s*([^)]*?)\\s*(\\))\\s*=",
+          "captures": {
+            "1": { "name": "entity.name.function.genia" },
+            "2": { "name": "punctuation.section.parameters.begin.genia" },
+            "3": { "name": "variable.parameter.genia" },
+            "4": { "name": "punctuation.section.parameters.end.genia" }
+          }
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.genia",
+          "match": "\\b(?:\\d+\\.\\d+|\\d+)\\b"
+        }
+      ]
+    },
+    "pattern-operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.pattern.genia",
+          "match": "->|\\||\\?"
+        }
+      ]
+    },
+    "spread": {
+      "patterns": [
+        {
+          "name": "keyword.operator.spread.genia",
+          "match": "\\.\\."
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.genia",
+          "match": "==|!=|<=|>=|[+\\-*/%<>]"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "variable.other.genia",
+          "match": "\\b[A-Za-z_][A-Za-z0-9_]*\\b"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide basic editor experience for Genia source files so `.genia` files are recognized and editable in VS Code without introducing an LSP or semantic features. 
- Keep the implementation minimal and idiomatic: file association, syntax highlighting, bracket/comment/pair behavior, and simple indentation rules only.

### Description

- Update `vscode/genia-debugger/package.json` to contribute a `genia` language (aliases `Genia`, `genia`), associate `.genia` extension, add `language-configuration.json`, register the TextMate grammar, and include `genia` in the debugger `languages` list. 
- Add `vscode/genia-debugger/language-configuration.json` with `#` line comments, bracket pairs `() [] {}`, auto-closing/surrounding pairs for brackets and quotes, and indentation rules that increase after `{` and decrease before `}`. 
- Add a lightweight TextMate grammar at `vscode/genia-debugger/syntaxes/genia.tmLanguage.json` using regex-based patterns to highlight keywords (`true`, `false`, `nil`), function definitions (name + parameters), pattern arrows (`->`, `|`, `?`), numbers (ints/floats), double-quoted strings, comments (`#`), identifiers, operators (`+ - * / % == != < > <= >=`), and the spread operator `..` (for list patterns). 
- Add `vscode/genia-debugger/example.genia` as a small sample file for manual validation. 
- Update `vscode/genia-debugger/README.md` and the repository `README.md` to document `.genia` support and dev-mode steps for running the extension.

### Testing

- Ran `npm run build` in `vscode/genia-debugger` to validate the extension build, which failed with TypeScript errors (`TS2688`) because required type definitions (`@types/node`, `@types/vscode`) are not available in this environment. 
- Ran `npm install` in `vscode/genia-debugger` which failed with `403 Forbidden` from the npm registry, preventing installation of dev dependencies and a full build validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5b7b4e1f883299ee7219e0f76af24)