### PR TITLE
Add `ref_is_set` introspection and concurrency-focused ref tests

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -1523,6 +1523,10 @@ class GeniaRef:
             self._condition.notify_all()
             return value
 
+    def is_set(self) -> bool:
+        with self._condition:
+            return self._is_set
+
     def update(self, fn: Any) -> Any:
         with self._condition:
             while not self._is_set:
@@ -2136,6 +2140,11 @@ Commands:
             raise TypeError("ref_set expected a ref as first argument")
         return ref_value.set(value)
 
+    def ref_is_set_fn(ref_value: Any) -> bool:
+        if not isinstance(ref_value, GeniaRef):
+            raise TypeError("ref_is_set expected a ref")
+        return ref_value.is_set()
+
     def ref_update_fn(ref_value: Any, updater: Any) -> Any:
         if not isinstance(ref_value, GeniaRef):
             raise TypeError("ref_update expected a ref as first argument")
@@ -2156,6 +2165,7 @@ Commands:
     env.set("ref", ref_fn)
     env.set("ref_get", ref_get_fn)
     env.set("ref_set", ref_set_fn)
+    env.set("ref_is_set", ref_is_set_fn)
     env.set("ref_update", ref_update_fn)
     env.set("byte_length", byte_length_fn)
     env.set("is_empty", is_empty_fn)

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -40,3 +40,67 @@ def test_ref_get_blocks_until_set():
     reader.join(timeout=1)
 
     assert result["value"] == 99
+
+
+def test_multiple_waiting_readers_wake_after_set():
+    env = make_global_env([])
+    run_source("r = ref()", env)
+
+    started = threading.Barrier(4)
+    results: list[object] = []
+    lock = threading.Lock()
+
+    def waiting_reader():
+        started.wait()
+        value = run_source("ref_get(r)", env)
+        with lock:
+            results.append(value)
+
+    readers = [threading.Thread(target=waiting_reader) for _ in range(3)]
+    for reader in readers:
+        reader.start()
+
+    started.wait()
+    time.sleep(0.05)
+    assert all(reader.is_alive() for reader in readers)
+
+    run_source("ref_set(r, 123)", env)
+    for reader in readers:
+        reader.join(timeout=1)
+
+    assert results == [123, 123, 123]
+
+
+def test_multiple_sequential_ref_update_calls_are_serialized(run):
+    src = """
+    r = ref(0)
+    ref_update(r, (x) -> x + 1)
+    ref_update(r, (x) -> x + 2)
+    ref_update(r, (x) -> x * 10)
+    ref_get(r)
+    """
+    assert run(src) == 30
+
+
+def test_ref_update_blocks_until_set():
+    env = make_global_env([])
+    run_source("r = ref()", env)
+
+    result: dict[str, object] = {}
+
+    def waiting_updater():
+        result["value"] = run_source("ref_update(r, (x) -> x + 1)", env)
+
+    updater = threading.Thread(target=waiting_updater)
+    updater.start()
+
+    time.sleep(0.05)
+    assert updater.is_alive()
+    assert run_source("ref_is_set(r)", env) is False
+
+    run_source("ref_set(r, 41)", env)
+    updater.join(timeout=1)
+
+    assert result["value"] == 42
+    assert run_source("ref_get(r)", env) == 42
+    assert run_source("ref_is_set(r)", env) is True


### PR DESCRIPTION
### Motivation
- Prepare for future concurrency work by adding a minimal, non-blocking ref introspection primitive while preserving all existing ref semantics and tests.
- Provide focused tests that exercise multiple waiters, serialized `ref_update` behavior, and blocking `ref_update` on unset refs to ensure the runtime primitives behave correctly under concurrent use.
- Chose a simple introspection API to avoid changing blocking semantics or introducing ambiguity with `nil` values, keeping the runtime changes minimal and localized.

### Description
- Added `GeniaRef.is_set()` which returns a boolean under the same condition lock used by other ref operations to ensure thread safety.
- Exposed a new builtin `ref_is_set` in the global environment that calls `GeniaRef.is_set()` and validates its argument, keeping the rest of the ref API (`ref`, `ref_get`, `ref_set`, `ref_update`) unchanged.
- Added new tests in `tests/test_refs.py` that cover: multiple waiting readers waking after a single `ref_set`, multiple sequential `ref_update` calls preserving serialized updates, and `ref_update` blocking until an unset ref is set.
- Files changed: `src/genia/interpreter.py` and `tests/test_refs.py` with only localized logic and tests updates.

### Testing
- Ran `pytest -q tests/test_refs.py` which executed the original and new ref tests and reported all passing (`6 passed`).
- No other test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c929e276d48329b5118e1e3ab1847f)