### PR TITLE
Add minimal UTF-8-aware string foundation and core string builtins

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -44,6 +44,11 @@ import sys
 import threading
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Optional
+from .utf8 import (
+    format_debug,
+    format_display,
+    utf8_byte_length,
+)
 
 BASE_DIR = Path(__file__).resolve().parents[2] if "__file__" in globals() else Path.cwd()
 
@@ -212,6 +217,53 @@ def lex(source: str) -> list[Token]:
 
     tokens.append(Token("EOF", "", len(source)))
     return tokens
+
+
+def parse_string_literal(text: str) -> str:
+    if len(text) < 2 or text[0] not in "\"'" or text[-1] != text[0]:
+        raise SyntaxError(f"Invalid string literal: {text!r}")
+    quote = text[0]
+    content = text[1:-1]
+    out: list[str] = []
+    i = 0
+    while i < len(content):
+        ch = content[i]
+        if ch != "\\":
+            out.append(ch)
+            i += 1
+            continue
+
+        i += 1
+        if i >= len(content):
+            raise SyntaxError("Trailing backslash in string literal")
+        esc = content[i]
+        i += 1
+
+        if esc == "n":
+            out.append("\n")
+        elif esc == "r":
+            out.append("\r")
+        elif esc == "t":
+            out.append("\t")
+        elif esc == "\\":
+            out.append("\\")
+        elif esc == "\"":
+            out.append("\"")
+        elif esc == "'":
+            out.append("'")
+        elif esc == "u":
+            if i + 4 > len(content):
+                raise SyntaxError("Invalid \\u escape in string literal")
+            hex_part = content[i:i + 4]
+            if not re.fullmatch(r"[0-9A-Fa-f]{4}", hex_part):
+                raise SyntaxError("Invalid \\u escape in string literal")
+            out.append(chr(int(hex_part, 16)))
+            i += 4
+        elif esc == quote:
+            out.append(quote)
+        else:
+            raise SyntaxError(f"Unsupported escape sequence: \\{esc}")
+    return "".join(out)
 
 
 # -----------------------------
@@ -1045,7 +1097,7 @@ class Parser:
             return Number(float(tok.text) if "." in tok.text else int(tok.text), span=self.span_for_tokens(tok, tok))
         if tok.kind == "STRING":
             self.i += 1
-            return String(eval(tok.text), span=self.span_for_tokens(tok, tok))
+            return String(parse_string_literal(tok.text), span=self.span_for_tokens(tok, tok))
         if tok.kind == "DOTDOT":
             self.i += 1
             if self.at("IDENT"):
@@ -1106,7 +1158,7 @@ class Parser:
             return Number(float(tok.text) if "." in tok.text else int(tok.text), span=self.span_for_tokens(tok, tok))
         if tok.kind == "STRING":
             self.i += 1
-            return String(eval(tok.text), span=self.span_for_tokens(tok, tok))
+            return String(parse_string_literal(tok.text), span=self.span_for_tokens(tok, tok))
         if tok.kind == "IDENT":
             self.i += 1
             if tok.text == "true":
