### PR TITLE
Allow `$`-prefixed identifiers in lexer

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -133,6 +133,8 @@ PUNCTUATION_TOKENS = [
     ("SEMI", ";"),
 ]
 def _is_identifier_start(ch: str) -> bool:
+    if ch == "$":
+        return True
     return bool(IDENT_START_RE.fullmatch(ch))
 
 


### PR DESCRIPTION
### Motivation
- Accept AWK-style field identifiers so expressions and patterns containing `$1` tokenize as identifiers instead of raising a `SyntaxError` during lexing.

### Description
- Update `src/genia/interpreter.py` by changing the lexer helper `def _is_identifier_start(ch: str) -> bool` to return `True` when `ch == '$'`, enabling `$`-prefixed names to be recognized as `IDENT` tokens.

### Testing
- Ran `pytest -q tests/test_cases.py::test_cases[awk_split_slash]` and `pytest -q tests/test_cases.py`, and both runs completed successfully (the targeted case passed and the full test suite passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6cfc793788329b347386b1f92ed25)