### PR TITLE
Clarify exact-arity vs varargs function resolution precedence

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -1712,23 +1712,39 @@ class Evaluator:
 
         if isinstance(fn, dict) and all(isinstance(k, int) for k in fn):
             arity = len(args)
-            target = fn.get(arity)
-            if target is None:
-                for candidate in fn.values():
-                    if isinstance(candidate, GeniaFunction) and candidate.rest_param is not None and arity >= candidate.arity:
-                        target = candidate
-                        break
+
+            def resolve_target(functions: dict[int, Any], call_arity: int) -> Any | None:
+                exact = functions.get(call_arity)
+                if exact is not None:
+                    return exact
+
+                vararg_matches = [
+                    candidate
+                    for candidate in functions.values()
+                    if isinstance(candidate, GeniaFunction)
+                    and candidate.rest_param is not None
+                    and call_arity >= candidate.arity
+                ]
+                if len(vararg_matches) == 1:
+                    return vararg_matches[0]
+                if len(vararg_matches) > 1:
+                    callee = callee_node.name if isinstance(callee_node, IrVar) else "function"
+                    candidates = ", ".join(
+                        f"{callee}/{candidate.arity}+"
+                        for candidate in sorted(vararg_matches, key=lambda f: f.arity)
+                    )
+                    raise TypeError(
+                        f"Ambiguous function resolution: {callee}/{call_arity}. Matching varargs: {candidates}"
+                    )
+                return None
+
+            target = resolve_target(fn, arity)
 
             if target is None and isinstance(callee_node, IrVar):
                 if self.env.try_autoload(callee_node.name, arity):
                     fn = self.env.get(callee_node.name)
                     if isinstance(fn, dict) and all(isinstance(k, int) for k in fn):
-                        target = fn.get(arity)
-                        if target is None:
-                            for candidate in fn.values():
-                                if isinstance(candidate, GeniaFunction) and candidate.rest_param is not None and arity >= candidate.arity:
-                                    target = candidate
-                                    break
+                        target = resolve_target(fn, arity)
 
             if target is None:
                 callee = callee_node.name if isinstance(callee_node, IrVar) else "function"

--- a/tests/test_function_resolution_precedence.py
+++ b/tests/test_function_resolution_precedence.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+
+from genia import make_global_env, run_source
+
+
+def test_exact_fixed_arity_preferred_over_varargs(run):
+    src = '''
+    pick(a, b) = "exact"
+    pick(a, ..rest) = "varargs"
+    pick(1, 2)
+    '''
+    assert run(src) == "exact"
+
+
+def test_varargs_used_when_no_exact_arity_exists(run):
+    src = '''
+    pick(a, b) = "exact2"
+    pick(a, ..rest) = "varargs"
+    pick(1, 2, 3)
+    '''
+    assert run(src) == "varargs"
+
+
+def test_ambiguous_varargs_resolution_raises(run):
+    with pytest.raises(TypeError, match="Ambiguous function resolution"):
+        run(
+            '''
+            pick(a, ..rest) = "prefix1"
+            pick(a, b, ..rest) = "prefix2"
+            pick(1, 2, 3)
+            '''
+        )
+
+
+def test_autoload_resolution_matches_non_autoload(tmp_path: Path):
+    src = '''
+    pick(a, b) = "exact"
+    pick(a, ..rest) = "varargs"
+    pick(1, 2)
+    '''
+    assert run_source(src, make_global_env([])) == "exact"
+
+    prelude_file = tmp_path / "std" / "prelude" / "pick.genia"
+    prelude_file.parent.mkdir(parents=True)
+    prelude_file.write_text(
+        "pick(a, b) = \"exact\"\n"
+        "pick(a, ..rest) = \"varargs\"\n",
+        encoding="utf-8",
+    )
+
+    env = make_global_env([])
+    env.register_autoload("pick", 2, str(prelude_file.resolve()))
+    env.register_autoload("pick", 1, str(prelude_file.resolve()))
+
+    assert run_source("pick(1, 2)", env) == "exact"
+    assert run_source("pick(1, 2, 3)", env) == "varargs"
+
+
+def test_autoload_ambiguous_matches_non_autoload(tmp_path: Path):
+    with pytest.raises(TypeError, match="Ambiguous function resolution"):
+        run_source(
+            '''
+            pick(a, ..rest) = "prefix1"
+            pick(a, b, ..rest) = "prefix2"
+            pick(1, 2, 3)
+            ''',
+            make_global_env([]),
+        )
+
+    prelude_file = tmp_path / "std" / "prelude" / "ambiguous.genia"
+    prelude_file.parent.mkdir(parents=True)
+    prelude_file.write_text(
+        "pick(a, ..rest) = \"prefix1\"\n"
+        "pick(a, b, ..rest) = \"prefix2\"\n",
+        encoding="utf-8",
+    )
+
+    env = make_global_env([])
+    env.register_autoload("pick", 1, str(prelude_file.resolve()))
+
+    with pytest.raises(TypeError, match="Ambiguous function resolution"):
+        run_source("pick(1, 2, 3)", env)


### PR DESCRIPTION
### Motivation
- Make resolution between same-name exact-arity and varargs functions deterministic and explicit.  
- Prevent silent mis-dispatch when multiple varargs candidates could match a call.  
- Ensure autoloaded functions follow the same resolution rules as already-loaded definitions.  

### Description
- Centralized selection logic in `invoke_callable` by adding a `resolve_target` routine that first returns an exact arity match and only then considers varargs candidates.  
- If exactly one varargs candidate matches (`call_arity >= candidate.arity`) it is selected, and if multiple varargs candidates match the evaluator raises `TypeError("Ambiguous function resolution: ...")`.  
- The same resolver is reused after autoloading so lazy-loaded definitions behave identically to non-autoloaded ones.  
- Added a focused test module `tests/test_function_resolution_precedence.py` covering exact-arity preference, varargs fallback, ambiguity errors, and autoload parity.  

### Testing
- Ran `pytest -q tests/test_function_resolution_precedence.py tests/test_varargs_apply.py tests/test_autoload.py` and all tests passed.  
- Test run summary: 18 passed, 0 failed.  
- The new tests exercise both direct and autoloaded function resolution cases and verify the ambiguity error path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6e3caf36483299a5b5b63f8fc9ba4)