@@ -1746,20 +1798,76 @@ def make_global_env(
     env.debug_mode = debug_mode
 
     def log(*args: Any) -> Any:
-        output = " ".join(str(arg) for arg in args) + "\n"
+        output = " ".join(format_display(arg) for arg in args) + "\n"
         if output_handler is None:
-            print(*args)
+            print(output, end="")
         else:
             output_handler(output)
         return args[-1] if args else None
 
     def print_fn(*args: Any) -> Any:
-        output = " ".join(str(arg) for arg in args) + "\n"
+        output = " ".join(format_display(arg) for arg in args) + "\n"
         if output_handler is None:
-            print(*args)
+            print(output, end="")
         else:
             output_handler(output)
         return args[-1] if args else None
+
+    def _ensure_string(value: Any, name: str) -> str:
+        if not isinstance(value, str):
+            raise TypeError(f"{name} expected a string")
+        return value
+
+    def byte_length_fn(value: Any) -> int:
+        return utf8_byte_length(_ensure_string(value, "byte_length"))
+
+    def is_empty_fn(value: Any) -> bool:
+        return _ensure_string(value, "is_empty") == ""
+
+    def concat_fn(left: Any, right: Any) -> str:
+        return _ensure_string(left, "concat") + _ensure_string(right, "concat")
+
+    def contains_fn(haystack: Any, needle: Any) -> bool:
+        return _ensure_string(needle, "contains") in _ensure_string(haystack, "contains")
+
+    def starts_with_fn(value: Any, prefix: Any) -> bool:
+        return _ensure_string(value, "starts_with").startswith(_ensure_string(prefix, "starts_with"))
+
+    def ends_with_fn(value: Any, suffix: Any) -> bool:
+        return _ensure_string(value, "ends_with").endswith(_ensure_string(suffix, "ends_with"))
+
+    def find_fn(value: Any, needle: Any) -> int | None:
+        idx = _ensure_string(value, "find").find(_ensure_string(needle, "find"))
+        return None if idx < 0 else idx
+
+    def split_fn(value: Any, sep: Any) -> list[str]:
+        return _ensure_string(value, "split").split(_ensure_string(sep, "split"))
+
+    def split_whitespace_fn(value: Any) -> list[str]:
+        return _ensure_string(value, "split_whitespace").split()
+
+    def join_fn(sep: Any, xs: Any) -> str:
+        separator = _ensure_string(sep, "join")
+        if not isinstance(xs, list):
+            raise TypeError("join expected a list as second argument")
+        if not all(isinstance(item, str) for item in xs):
+            raise TypeError("join expected a list of strings")
+        return separator.join(xs)
+
+    def trim_fn(value: Any) -> str:
+        return _ensure_string(value, "trim").strip()
+
+    def trim_start_fn(value: Any) -> str:
+        return _ensure_string(value, "trim_start").lstrip()
+
+    def trim_end_fn(value: Any) -> str:
+        return _ensure_string(value, "trim_end").rstrip()
+
+    def lower_fn(value: Any) -> str:
+        return _ensure_string(value, "lower").lower()
+
+    def upper_fn(value: Any) -> str:
+        return _ensure_string(value, "upper").upper()
 
     def input_fn(prompt: str = "") -> str:
         return input(prompt)
@@ -1861,6 +1969,21 @@ Commands:
     env.set("ref_get", ref_get_fn)
     env.set("ref_set", ref_set_fn)
     env.set("ref_update", ref_update_fn)
+    env.set("byte_length", byte_length_fn)
+    env.set("is_empty", is_empty_fn)
+    env.set("concat", concat_fn)
+    env.set("contains", contains_fn)
+    env.set("starts_with", starts_with_fn)
+    env.set("ends_with", ends_with_fn)
+    env.set("find", find_fn)
+    env.set("split", split_fn)
+    env.set("split_whitespace", split_whitespace_fn)
+    env.set("join", join_fn)
+    env.set("trim", trim_fn)
+    env.set("trim_start", trim_start_fn)
+    env.set("trim_end", trim_end_fn)
+    env.set("lower", lower_fn)
+    env.set("upper", upper_fn)
 
     env.register_autoload("reduce", 3, "std/prelude/list.genia")
     env.register_autoload("count", 1, "std/prelude/list.genia")
@@ -1951,7 +2074,7 @@ def repl() -> None:
             continue
         if not buf and line.strip() == ":env":
             for k in sorted(env.values):
-                print(f"{k} = {env.values[k]!r}")
+                print(f"{k} = {format_debug(env.values[k])}")
             continue
         buf += line + "\n"
         if not is_complete(buf):
@@ -1963,7 +2086,7 @@ def repl() -> None:
         try:
             result = run_source(source, env)
             if result is not None:
-                print(repr(result))
+                print(format_debug(result))
         except Exception as e:  # noqa: BLE001
             print(f"Error: {e}", file=sys.stderr)
 
@@ -2003,7 +2126,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
         with open(args.program, "r", encoding="utf-8") as f:
             result = run_source(f.read(), env, filename=str(Path(args.program).resolve()))
         if result is not None:
-            print(repr(result))
+            print(format_debug(result))
         return 0
 
     repl()

--- a/src/genia/utf8.py
+++ b/src/genia/utf8.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+
+def utf8_byte_length(s: str) -> int:
+    return len(s.encode("utf-8"))
+
+
+def utf8_is_boundary(s: str, byte_offset: int) -> bool:
+    encoded = s.encode("utf-8")
+    if byte_offset < 0 or byte_offset > len(encoded):
+        return False
+    if byte_offset == 0 or byte_offset == len(encoded):
+        return True
+    return (encoded[byte_offset] & 0b1100_0000) != 0b1000_0000
+
+
+def utf8_codepoints(s: str) -> Iterator[str]:
+    return iter(s)
+
+
+def utf8_safe_slice_by_codepoint(s: str, start: int | None, end: int | None) -> str:
+    return s[slice(start, end)]
+
+
+def format_display(value: Any) -> str:
+    if value is None:
+        return "nil"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "[" + ", ".join(format_display(item) for item in value) + "]"
+    return str(value)
+
+
+def _escape_for_debug(s: str) -> str:
+    return (
+        s.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+
+
+def format_debug(value: Any) -> str:
+    if value is None:
+        return "nil"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return f'"{_escape_for_debug(value)}"'
+    if isinstance(value, list):
+        return "[" + ", ".join(format_debug(item) for item in value) + "]"
+    return repr(value)

--- a/tests/test_strings_utf8.py
+++ b/tests/test_strings_utf8.py
@@ -1,19 +1,10 @@
-import pytest
-
 from genia import make_global_env, run_source
+from genia.utf8 import format_debug, utf8_codepoints, utf8_is_boundary, utf8_safe_slice_by_codepoint
 
 
 def _run(src: str):
     env = make_global_env([])
     return run_source(src, env)
-
-
-def _assert_pending_or_equal(src: str, expected):
-    try:
-        result = _run(src)
-    except NameError:
-        pytest.xfail(f"pending builtin behavior for: {src}")
-    assert result == expected
 
 
 def test_unicode_string_literals_round_trip_through_parser_and_eval(run):
@@ -34,44 +25,45 @@ def test_string_literal_escapes_round_trip(run):
 
 
 def test_byte_length_utf8_minimal_examples():
-    _assert_pending_or_equal('byte_length("")', 0)
-    _assert_pending_or_equal('byte_length("abc")', 3)
-    _assert_pending_or_equal('byte_length("é")', 2)
-    _assert_pending_or_equal('byte_length("漢")', 3)
-    _assert_pending_or_equal('byte_length("🙂")', 4)
+    assert _run('byte_length("")') == 0
+    assert _run('byte_length("abc")') == 3
+    assert _run('byte_length("é")') == 2
+    assert _run('byte_length("漢")') == 3
+    assert _run('byte_length("🙂")') == 4
 
 
 def test_basic_string_predicates_and_search_for_ascii_and_unicode():
-    _assert_pending_or_equal('contains("café", "fé")', True)
-    _assert_pending_or_equal('starts_with("漢字abc", "漢")', True)
-    _assert_pending_or_equal('ends_with("hi🙂", "🙂")', True)
+    assert _run('contains("café", "fé")') is True
+    assert _run('starts_with("漢字abc", "漢")') is True
+    assert _run('ends_with("hi🙂", "🙂")') is True
 
     # Minimal model expectation: `find` returns Unicode code-point positions.
-    _assert_pending_or_equal('find("naïve", "ï")', 2)
-    _assert_pending_or_equal('find("🙂a", "a")', 1)
+    assert _run('find("naïve", "ï")') == 2
+    assert _run('find("🙂a", "a")') == 1
+    assert _run('find("abc", "x")') is None
 
 
 def test_split_and_split_whitespace_for_ascii_and_unicode():
-    _assert_pending_or_equal('split("a,b,c", ",")', ["a", "b", "c"])
-    _assert_pending_or_equal('split("é|漢|🙂", "|")', ["é", "漢", "🙂"])
-    _assert_pending_or_equal('split_whitespace("a  b\tc\nd")', ["a", "b", "c", "d"])
+    assert _run('split("a,b,c", ",")') == ["a", "b", "c"]
+    assert _run('split("é|漢|🙂", "|")') == ["é", "漢", "🙂"]
+    assert _run('split_whitespace("a  b\tc\nd")') == ["a", "b", "c", "d"]
 
 
 def test_join_for_ascii_and_unicode_sequences():
-    _assert_pending_or_equal('join(",", ["a", "b", "c"])', "a,b,c")
-    _assert_pending_or_equal('join(" ", ["🙂", "漢字"])', "🙂 漢字")
+    assert _run('join(",", ["a", "b", "c"])') == "a,b,c"
+    assert _run('join(" ", ["🙂", "漢字"])') == "🙂 漢字"
 
 
 def test_trim_variants_for_ascii_and_unicode():
-    _assert_pending_or_equal('trim("  hello  ")', "hello")
-    _assert_pending_or_equal('trim_start("  hello")', "hello")
-    _assert_pending_or_equal('trim_end("hello  ")', "hello")
-    _assert_pending_or_equal('trim("  漢字  ")', "漢字")
+    assert _run('trim("  hello  ")') == "hello"
+    assert _run('trim_start("  hello")') == "hello"
+    assert _run('trim_end("hello  ")') == "hello"
+    assert _run('trim("  漢字  ")') == "漢字"
 
 
 def test_basic_case_conversion_ascii_only():
-    _assert_pending_or_equal('lower("ABC")', "abc")
-    _assert_pending_or_equal('upper("abc")', "ABC")
+    assert _run('lower("ABC")') == "abc"
+    assert _run('upper("abc")') == "ABC"
 
 
 def test_print_displays_string_content_without_quotes():
@@ -83,5 +75,19 @@ def test_print_displays_string_content_without_quotes():
     assert outputs == ["漢字🙂\n"]
 
 
-# TODO: Add explicit debug/repr string formatting tests if/when the runtime
-# exposes a stable repr/display distinction for programmatic assertions.
+def test_debug_format_uses_quoted_escaped_strings():
+    assert format_debug("漢字🙂") == '"漢字🙂"'
+    assert format_debug("a\n\tb") == r'"a\n\tb"'
+
+
+def test_utf8_internal_helpers_boundaries_and_slicing_are_safe():
+    text = "é漢🙂z"
+    assert list(utf8_codepoints(text)) == ["é", "漢", "🙂", "z"]
+    assert utf8_is_boundary(text, 0) is True
+    assert utf8_is_boundary(text, 1) is False
+    assert utf8_is_boundary(text, 2) is True
+    assert utf8_is_boundary(text, 5) is True
+    assert utf8_is_boundary(text, 8) is False
+    assert utf8_is_boundary(text, 9) is True
+    assert utf8_safe_slice_by_codepoint(text, 0, 3) == "é漢🙂"
+    assert utf8_safe_slice_by_codepoint(text, 1, 3) == "漢🙂"


### PR DESCRIPTION
### Motivation
- Provide a small, robust UTF-8-aware foundation for Genia String semantics so language-level string operations behave as text (UTF-8) rather than raw bytes.
- Avoid risky shortcuts (no use of `eval` for string literals) and make a clear, minimal runtime surface for display vs debug formatting.
- Keep the implementation minimal and safe: immutable string model at runtime and only internal helpers for code-point-aware operations (no Bytes or advanced features). 

### Description
- Added `src/genia/utf8.py` with a minimal set of helpers: `utf8_byte_length`, `utf8_is_boundary`, `utf8_codepoints`, `utf8_safe_slice_by_codepoint`, `format_display`, and `format_debug` to centralize UTF-8 and display/debug formatting logic.
- Replaced `eval(tok.text)` string decoding in the parser with an explicit `parse_string_literal` implementation in `src/genia/interpreter.py` that supports `\n`, `\r`, `\t`, `\\`, `\"`, `\'`, and `\uXXXX` escapes and wired it for both expressions and pattern parsing.
- Implemented a small set of runtime string builtins in `make_global_env` in `src/genia/interpreter.py`: `byte_length`, `is_empty`, `concat`, `contains`, `starts_with`, `ends_with`, `find` (returns `nil`/`None` when not found), `split`, `split_whitespace`, `join`, `trim`, `trim_start`, `trim_end`, `lower`, and `upper`.
- Switched user-facing output path to use `format_display` (for `print`/`log`) and REPL/top-level/debug output to use `format_debug` (quoted and escaped strings), and added a few focused tests; intentionally left advanced features unimplemented (no Bytes type, no grapheme clustering, no locale rules, no new syntax).

### Testing
- Ran the focused tests `PYTHONPATH=src pytest -q tests/test_strings_utf8.py` and observed it passed (file-level assertions for literals, escapes, byte lengths, searching/splitting/trimming/case conversion, debug formatting, and internal helpers).
- Ran the full test suite `PYTHONPATH=src pytest -q` and confirmed all tests passed (existing tests preserved).
- All automated tests mentioned above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a20646588329875050cfa3523be1)