### PR TITLE
Add minimal stdlib agent abstraction on refs/processes

### DIFF
--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2265,6 +2265,11 @@ Concurrency builtins (host-backed):
     env.register_autoload("awk_map", 2, "std/prelude/awk.genia")
     env.register_autoload("awk_count", 2, "std/prelude/awk.genia")
     env.register_autoload("fields", 1, "std/prelude/awk.genia")
+    env.register_autoload("agent", 1, "std/prelude/agent.genia")
+    env.register_autoload("agent_send", 2, "std/prelude/agent.genia")
+    env.register_autoload("agent_get", 1, "std/prelude/agent.genia")
+    env.register_autoload("agent_state", 1, "std/prelude/agent.genia")
+    env.register_autoload("agent_alive?", 1, "std/prelude/agent.genia")
     return env
 
 

--- a/std/prelude/agent.genia
+++ b/std/prelude/agent.genia
@@ -1,0 +1,16 @@
+agent(initial) = agent_with_state(ref(initial))
+
+agent_with_state(state) =
+  ["agent", state, spawn((update) -> ref_update(state, update))]
+
+agent_send(agent, update) =
+  (["agent", _, worker], update) -> send(worker, update)
+
+agent_get(agent) =
+  (["agent", state, _]) -> ref_get(state)
+
+agent_state(agent) =
+  (["agent", state, _]) -> ref_get(state)
+
+agent_alive?(agent) =
+  (["agent", _, worker]) -> process_alive?(worker)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,88 @@
+import time
+
+from genia import make_global_env, run_source
+
+
+def test_agent_increment_updates_state_correctly():
+    env = make_global_env([])
+    run_source(
+        """
+        a = agent(0)
+        agent_send(a, (x) -> x + 1)
+        agent_send(a, (x) -> x + 1)
+        """,
+        env,
+    )
+
+    for _ in range(100):
+        if run_source("agent_get(a)", env) == 2:
+            break
+        time.sleep(0.01)
+
+    assert run_source("agent_get(a)", env) == 2
+
+
+def test_agent_processes_multiple_sends_in_order():
+    env = make_global_env([])
+    run_source(
+        """
+        a = agent(1)
+        agent_send(a, (x) -> x + 2)
+        agent_send(a, (x) -> x * 10)
+        """,
+        env,
+    )
+
+    for _ in range(100):
+        if run_source("agent_get(a)", env) == 30:
+            break
+        time.sleep(0.01)
+
+    assert run_source("agent_get(a)", env) == 30
+
+
+def test_agent_get_and_agent_state_return_current_state():
+    env = make_global_env([])
+    run_source(
+        """
+        a = agent(41)
+        agent_send(a, (x) -> x + 1)
+        """,
+        env,
+    )
+
+    for _ in range(100):
+        if run_source("agent_state(a)", env) == 42:
+            break
+        time.sleep(0.01)
+
+    assert run_source("agent_get(a)", env) == 42
+    assert run_source("agent_state(a)", env) == 42
+
+
+def test_agent_updates_are_asynchronous_relative_to_caller():
+    env = make_global_env([])
+    run_source(
+        """
+        gate = ref()
+        a = agent(0)
+        agent_send(a, (_) -> ref_get(gate))
+        agent_send(a, (x) -> x + 1)
+        """,
+        env,
+    )
+
+    assert run_source("agent_get(a)", env) == 0
+
+    run_source("ref_set(gate, 41)", env)
+    for _ in range(100):
+        if run_source("agent_get(a)", env) == 42:
+            break
+        time.sleep(0.01)
+
+    assert run_source("agent_get(a)", env) == 42
+
+
+def test_agent_alive_reports_worker_status():
+    env = make_global_env([])
+    assert run_source("agent_alive?(agent(0))", env) is True


### PR DESCRIPTION
### Motivation
- Provide a small, standard-library agent abstraction built on the existing `ref` and `process` primitives so users can have serialized, asynchronous state updates without changing core evaluator semantics.
- Keep the first iteration minimal and debuggable: a ref for state and a spawned worker process that applies update functions one at a time.

### Description
- Added a new prelude module `std/prelude/agent.genia` implementing agents as the tagged value `["agent", state_ref, worker_process]` and exposing `agent`, `agent_send`, `agent_get`, `agent_state`, and `agent_alive?` APIs.
- Registered autoload entries for the new functions in `make_global_env` so the API is available like other prelude functions via `env.register_autoload` in `src/genia/interpreter.py`.
- Added tests in `tests/test_agents.py` that verify increment-style updates, ordered processing, state access via `agent_get`/`agent_state`, asynchronous behavior relative to the caller, and worker liveness.

### Testing
- Ran the focused test command `pytest -q tests/test_agents.py tests/test_refs.py tests/test_processes.py` and the run succeeded with all tests passing (`17 passed`).
- The agent tests exercise ordering, atomic updates via `ref_update`, blocking semantics where appropriate, and liveness checks for the spawned worker.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c959c0810c8329a5c042eaa7b868e3)