### PR TITLE
Allow `$` and skewer-case identifiers

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -73,9 +73,9 @@ BASE_DIR = Path(__file__).resolve().parents[2] if "__file__" in globals() else P
 # - Clojure-style symbol punctuation that we allow in names is listed below.
 # - `name?` and `name!` are ordinary identifiers (no special lexer semantics).
 # - `/` is reserved for division and is not allowed inside identifier names.
-ALWAYS_OPERATOR_DELIMITERS = frozenset({"+", "-", "*", "/", "%", "=", "<", ">", "|", ",", ";", "(", ")", "{", "}", "[", "]"})
-ALLOWED_SYMBOL_PUNCTUATION = frozenset({"_", "?", "!", ".", ":", "$"})
-IDENT_START_RE = re.compile(r"[A-Za-z_]")
+ALWAYS_OPERATOR_DELIMITERS = frozenset({"+", "*", "/", "%", "=", "<", ">", "|", ",", ";", "(", ")", "{", "}", "[", "]"})
+ALLOWED_SYMBOL_PUNCTUATION = frozenset({"_", "?", "!", ".", ":", "$", "-"})
+IDENT_START_RE = re.compile(r"[A-Za-z_$]")
 IDENT_BODY_RE = re.compile(r"[A-Za-z0-9]")
 
 TOKEN_SPEC = [
@@ -211,6 +211,8 @@ def lex(source: str) -> list[Token]:
             ident_start = pos
             pos += 1
             while pos < length and _is_identifier_part(source[pos]):
+                if source[pos] == "-" and pos + 1 < length and source[pos + 1] == ">":
+                    break
                 pos += 1
             tokens.append(Token("IDENT", source[ident_start:pos], ident_start))
             continue

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -58,7 +58,7 @@ def test_identifier_regression_for_underscore_and_reserved_literals(run):
 
 
 def test_arithmetic_operator_tokens_regression():
-    tokens = _kinds_texts("a+b-c*d/e%f")
+    tokens = _kinds_texts("a+b - c*d/e%f")
     assert tokens == [
         ("IDENT", "a"),
         ("PLUS", "+"),
@@ -72,3 +72,12 @@ def test_arithmetic_operator_tokens_regression():
         ("PERCENT", "%"),
         ("IDENT", "f"),
     ]
+
+
+def test_dollar_and_skewer_case_supported_in_all_names(run):
+    src = """
+    my-fn-name($value, second-arg) = $value + second-arg
+    $result-value = my-fn-name(20, 22)
+    $result-value
+    """
+    assert run(src) == 42

--- a/tests/test_lexer_symbols.py
+++ b/tests/test_lexer_symbols.py
@@ -18,12 +18,10 @@ def test_name_suffix_qmark_and_bang_are_plain_identifiers():
     ]
 
 
-def test_plus_minus_and_slash_are_always_operators_not_identifier_chars():
+def test_plus_and_slash_are_operators_but_hyphenated_names_are_identifiers():
     tokens = _kinds_texts("foo-bar + a+b + ns/name")
     assert tokens == [
-        ("IDENT", "foo"),
-        ("MINUS", "-"),
-        ("IDENT", "bar"),
+        ("IDENT", "foo-bar"),
         ("PLUS", "+"),
         ("IDENT", "a"),
         ("PLUS", "+"),


### PR DESCRIPTION
### Motivation
- Enable using `$` in names and support hyphenated (skewer-case) names like `my-fn-name` across functions, parameters, and variables to match requested identifier conventions.

### Description
- Updated lexer rules in `src/genia/interpreter.py` to allow `$` as an identifier start by changing `IDENT_START_RE` to include `$` and to permit `-` inside identifiers by adding `-` to `ALLOWED_SYMBOL_PUNCTUATION` and removing it from the always-operator set.
- Prevented identifiers from swallowing the `->` arrow token by breaking identifier scanning when a `-` is followed by `>` so `map->vec` still tokenizes as `IDENT`, `ARROW`, `IDENT`.
- Adjusted tests to reflect the new behavior by treating hyphenated names as single `IDENT` tokens and added `test_dollar_and_skewer_case_supported_in_all_names` to verify `$` and skewer-case work for function names, parameters, and assigned variables.
- Minor whitespace/tokenization tweak in `tests/test_identifiers.py` to keep subtraction parsed as `MINUS` in the arithmetic-regression test.

### Testing
- Ran targeted tests with `PYTHONPATH=src pytest -q tests/test_identifiers.py tests/test_lexer_symbols.py` which succeeded (`14 passed`).
- Ran the full test suite with `PYTHONPATH=src pytest -q` which succeeded (`139 passed`).
- Attempted an environment-driven `uv run pytest -q` which failed due to network/PyPI fetch errors in the environment and is not indicative of code correctness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6c760f3e8832987a0d096eea6ef1d)