### PR TITLE
Lightweight Genia symbol/indexer + DocumentSymbol/Definition providers

### DIFF
--- a/vscode/genia-debugger/README.md
+++ b/vscode/genia-debugger/README.md
@@ -15,7 +15,28 @@ The extension now contributes a `genia` language with:
 - Line comments with `#`
 - Basic indentation behavior around `{` and `}`
 
-This is intentionally minimal and does **not** include LSP features (autocomplete, hover, go-to-definition, rename, semantic analysis, formatting, linting, etc.).
+This is intentionally lightweight and implemented directly in extension APIs (not a full Language Server).
+
+In addition to declarative syntax/comment support, the extension now provides:
+
+- Document symbols / Outline for top-level Genia functions and assignments
+- Breadcrumb-friendly symbol ranges for top-level definitions
+- Basic same-file go-to-definition for top-level functions and assignments
+- Basic workspace symbol search across `*.genia` files
+
+This is still **not** a full semantic stack and does **not** yet include:
+
+- Hover
+- Autocomplete / completion
+- Diagnostics
+- Rename
+- References
+- Cross-file semantic analysis
+- Semantic tokens
+- Formatting
+- Code actions
+- Signature help
+- Full LSP architecture
 
 ## Debugging support
 
@@ -38,7 +59,7 @@ This is intentionally minimal and does **not** include LSP features (autocomplet
 - Data breakpoints
 - Debug console REPL integration
 - Inline values
-- Language server features (autocomplete, hover, go-to-definition, etc.)
+- Full Language Server Protocol (LSP) implementation
 
 ## Runtime assumptions
 
@@ -94,11 +115,12 @@ Optional fields:
 
 ## Architecture (minimal)
 
-- `src/extension.ts`: registers a debug adapter descriptor factory for debugger type `genia`.
+- `src/extension.ts`: registers the debug adapter descriptor factory plus lightweight language providers (`DocumentSymbolProvider`, `DefinitionProvider`, and `WorkspaceSymbolProvider`) for `genia`.
+- `src/languageIndexer.ts`: tiny top-level parser/indexer used by symbol and definition features.
 - `src/geniaDebugAdapter.ts`: standalone debug adapter process using `@vscode/debugadapter`.
 - `language-configuration.json`: basic editing behavior (comments, brackets, pairs, indentation).
 - `syntaxes/genia.tmLanguage.json`: regex-based TextMate highlighting rules.
 
 ## Next logical milestone
 
-Add robust protocol correlation IDs and richer variable expansion (nested values with non-zero variable references), then add attach mode.
+For language tooling, the next step before a full LSP is incremental document/workspace indexing with small correctness improvements (import-aware cross-file definition lookup, safer range recovery, and provider-level caching).

--- a/vscode/genia-debugger/package.json
+++ b/vscode/genia-debugger/package.json
@@ -11,7 +11,9 @@
     "Debuggers"
   ],
   "activationEvents": [
-    "onDebug:genia"
+    "onDebug:genia",
+    "onLanguage:genia",
+    "onWorkspaceSymbol"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -92,7 +94,8 @@
   "scripts": {
     "build": "tsc -p .",
     "watch": "tsc -w -p .",
-    "vscode:prepublish": "npm run build"
+    "vscode:prepublish": "npm run build",
+    "test": "npm run build && node --test out/languageIndexer.test.js"
   },
   "devDependencies": {
     "@types/node": "^20.14.2",

--- a/vscode/genia-debugger/src/extension.ts
+++ b/vscode/genia-debugger/src/extension.ts
@@ -1,10 +1,21 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+import {
+  GeniaDefinitionProvider,
+  GeniaDocumentSymbolProvider,
+  GeniaWorkspaceSymbolProvider,
+} from './languageProviders';
 
 export function activate(context: vscode.ExtensionContext): void {
   const factory = new GeniaDebugAdapterDescriptorFactory(context);
+  const selector: vscode.DocumentSelector = [{ language: 'genia' }];
+
   context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('genia', factory));
   context.subscriptions.push(factory);
+
+  context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(selector, new GeniaDocumentSymbolProvider()));
+  context.subscriptions.push(vscode.languages.registerDefinitionProvider(selector, new GeniaDefinitionProvider()));
+  context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new GeniaWorkspaceSymbolProvider()));
 }
 
 export function deactivate(): void {

--- a/vscode/genia-debugger/src/languageIndexer.test.ts
+++ b/vscode/genia-debugger/src/languageIndexer.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { findWordAtPosition, indexGeniaDocument, resolveDefinition } from './languageIndexer';
+
+test('indexer finds top-level functions and assignments', () => {
+  const source = `add(a, b) = a + b
+value = 1
+  nested(x) = x
+`;
+
+  const indexed = indexGeniaDocument(source);
+  assert.equal(indexed.symbols.length, 2);
+  assert.equal(indexed.symbols[0]?.kind, 'function');
+  assert.equal(indexed.symbols[0]?.name, 'add');
+  assert.deepEqual(indexed.symbols[0]?.parameters, ['a', 'b']);
+  assert.equal(indexed.symbols[1]?.kind, 'variable');
+  assert.equal(indexed.symbols[1]?.name, 'value');
+});
+
+test('indexer finds multiline function definitions', () => {
+  const source = `fact(
+  n
+) =
+  if(n == 0, 1, n * fact(n - 1))
+next = 42
+`;
+
+  const indexed = indexGeniaDocument(source);
+  const fact = indexed.symbols.find((symbol) => symbol.name === 'fact');
+  assert.ok(fact);
+  assert.equal(fact.kind, 'function');
+  assert.deepEqual(fact.parameters, ['n']);
+  assert.equal(fact.range.startLine, 0);
+  assert.equal(fact.range.endLine, 3);
+});
+
+test('definition resolution finds same-file function definition', () => {
+  const source = `sum(a, b) = a + b
+x = sum(1, 2)
+`;
+
+  const indexed = indexGeniaDocument(source);
+  const callLine = 1;
+  const characterInName = source.split(/\r?\n/)[callLine].indexOf('sum') + 1;
+  const word = findWordAtPosition(source, callLine, characterInName);
+  assert.equal(word, 'sum');
+
+  const resolved = resolveDefinition(indexed, word!);
+  assert.ok(resolved);
+  assert.equal(resolved.name, 'sum');
+  assert.equal(resolved.selectionRange.startLine, 0);
+});
+
+test('malformed code does not crash indexing', () => {
+  const source = `broken(
+  x,
+# comment only
+name =
+foo( =
+`;
+
+  assert.doesNotThrow(() => indexGeniaDocument(source));
+  const indexed = indexGeniaDocument(source);
+  assert.ok(Array.isArray(indexed.symbols));
+});

--- a/vscode/genia-debugger/src/languageIndexer.ts
+++ b/vscode/genia-debugger/src/languageIndexer.ts
@@ -1,0 +1,293 @@
+export type GeniaSymbolKind = 'function' | 'variable';
+
+export interface IndexedRange {
+  startLine: number;
+  startCharacter: number;
+  endLine: number;
+  endCharacter: number;
+}
+
+export interface IndexedSymbol {
+  kind: GeniaSymbolKind;
+  name: string;
+  parameters: string[];
+  detail?: string;
+  range: IndexedRange;
+  selectionRange: IndexedRange;
+}
+
+export interface IndexedDocument {
+  symbols: IndexedSymbol[];
+  byName: Map<string, IndexedSymbol[]>;
+}
+
+const IDENTIFIER = /[A-Za-z_][A-Za-z0-9_]*/y;
+
+export function indexGeniaDocument(text: string): IndexedDocument {
+  const lines = text.split(/\r?\n/);
+  const symbols: IndexedSymbol[] = [];
+
+  let line = 0;
+  while (line < lines.length) {
+    const currentLine = stripComment(lines[line]);
+    const match = currentLine.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)\b/);
+
+    if (!match) {
+      line += 1;
+      continue;
+    }
+
+    const indent = match[1].length;
+    if (indent > 0) {
+      line += 1;
+      continue;
+    }
+
+    const name = match[2];
+    const nameColumn = match[1].length;
+
+    const functionHeader = collectFunctionHeader(lines, line, name);
+    if (functionHeader) {
+      const endLine = findDefinitionEnd(lines, line, functionHeader.headerEndLine, functionHeader.bodyToken);
+      const endCharacter = lines[endLine]?.length ?? 0;
+      symbols.push({
+        kind: 'function',
+        name,
+        parameters: functionHeader.parameters,
+        detail: `(${functionHeader.parameters.join(', ')})`,
+        range: { startLine: line, startCharacter: 0, endLine, endCharacter },
+        selectionRange: {
+          startLine: line,
+          startCharacter: nameColumn,
+          endLine: line,
+          endCharacter: nameColumn + name.length,
+        },
+      });
+      line = endLine + 1;
+      continue;
+    }
+
+    const assignment = stripComment(lines[line]).match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?![=])/);
+    if (assignment) {
+      const endLine = findAssignmentEnd(lines, line);
+      symbols.push({
+        kind: 'variable',
+        name,
+        parameters: [],
+        range: { startLine: line, startCharacter: 0, endLine, endCharacter: lines[endLine]?.length ?? 0 },
+        selectionRange: {
+          startLine: line,
+          startCharacter: nameColumn,
+          endLine: line,
+          endCharacter: nameColumn + name.length,
+        },
+      });
+      line = endLine + 1;
+      continue;
+    }
+
+    line += 1;
+  }
+
+  const byName = new Map<string, IndexedSymbol[]>();
+  for (const symbol of symbols) {
+    const bucket = byName.get(symbol.name) ?? [];
+    bucket.push(symbol);
+    byName.set(symbol.name, bucket);
+  }
+
+  return { symbols, byName };
+}
+
+export function findWordAtPosition(text: string, lineNumber: number, character: number): string | undefined {
+  const lines = text.split(/\r?\n/);
+  const line = lines[lineNumber] ?? '';
+  if (line.length === 0) {
+    return undefined;
+  }
+
+  let left = Math.min(character, line.length - 1);
+  let right = left;
+
+  const isWord = (ch: string): boolean => /[A-Za-z0-9_]/.test(ch);
+  if (!isWord(line[left])) {
+    if (left > 0 && isWord(line[left - 1])) {
+      left -= 1;
+      right = left;
+    } else {
+      return undefined;
+    }
+  }
+
+  while (left > 0 && isWord(line[left - 1])) {
+    left -= 1;
+  }
+  while (right + 1 < line.length && isWord(line[right + 1])) {
+    right += 1;
+  }
+
+  const word = line.slice(left, right + 1);
+  IDENTIFIER.lastIndex = 0;
+  if (!IDENTIFIER.test(word)) {
+    return undefined;
+  }
+  return word;
+}
+
+export function resolveDefinition(indexed: IndexedDocument, identifier: string): IndexedSymbol | undefined {
+  return indexed.byName.get(identifier)?.[0];
+}
+
+function collectFunctionHeader(
+  lines: string[],
+  startLine: number,
+  name: string,
+): { parameters: string[]; bodyToken: '=' | '{'; headerEndLine: number } | undefined {
+  const firstLine = stripComment(lines[startLine]);
+  const headerStart = firstLine.match(new RegExp(`^${name}\\s*\\(`));
+  if (!headerStart) {
+    return undefined;
+  }
+
+  let line = startLine;
+  let parenDepth = 0;
+  let seenParen = false;
+  let paramsBuffer = '';
+
+  while (line < lines.length) {
+    const segment = stripComment(lines[line]);
+    for (let idx = 0; idx < segment.length; idx += 1) {
+      const ch = segment[idx];
+      if (!seenParen) {
+        if (ch === '(') {
+          seenParen = true;
+          parenDepth = 1;
+        }
+        continue;
+      }
+
+      if (ch === '(') {
+        parenDepth += 1;
+      } else if (ch === ')') {
+        parenDepth -= 1;
+        if (parenDepth === 0) {
+          const tail = segment.slice(idx + 1).trimStart();
+          if (tail.startsWith('=') || tail.startsWith('{')) {
+            return {
+              parameters: parseParameters(paramsBuffer),
+              bodyToken: tail[0] as '=' | '{',
+              headerEndLine: line,
+            };
+          }
+
+          const token = findBodyToken(lines, line + 1);
+          if (token) {
+            return {
+              parameters: parseParameters(paramsBuffer),
+              bodyToken: token.token,
+              headerEndLine: token.line,
+            };
+          }
+          return undefined;
+        }
+      }
+
+      if (seenParen && parenDepth > 0) {
+        paramsBuffer += ch;
+      }
+    }
+
+    if (seenParen && parenDepth > 0) {
+      paramsBuffer += '\n';
+    }
+
+    line += 1;
+  }
+
+  return undefined;
+}
+
+function parseParameters(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(entry));
+}
+
+function findBodyToken(lines: string[], fromLine: number): { token: '=' | '{'; line: number } | undefined {
+  for (let line = fromLine; line < lines.length; line += 1) {
+    const trimmed = stripComment(lines[line]).trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed.startsWith('=') || trimmed.startsWith('{')) {
+      return { token: trimmed[0] as '=' | '{', line };
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+function findDefinitionEnd(lines: string[], startLine: number, headerEndLine: number, bodyToken: '=' | '{'): number {
+  if (bodyToken === '{') {
+    return findMatchingBraceEnd(lines, headerEndLine) ?? headerEndLine;
+  }
+
+  return findAssignmentEnd(lines, headerEndLine);
+}
+
+function findAssignmentEnd(lines: string[], startLine: number): number {
+  const baseIndent = leadingWhitespace(lines[startLine]);
+  let endLine = startLine;
+
+  for (let line = startLine + 1; line < lines.length; line += 1) {
+    const raw = lines[line];
+    const trimmed = stripComment(raw).trim();
+    if (trimmed.length === 0) {
+      endLine = line;
+      continue;
+    }
+
+    const indent = leadingWhitespace(raw);
+    if (indent > baseIndent) {
+      endLine = line;
+      continue;
+    }
+
+    break;
+  }
+
+  return endLine;
+}
+
+function findMatchingBraceEnd(lines: string[], startLine: number): number | undefined {
+  let depth = 0;
+  let sawOpening = false;
+
+  for (let line = startLine; line < lines.length; line += 1) {
+    const text = stripComment(lines[line]);
+    for (const ch of text) {
+      if (ch === '{') {
+        depth += 1;
+        sawOpening = true;
+      } else if (ch === '}') {
+        depth -= 1;
+        if (sawOpening && depth === 0) {
+          return line;
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function stripComment(line: string): string {
+  const hash = line.indexOf('#');
+  return hash >= 0 ? line.slice(0, hash) : line;
+}
+
+function leadingWhitespace(line: string): number {
+  const match = line.match(/^\s*/);
+  return match ? match[0].length : 0;
+}

--- a/vscode/genia-debugger/src/languageProviders.ts
+++ b/vscode/genia-debugger/src/languageProviders.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+import { findWordAtPosition, indexGeniaDocument, resolveDefinition } from './languageIndexer';
+
+export class GeniaDocumentSymbolProvider implements vscode.DocumentSymbolProvider {
+  provideDocumentSymbols(document: vscode.TextDocument): vscode.ProviderResult<vscode.DocumentSymbol[]> {
+    const indexed = indexGeniaDocument(document.getText());
+    return indexed.symbols.map((symbol) => {
+      const range = toRange(symbol.range);
+      const selectionRange = toRange(symbol.selectionRange);
+      const kind = symbol.kind === 'function' ? vscode.SymbolKind.Function : vscode.SymbolKind.Variable;
+      return new vscode.DocumentSymbol(symbol.name, symbol.detail ?? '', kind, range, selectionRange);
+    });
+  }
+}
+
+export class GeniaDefinitionProvider implements vscode.DefinitionProvider {
+  provideDefinition(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): vscode.ProviderResult<vscode.Definition | vscode.DefinitionLink[]> {
+    const text = document.getText();
+    const word = findWordAtPosition(text, position.line, position.character);
+    if (!word) {
+      return undefined;
+    }
+
+    const indexed = indexGeniaDocument(text);
+    const target = resolveDefinition(indexed, word);
+    if (!target) {
+      return undefined;
+    }
+
+    return new vscode.Location(document.uri, toRange(target.selectionRange));
+  }
+}
+
+export class GeniaWorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
+  async provideWorkspaceSymbols(query: string, token: vscode.CancellationToken): Promise<vscode.SymbolInformation[]> {
+    const normalizedQuery = query.trim().toLowerCase();
+    const uris = await vscode.workspace.findFiles('**/*.genia', '**/node_modules/**', 200);
+    const symbols: vscode.SymbolInformation[] = [];
+
+    for (const uri of uris) {
+      if (token.isCancellationRequested) {
+        break;
+      }
+
+      const document = await vscode.workspace.openTextDocument(uri);
+      const indexed = indexGeniaDocument(document.getText());
+
+      for (const symbol of indexed.symbols) {
+        if (normalizedQuery && !symbol.name.toLowerCase().includes(normalizedQuery)) {
+          continue;
+        }
+
+        symbols.push(
+          new vscode.SymbolInformation(
+            symbol.name,
+            symbol.kind === 'function' ? vscode.SymbolKind.Function : vscode.SymbolKind.Variable,
+            symbol.detail ?? '',
+            new vscode.Location(uri, toRange(symbol.selectionRange)),
+          ),
+        );
+      }
+    }
+
+    return symbols;
+  }
+}
+
+function toRange(range: { startLine: number; startCharacter: number; endLine: number; endCharacter: number }): vscode.Range {
+  return new vscode.Range(
+    new vscode.Position(range.startLine, range.startCharacter),
+    new vscode.Position(range.endLine, range.endCharacter),
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide basic editor navigation for `genia` files (Outline, breadcrumbs, same-file go-to-definition, optional workspace symbols) without introducing a full Language Server.

### Description
- Add a minimal top-level Genia indexer `src/languageIndexer.ts` that extracts function/variable symbols, parameter lists, full ranges and selection ranges, and a by-name lookup map used by providers.
- Implement `DocumentSymbolProvider`, `DefinitionProvider`, and a lightweight `WorkspaceSymbolProvider` in `src/languageProviders.ts` that use the indexer to populate Outline/breadcrumbs and resolve same-file definitions.
- Wire providers into extension activation in `src/extension.ts` (providers scoped to language id `genia`) and update activation events in `package.json`.
- Add focused Node tests `src/languageIndexer.test.ts` and update the README to document the new lightweight language features and explicit non-goals.

### Testing
- Ran `npm run build` in `vscode/genia-debugger` and the TypeScript build completed successfully.
- Ran `npm test` in `vscode/genia-debugger`, executing the indexer tests (`out/languageIndexer.test.js`), and all tests passed (4/4).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69b72be788329b3f09c01a813e6bc)