### PR TITLE
Add minimal host-backed process primitives

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import math
 import os
 import bisect
+import queue
 from pathlib import Path
 import argparse
 import re
@@ -1542,6 +1543,29 @@ class GeniaRef:
             return "<ref <unset>>"
 
 
+class GeniaProcess:
+    def __init__(self, handler: Callable[[Any], Any]):
+        self._handler = handler
+        self._mailbox: queue.Queue[Any] = queue.Queue()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        while True:
+            message = self._mailbox.get()
+            self._handler(message)
+
+    def send(self, message: Any) -> None:
+        self._mailbox.put(message)
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    def __repr__(self) -> str:
+        status = "alive" if self.is_alive() else "dead"
+        return f"<process {status}>"
+
+
 def eval_with_tco(
     fn: Any,
     args: tuple[Any, ...],
@@ -2152,6 +2176,22 @@ Commands:
             raise TypeError("ref_update expected a function as second argument")
         return ref_value.update(updater)
 
+    def spawn_fn(handler: Any) -> GeniaProcess:
+        if not callable(handler):
+            raise TypeError("spawn expected a function")
+        return GeniaProcess(handler)
+
+    def send_fn(process: Any, message: Any) -> None:
+        if not isinstance(process, GeniaProcess):
+            raise TypeError("send expected a process as first argument")
+        process.send(message)
+        return None
+
+    def process_alive_fn(process: Any) -> bool:
+        if not isinstance(process, GeniaProcess):
+            raise TypeError("process_alive? expected a process")
+        return process.is_alive()
+
     env.set("log", log)
     env.set("print", print_fn)
     env.set("input", input_fn)
@@ -2167,6 +2207,9 @@ Commands:
     env.set("ref_set", ref_set_fn)
     env.set("ref_is_set", ref_is_set_fn)
     env.set("ref_update", ref_update_fn)
+    env.set("spawn", spawn_fn)
+    env.set("send", send_fn)
+    env.set("process_alive?", process_alive_fn)
     env.set("byte_length", byte_length_fn)
     env.set("is_empty", is_empty_fn)
     env.set("concat", concat_fn)

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -1,0 +1,59 @@
+import threading
+import time
+
+from genia import make_global_env, run_source
+
+
+def test_spawn_returns_handle():
+    env = make_global_env([])
+    process = run_source("spawn((msg) -> msg)", env)
+    assert process is not None
+    assert "process" in repr(process)
+
+
+def test_send_delivers_messages_in_order():
+    env = make_global_env([])
+    run_source(
+        """
+        out = ref([])
+        p = spawn((msg) -> ref_update(out, (xs) -> append(xs, [msg])))
+        send(p, 1)
+        send(p, 2)
+        send(p, 3)
+        """,
+        env,
+    )
+
+    for _ in range(100):
+        if run_source("ref_get(out)", env) == [1, 2, 3]:
+            break
+        time.sleep(0.01)
+    assert run_source("ref_get(out)", env) == [1, 2, 3]
+
+
+def test_process_handler_updates_shared_state_predictably():
+    env = make_global_env([])
+    run_source(
+        """
+        total = ref(0)
+        p = spawn((msg) -> ref_update(total, (n) -> n + msg))
+        """,
+        env,
+    )
+
+    threads = [threading.Thread(target=lambda: run_source("send(p, 1)", env)) for _ in range(25)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1)
+
+    for _ in range(100):
+        if run_source("ref_get(total)", env) == 25:
+            break
+        time.sleep(0.01)
+    assert run_source("ref_get(total)", env) == 25
+
+
+def test_process_alive_reports_useful_status():
+    env = make_global_env([])
+    assert run_source("process_alive?(spawn((msg) -> msg))", env) is True


### PR DESCRIPTION
### Motivation
- Provide a minimal, host-backed concurrency substrate so Genia can support process-style message passing while keeping higher-level agent abstractions for later.
- Keep the runtime simple and deterministic by enforcing strict one-at-a-time mailbox processing per process using Python primitives.

### Description
- Add `GeniaProcess` (in `src/genia/interpreter.py`) which owns a `queue.Queue` mailbox and a daemon `threading.Thread` worker that repeatedly `get()`s one message and calls the provided handler exactly once per message.
- Add host-builtins `spawn(handler)`, `send(process, message)`, and `process_alive?(process)` exposed to Genia programs and registered in the global environment.
- Import `queue` and add minimal type-checking for `spawn`/`send`/`process_alive?` callables and process handles in the interpreter.
- Intentionally omit `receive()` primitives and any supervision/linking/monitoring/restart lifecycle features to keep the implementation minimal and host-backed.

### Testing
- Added `tests/test_processes.py` which validates that `spawn` returns a handle, `send` delivers messages in order, concurrent sends produce predictable state updates, and `process_alive?` reports liveness.
- Ran `pytest -q tests/test_processes.py tests/test_refs.py` which succeeded: all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c92bf450b88329b555e95fe32f06a0)