### PR TITLE
Move `apply` into `fn` stdlib and add varargs `compose`

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -1445,7 +1445,12 @@ class Env:
         root = self.root()
         path = root.autoloads.get((name, arity))
         if path is None:
-            return False
+            for (autoload_name, _), candidate_path in root.autoloads.items():
+                if autoload_name == name:
+                    path = candidate_path
+                    break
+            if path is None:
+                return False
 
         full_path = (BASE_DIR / path).resolve()
         key = str(full_path)
@@ -1497,7 +1502,6 @@ class TailCall:
 
 
 _UNSET = object()
-_APPLY_SENTINEL = object()
 
 
 class GeniaRef:
@@ -1688,23 +1692,12 @@ class Evaluator:
             try:
                 fn = self.env.get(name)
             except NameError:
-                if name == "apply":
-                    fn = _APPLY_SENTINEL
-                elif self.env.try_autoload(name, len(args)):
+                if self.env.try_autoload(name, len(args)):
                     fn = self.env.get(name)
                 else:
                     raise
         else:
             fn = self.eval(node.fn)
-
-        if fn is _APPLY_SENTINEL:
-            if len(args) != 2:
-                raise TypeError(f"apply expected 2 args, got {len(args)}")
-            target_fn = args[0]
-            target_args = args[1]
-            if not isinstance(target_args, list):
-                raise TypeError("apply expected a list as second argument")
-            return self.invoke_callable(target_fn, target_args, tail_position=tail_position)
 
         return self.invoke_callable(fn, args, tail_position=tail_position, callee_node=node.fn)
 
@@ -2170,6 +2163,9 @@ Commands:
     env.register_autoload("nth", 2, "std/prelude/list.genia")
     env.register_autoload("take", 2, "std/prelude/list.genia")
     env.register_autoload("drop", 2, "std/prelude/list.genia")
+    env.register_autoload("apply", 2, "std/prelude/fn.genia")
+    env.register_autoload("compose", 1, "std/prelude/fn.genia")
+
     env.register_autoload("sum", 1, "std/prelude/math.genia")
     env.register_autoload("awkify", 2, "std/prelude/awk.genia")
     env.register_autoload("awk_filter", 2, "std/prelude/awk.genia")

--- a/std/prelude/fn.genia
+++ b/std/prelude/fn.genia
@@ -1,0 +1,7 @@
+apply(f, args) = f(..args)
+
+compose(..fns) = (..args) -> compose_apply(fns, args)
+
+compose_apply(fns, args) =
+  ([f], args) -> apply(f, args) |
+  ([f, ..rest], args) -> f(compose_apply(rest, args))

--- a/tests/test_fn_stdlib.py
+++ b/tests/test_fn_stdlib.py
@@ -1,0 +1,40 @@
+import pytest
+
+
+def test_apply_autoload_from_fn_stdlib(run):
+    src = '''
+    add(a, b) = a + b
+    apply(add, [20, 22])
+    '''
+    assert run(src) == 42
+
+
+def test_compose_varargs_chain(run):
+    src = '''
+    add(a, b) = a + b
+    inc(x) = x + 1
+    square(x) = x * x
+
+    f = compose(square, inc, add)
+    f(2, 3)
+    '''
+    assert run(src) == 36
+
+
+def test_compose_single_function_passthrough(run):
+    src = '''
+    pair(a, b) = [a, b]
+    f = compose(pair)
+    f(1, 2)
+    '''
+    assert run(src) == [1, 2]
+
+
+def test_compose_empty_function_list_has_no_matching_clause(run):
+    with pytest.raises(RuntimeError):
+        run(
+            '''
+            id = compose()
+            id(1)
+            '''
+        )


### PR DESCRIPTION
### Motivation
- Make `apply` a normal standard-library function so it can take advantage of language features (varargs/spread) instead of being special-cased in the interpreter.
- Provide a varargs `compose` helper in stdlib so composed functions can accept arbitrary argument lists and chain cleanly.
- Ensure autoload works sensibly for varargs stdlib functions so they load on first use even when called with different arities.

### Description
- Added `std/prelude/fn.genia` implementing `apply(f, args) = f(..args)` and `compose(..fns)` with a helper `compose_apply` to support varargs composition.
- Removed the interpreter-level `apply` sentinel and its special-cased dispatch, letting `apply` resolve and execute like any other function.
- Improved `Env.try_autoload` to fall back by function name when an exact `(name, arity)` entry is not present so varargs stdlib functions autoload correctly.
- Registered autoload entries for `apply` and `compose` and added `tests/test_fn_stdlib.py` covering `apply` autoloading and `compose` semantics.

### Testing
- Ran `pytest -q tests/test_varargs_apply.py tests/test_fn_stdlib.py tests/test_autoload.py` and all tests passed (`17 passed`).
- Ran `pytest -q tests/test_higher_order.py tests/test_cases.py` and all tests passed (`48 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e0bb360c8329997e9bc4708301d8)