### PR TITLE
Add focused UTF-8 string baseline tests

### DIFF
--- a/tests/test_strings_utf8.py
+++ b/tests/test_strings_utf8.py
@@ -1,0 +1,87 @@
+import pytest
+
+from genia import make_global_env, run_source
+
+
+def _run(src: str):
+    env = make_global_env([])
+    return run_source(src, env)
+
+
+def _assert_pending_or_equal(src: str, expected):
+    try:
+        result = _run(src)
+    except NameError:
+        pytest.xfail(f"pending builtin behavior for: {src}")
+    assert result == expected
+
+
+def test_unicode_string_literals_round_trip_through_parser_and_eval(run):
+    assert run('"é"') == "é"
+    assert run('"漢字"') == "漢字"
+    assert run('"🙂"') == "🙂"
+    assert run('"ASCII + 漢字 + 🙂"') == "ASCII + 漢字 + 🙂"
+
+
+def test_string_literal_escapes_round_trip(run):
+    assert run(r'"\n"') == "\n"
+    assert run(r'"\r"') == "\r"
+    assert run(r'"\t"') == "\t"
+    assert run(r'"\\"') == "\\"
+    assert run(r'"\""') == '"'
+    assert run(r'"\u00E9"') == "é"
+    assert run(r'"\u6F22"') == "漢"
+
+
+def test_byte_length_utf8_minimal_examples():
+    _assert_pending_or_equal('byte_length("")', 0)
+    _assert_pending_or_equal('byte_length("abc")', 3)
+    _assert_pending_or_equal('byte_length("é")', 2)
+    _assert_pending_or_equal('byte_length("漢")', 3)
+    _assert_pending_or_equal('byte_length("🙂")', 4)
+
+
+def test_basic_string_predicates_and_search_for_ascii_and_unicode():
+    _assert_pending_or_equal('contains("café", "fé")', True)
+    _assert_pending_or_equal('starts_with("漢字abc", "漢")', True)
+    _assert_pending_or_equal('ends_with("hi🙂", "🙂")', True)
+
+    # Minimal model expectation: `find` returns Unicode code-point positions.
+    _assert_pending_or_equal('find("naïve", "ï")', 2)
+    _assert_pending_or_equal('find("🙂a", "a")', 1)
+
+
+def test_split_and_split_whitespace_for_ascii_and_unicode():
+    _assert_pending_or_equal('split("a,b,c", ",")', ["a", "b", "c"])
+    _assert_pending_or_equal('split("é|漢|🙂", "|")', ["é", "漢", "🙂"])
+    _assert_pending_or_equal('split_whitespace("a  b\tc\nd")', ["a", "b", "c", "d"])
+
+
+def test_join_for_ascii_and_unicode_sequences():
+    _assert_pending_or_equal('join(",", ["a", "b", "c"])', "a,b,c")
+    _assert_pending_or_equal('join(" ", ["🙂", "漢字"])', "🙂 漢字")
+
+
+def test_trim_variants_for_ascii_and_unicode():
+    _assert_pending_or_equal('trim("  hello  ")', "hello")
+    _assert_pending_or_equal('trim_start("  hello")', "hello")
+    _assert_pending_or_equal('trim_end("hello  ")', "hello")
+    _assert_pending_or_equal('trim("  漢字  ")', "漢字")
+
+
+def test_basic_case_conversion_ascii_only():
+    _assert_pending_or_equal('lower("ABC")', "abc")
+    _assert_pending_or_equal('upper("abc")', "ABC")
+
+
+def test_print_displays_string_content_without_quotes():
+    outputs: list[str] = []
+    env = make_global_env([], output_handler=outputs.append)
+
+    run_source('print("漢字🙂")', env)
+
+    assert outputs == ["漢字🙂\n"]
+
+
+# TODO: Add explicit debug/repr string formatting tests if/when the runtime
+# exposes a stable repr/display distinction for programmatic assertions.


### PR DESCRIPTION
### Motivation
- Establish a minimal, executable specification for UTF-8-aware string behavior before implementing runtime string builtins. 
- Keep the change test-only and small so later implementation can target these concrete expectations. 

### Description
- Added `tests/test_strings_utf8.py` which follows existing pytest conventions and the repo's `run`/`run_source` helpers. 
- The new tests assert Unicode literal round-trip and escape parsing, and declare intended builtins (`byte_length`, `contains`, `starts_with`, `ends_with`, `find`, `split`, `split_whitespace`, `join`, `trim`, `trim_start`, `trim_end`, `lower`, `upper`) as pending when not implemented by xfailing on `NameError` so implementation can follow later. 
- The test suite documents minimal expectations for `byte_length` (UTF-8 byte counts) and for `find` (code-point indexing is the minimal model), and covers split/join/trim/case conversion and print output formatting. 
- Leaves repr/debug formatting and grapheme/locale-sensitive behaviors intentionally deferred with a TODO comment. 

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_strings_utf8.py` which completed with `3 passed, 6 xfailed`. 
- Ran `PYTHONPATH=src pytest -q tests/test_core.py tests/test_strings_utf8.py` which completed with `8 passed, 6 xfailed`. 
- All automated test runs above succeeded with the new tests either passing or being marked xfailed for unimplemented builtins.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69f4cf944832994a13b22881bdd62)