### PR TITLE
Add runnable concurrency/agent examples and integration tests

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -224,9 +224,9 @@ Result:
 
 ---
 
-# 8. Host-backed Concurrency (Minimal)
+# 8. Host-backed Concurrency and Agents
 
-## 8.1 Process Creation and Message Send
+## 8.1 Basic Process + Send
 
 ```genia
 inbox = ref([])
@@ -243,7 +243,61 @@ Result (after mailbox drains):
 ["a", "b", "c"]
 ```
 
-## 8.2 Process Liveness
+## 8.2 Ref Used with a Process
+
+```genia
+total = ref(0)
+p = spawn((msg) -> ref_update(total, (n) -> n + msg))
+send(p, 10)
+send(p, 5)
+ref_get(total)
+```
+
+Result (after mailbox drains):
+
+```text
+15
+```
+
+## 8.3 Simple Counter Agent
+
+```genia
+counter = agent(0)
+agent_send(counter, (n) -> n + 1)
+agent_send(counter, (n) -> n + 1)
+agent_send(counter, (n) -> n + 1)
+agent_get(counter)
+```
+
+Result (after mailbox drains):
+
+```text
+3
+```
+
+## 8.4 Logging / Background Worker Pattern
+
+```genia
+append_logged(xs, msg) {
+  log(msg)
+  append(xs, [msg])
+}
+
+logs = ref([])
+logger = spawn((msg) -> ref_update(logs, (xs) -> append_logged(xs, msg)))
+send(logger, "boot")
+send(logger, "request")
+send(logger, "done")
+ref_get(logs)
+```
+
+Result (after mailbox drains):
+
+```text
+["boot", "request", "done"]
+```
+
+## 8.5 Process Liveness
 
 ```genia
 p = spawn((msg) -> msg)
@@ -480,6 +534,7 @@ These examples demonstrate:
 * Pattern matching (including nested and duplicate bindings)
 * List destructuring with rest patterns
 * Lambda functions and closures
+* Processes, refs, and agents for host-backed concurrency
 * Blocks and evaluation order
 * Higher-order functions
 * Autoloaded standard library

--- a/README.md
+++ b/README.md
@@ -184,15 +184,47 @@ Genia exposes a tiny process/mailbox substrate through builtins:
 * **Serial processing per process**: each process handles one message at a time; no concurrent handler execution within the same process.
 * **Host-backed concurrency**: this feature is implemented by the runtime host (not as a pure language-level scheduler).
 
-### Minimal Examples
+### Runnable Examples
 
 ```genia
-# Fan-in to shared state
+# 1) Basic process + send
+inbox = ref([])
+p = spawn((msg) -> ref_update(inbox, (xs) -> append(xs, [msg])))
+send(p, "a")
+send(p, "b")
+send(p, "c")
+ref_get(inbox)  # eventually ["a", "b", "c"]
+```
+
+```genia
+# 2) Ref used with a process
 total = ref(0)
-p = spawn((msg) -> ref_update(total, (n) -> n + msg))
-send(p, 1)
-send(p, 2)
-ref_get(total)   # eventually 3
+acc = spawn((msg) -> ref_update(total, (n) -> n + msg))
+send(acc, 10)
+send(acc, 5)
+ref_get(total)  # eventually 15
+```
+
+```genia
+# 3) Simple counter agent (autoloaded from std/prelude/agent.genia)
+counter = agent(0)
+agent_send(counter, (n) -> n + 1)
+agent_send(counter, (n) -> n + 1)
+agent_get(counter)  # eventually 2
+```
+
+```genia
+# 4) Logging/background worker pattern
+append_logged(xs, msg) {
+  log(msg)
+  append(xs, [msg])
+}
+
+logs = ref([])
+logger = spawn((msg) -> ref_update(logs, (xs) -> append_logged(xs, msg)))
+send(logger, "boot")
+send(logger, "request")
+ref_get(logs)  # eventually ["boot", "request"]
 ```
 
 ```genia

--- a/tests/test_concurrency_examples.py
+++ b/tests/test_concurrency_examples.py
@@ -1,0 +1,80 @@
+import time
+
+from genia import make_global_env, run_source
+
+
+def wait_for(env, expr, expected, *, timeout_s=1.0, sleep_s=0.01):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if run_source(expr, env) == expected:
+            return
+        time.sleep(sleep_s)
+    assert run_source(expr, env) == expected
+
+
+def test_example_basic_process_send():
+    env = make_global_env([])
+    run_source(
+        '''
+        inbox = ref([])
+        p = spawn((msg) -> ref_update(inbox, (xs) -> append(xs, [msg])))
+        send(p, "a")
+        send(p, "b")
+        send(p, "c")
+        ''',
+        env,
+    )
+
+    wait_for(env, "ref_get(inbox)", ["a", "b", "c"])
+
+
+def test_example_ref_used_with_process():
+    env = make_global_env([])
+    run_source(
+        '''
+        total = ref(0)
+        p = spawn((msg) -> ref_update(total, (n) -> n + msg))
+        send(p, 10)
+        send(p, 5)
+        send(p, -2)
+        ''',
+        env,
+    )
+
+    wait_for(env, "ref_get(total)", 13)
+
+
+def test_example_simple_counter_agent():
+    env = make_global_env([])
+    run_source(
+        '''
+        counter = agent(0)
+        agent_send(counter, (n) -> n + 1)
+        agent_send(counter, (n) -> n + 1)
+        agent_send(counter, (n) -> n + 1)
+        ''',
+        env,
+    )
+
+    wait_for(env, "agent_get(counter)", 3)
+
+
+def test_example_logging_background_worker_pattern():
+    env = make_global_env([])
+    run_source(
+        '''
+        append_logged(xs, msg) {
+          log(msg)
+          append(xs, [msg])
+        }
+
+        logs = ref([])
+        logger = spawn((msg) -> ref_update(logs, (xs) -> append_logged(xs, msg)))
+        send(logger, "boot")
+        send(logger, "request")
+        send(logger, "done")
+        ''',
+        env,
+    )
+
+    wait_for(env, "ref_get(logs)", ["boot", "request", "done"])


### PR DESCRIPTION
### Motivation

- Provide clear, runnable examples for the new host-backed concurrency substrate and the agent library so users can see common patterns in-place. 
- Ensure the examples are kept aligned with the currently implemented Genia syntax and builtins (`spawn`, `send`, `process_alive?`, `ref_*`, `agent*`).
- Add integration-style tests that execute the documented patterns to prevent regressions in async behavior.

### Description

- Expanded the concurrency section in `EXAMPLES.md` with four runnable snippets demonstrating: basic process + `send`, `ref` used with a process, a simple counter `agent`, and a logging/background worker pattern. 
- Updated the `README.md` concurrency subsection to include concise, runnable examples mirroring the same patterns and builtins. 
- Added `tests/test_concurrency_examples.py`, which provides a `wait_for` helper and integration-style tests that drive each example and assert eventual state after asynchronous mailbox processing. 
- Minor doc summary update to explicitly call out processes/refs/agents in the examples list.

### Testing

- Ran the new integration tests via `pytest -q tests/test_concurrency_examples.py tests/test_processes.py tests/test_agents.py`. 
- Result: all tests passed (`15 passed`), indicating the examples and async patterns behave as expected under the current runtime implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95ada2768832992af950a948fa485)