### PR TITLE
Docs: align README, GENIA_STATE, GENIA_RULES, and REPL docs with current interpreter behavior

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -1,75 +1,52 @@
 # Genia Prototype REPL
 
-This is a Python prototype REPL for the current Genia design.
+This document describes the **actual current behavior** of the Python prototype in `src/genia/interpreter.py`.
 
 ## Run
 
-```bash
-python3 genia_repl.py
-```
-
-Or run a file:
+Run the REPL:
 
 ```bash
-python3 genia_repl.py sample.genia
+python3 -m genia.interpreter
 ```
 
-## Supported in this prototype
+Run a program file:
 
-- numbers, strings, booleans, nil
-- arithmetic: `+ - * / %`
-- comparison: `< <= > >= == !=`
-- variables and function calls
-- function definitions with `=`
-- function definitions with `{}` block bodies
-- case expressions in function bodies
-- case expressions as the final expression in a block
-- pattern matching against the full argument tuple
-- single-parameter shorthand patterns
-- guards with `?`
-- `log(...)` builtin
-
-## Examples
-
-### Arithmetic
-
-```genia
-1 + 2 * 3
+```bash
+python3 -m genia.interpreter path/to/file.genia
 ```
 
-### Simple function
+Run in stdio debug-adapter mode:
 
-```genia
-square(x) = x * x
-square(5)
+```bash
+python3 -m genia.interpreter --debug-stdio path/to/file.genia
 ```
 
-### Factorial
+## Implemented today
 
-```genia
-fact(n) =
-  0 -> 1 |
-  n -> n * fact(n - 1)
-```
-
-### Factorial with logging block
-
-```genia
-fact2(n) {
-  log(n)
-  0 -> 1 |
-  n -> n * fact2(n - 1)
-}
-```
-
-### Tuple-pattern matching
-
-```genia
-add(x, y) =
-  (0, y) -> y |
-  (x, 0) -> x |
-  (x, y) -> x + y
-```
+- literals: numbers, strings (single/double quotes + escapes), booleans, `nil`
+- variables and top-level assignment (`name = expr`)
+- unary/binary operators: `!`, unary `-`, `+ - * / %`, comparisons, equality, `&&`, `||`
+- function definitions with expression body, block body, or case body
+- lambda expressions, including varargs lambdas with `..rest`
+- list literals with spread (`[..xs]`, `[1, ..xs, 2]`)
+- function-call argument spread (`f(..xs)`)
+- pattern matching:
+  - tuple patterns
+  - list patterns
+  - wildcard `_`
+  - rest pattern `..rest` / `.._`
+  - duplicate-binding equality semantics (`[x, x]`)
+  - guards with `?`
+- case expressions in function bodies and as final expression in a block
+- function resolution with fixed arity + varargs precedence
+- autoloaded stdlib functions keyed by `(name, arity)`
+- builtins:
+  - I/O: `log`, `print`, `input`, `stdin`, `help`
+  - refs: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
+  - concurrency: `spawn`, `send`, `process_alive?`
+  - strings: `byte_length`, `is_empty`, `concat`, `contains`, `starts_with`, `ends_with`, `find`, `split`, `split_whitespace`, `join`, `trim`, `trim_start`, `trim_end`, `lower`, `upper`
+  - constants: `pi`, `e`, `true`, `false`, `nil`
 
 ## REPL commands
 
@@ -77,13 +54,11 @@ add(x, y) =
 - `:env`
 - `:quit`
 
-## Not implemented yet
+## Not implemented (current)
 
-- lambdas
-- lists/maps/destructuring beyond tuple parameter matching
-- pipelines
-- modules/imports
-- member access / indexing
-- full standard library
+- map/dict literals and map patterns
+- module/import system
+- member access and indexing syntax
+- a language-level scheduler (concurrency is host-thread based)
+- general pipeline operator syntax
 
-This is a prototype to validate the language model and syntax decisions, not a finished implementation.

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -1,298 +1,96 @@
-# Genia — Compiler & Language Invariants (DO NOT BREAK)
+# Genia — Compiler & Language Invariants (Current)
 
-> This document defines **non-negotiable invariants** for the Genia language.
->
-> Audience:
->
-> * AI agents (Codex, ChatGPT)
-> * Parser / compiler implementers
-> * Contributors modifying syntax or semantics
->
-> If a change violates any rule in this document, it MUST be rejected or redesigned.
+These are implementation invariants that contributors should preserve.
 
----
+## 1) Expression vs case grammar separation
 
-# 1. Core Principle
+- Case syntax (`->`, `?`, `|`) is not a normal infix-expression system.
+- Parser must only parse case arms in explicit case contexts.
 
-Genia prioritizes:
+## 2) Case placement (hard constraint)
 
-> **Clarity over flexibility**
+Case expressions are valid only:
 
-and
+- as full function bodies
+- as the final expression in a block
 
-> **Unambiguous parsing over expressive shortcuts**
+Parser must reject case syntax in subexpressions, call arguments, list elements, and non-final block positions.
 
----
+## 3) One case expression per block
 
-# 2. Expression vs Case Separation (CRITICAL)
+- A block may include zero or more ordinary expressions.
+- If a case expression appears, it must be the final expression.
 
-## RULE 1
+## 4) Full tuple match model
 
-Case expressions are NOT ordinary expressions.
+Pattern matching always targets the full argument tuple.
 
-They exist in a separate grammar layer.
+- `f(x)` still matches a one-item tuple target.
+- Multi-arg functions are tuple-pattern sugar, not a separate mechanism.
 
-## MUST NOT
+## 5) Arrow disambiguation by parse context
 
-* Treat `->` as a general infix operator
-* Allow `|` outside case expressions
-* Allow `?` outside case guard context
+`->` means:
 
-## CONSEQUENCE
+- lambda arrow in expression parsing
+- case arm mapping in case parsing
 
-Parser must:
+Do not resolve this via precedence hacks.
 
-* Detect case context explicitly
-* Never attempt to interpret case syntax inside expression parsing
+## 6) Pattern validity rules
 
----
+Supported patterns:
 
-# 3. Case Expression Placement (HARD RULE)
+- literal
+- variable binding
+- wildcard `_`
+- tuple pattern
+- list pattern with optional rest
 
-## RULE 2
+Required constraints:
 
-Case expressions are ONLY allowed in:
+- list rest pattern (`..name` / `.._`) is valid only in final list-pattern position
+- duplicate names in a pattern require equality at match time
 
-* Function bodies
-* Final position in a block
+## 7) Spread semantics
 
-## MUST NOT
+- list literal spread requires list value at runtime
+- call argument spread requires list value at runtime
+- spreading non-list values must raise `TypeError`
 
-* Appear in subexpressions
-* Appear as function arguments
-* Appear inside lists or maps
-* Appear before other expressions in a block
+## 8) Function resolution invariants
 
-## CONSEQUENCE
+- fixed-arity match is preferred over varargs match
+- varargs ambiguity must raise `TypeError("Ambiguous function resolution")`
 
-Parser MUST reject:
+## 9) Operator model
 
-```
-x + (0 -> 1 | n -> n)
-```
+Implemented operators are limited to:
 
-```
-f(0 -> 1 | n -> n)
-```
+- unary: `-`, `!`
+- binary: `+ - * / % < <= > >= == != && ||`
 
-```
-{
-  0 -> 1 |
-  n -> n
-  log(x)
-}
-```
+No implicit pipeline/member/index operators should be introduced without explicitly updating state/rules docs and tests.
 
----
+## 10) Ref + concurrency runtime guarantees
 
-# 4. Single Case Expression Per Block
+- refs are synchronized host objects
+- process mailbox handling is FIFO per process
+- one handler invocation at a time per process
+- concurrency remains host-backed (threads), not language-scheduled
 
-## RULE 3
+## 11) Error behavior
 
-A block may contain:
+- unmatched function/case dispatch should raise deterministic runtime errors
+- invalid grammar forms should fail during parse with syntax errors
+- type-invalid builtins (e.g., non-list spread) should raise clear `TypeError`
 
-* zero or more ordinary expressions
-* at most ONE case expression
+## 12) Documentation + tests as contract
 
-If present:
+When changing syntax/semantics/runtime behavior, update together:
 
-* it MUST be the final expression
-
----
-
-# 5. Tuple Matching Model (CRITICAL)
-
-## RULE 4
-
-All pattern matching operates on the FULL argument tuple.
-
-Even for:
-
-```
-f(x)
-```
-
-Matching target is:
-
-```
-(x)
-```
-
-## MUST NOT
-
-* Match partial arguments implicitly
-* Introduce alternative matching targets
-
----
-
-# 6. Lambda vs Case Arrow Disambiguation
-
-## RULE 5
-
-`->` has TWO meanings, resolved by context ONLY:
-
-* Expression context → lambda
-* Case context → pattern mapping
-
-## MUST NOT
-
-* Use precedence to resolve ambiguity
-* Allow mixed interpretation in the same parse position
-
-## CONSEQUENCE
-
-Parser must decide BEFORE parsing `->`:
-
-* Are we in expression mode?
-* Or case mode?
-
----
-
-# 7. Block Semantics
-
-## RULE 6
-
-Blocks:
-
-* Are NOT indentation-sensitive
-* Use newlines as expression separators
-* Return the last expression
-
-## MUST NOT
-
-* Use indentation for structure
-* Require semicolons
-
----
-
-# 8. Operator Simplicity
-
-## RULE 7
-
-Operators must remain simple and predictable.
-
-## MUST NOT
-
-* Introduce new operators that overlap existing meaning
-* Reuse symbols already assigned to case grammar
-
----
-
-# 9. Non-Associative Comparisons
-
-## RULE 8
-
-These are invalid unless explicitly supported later:
-
-```
-a < b < c
-```
-
-```
-a == b == c
-```
-
-Parser must reject them.
-
----
-
-# 10. Minimal Core Guarantee
-
-## RULE 9
-
-The core language must remain minimal.
-
-## MUST NOT
-
-* Add features that duplicate existing capability
-* Add alternate syntax for the same concept
-
----
-
-# 11. No Hidden Semantics
-
-## RULE 10
-
-All behavior must be explicit in syntax.
-
-## MUST NOT
-
-* Introduce implicit conversions that affect control flow
-* Introduce hidden evaluation rules
-
----
-
-# 12. Error Model (v0.1 Constraint)
-
-## RULE 11
-
-Pattern match failure MUST produce a runtime error.
-
-## MUST NOT
-
-* Silently continue
-* Fall through to undefined behavior
-
----
-
-# 13. Grammar Simplicity Constraint
-
-## RULE 12
-
-Grammar must remain:
-
-* Layered (expression vs case)
-* Predictable
-* Small
-
-## MUST NOT
-
-* Merge case grammar into expression grammar
-* Create ambiguous productions
-
----
-
-# 14. AI Interpretability Constraint
-
-## RULE 13
-
-The language must remain easy for LLMs to reason about.
-
-## MUST NOT
-
-* Introduce syntax requiring global inference
-* Introduce context-sensitive ambiguity
-
----
-
-# 15. Feature Acceptance Test
-
-Before accepting any feature, it MUST pass:
-
-1. Does this reduce ambiguity?
-2. Does this simplify parsing?
-3. Does this preserve grammar separation?
-4. Can this be expressed via composition instead?
-
-If ANY answer is "no" → reject or redesign
-
----
-
-# 16. Parser Enforcement Requirements
-
-The parser MUST:
-
-* Reject invalid case placement
-* Reject ambiguous constructs
-* Enforce tuple matching rules
-* Distinguish lambda vs case early
-
----
-
-# 17. Final Principle
-
-> If a feature makes the language harder to explain in one paragraph, it does not belong in the core.
-
----
-
-# END
+- `GENIA_STATE.md`
+- `GENIA_RULES.md`
+- `GENIA_REPL_README.md`
+- `README.md` for user-visible behavior
+- corresponding tests under `tests/`

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1,375 +1,134 @@
 # Genia — Current Language State (Main Branch)
 
-> This document defines the **actual, enforced, and intended behavior** of Genia as it exists on the main branch.
->
-> Audience:
->
-> * AI agents (Codex, ChatGPT)
-> * Language implementers
-> * Contributors modifying parser, runtime, or syntax
->
-> This is the **ground truth**, not a wishlist.
+This file describes what is **actually implemented now** in the Python runtime.
 
----
+## 1) Execution model
 
-# 1. Language Identity
+- programs are expression sequences
+- top-level assignment is supported (`name = expr`)
+- blocks evaluate expressions in order and return the last value
+- no statement/declaration split at runtime level
 
-Genia is a:
+## 2) Implemented syntax and expression forms
 
-* Functional-first language
-* Expression-oriented language (everything evaluates to a value)
-* Runtime-typed language
-* Non-whitespace-sensitive language
-* Minimal-core, composition-first language
+- literals: number, string, boolean, `nil`
+- variables
+- function calls
+- unary operators: `-`, `!`
+- binary operators: `+ - * / % < <= > >= == != && ||`
+- block expressions: `{ ... }`
+- list literals: `[a, b, c]`
+- list spread in literals: `[..xs]`, `[1, ..xs, 2]`
+- call spread: `f(..xs)`
+- lambdas: `(x) -> x + 1`
+- varargs lambdas: `(..xs) -> xs`, `(a, ..rest) -> rest`
 
-Design priority:
+## 3) Functions and dispatch
 
-> Reduce ambiguity for both humans and AI while keeping the implementation small.
+- named functions are first-class values
+- multiple definitions by arity shape are allowed
+- varargs named functions are supported (`f(a, ..rest) = ...`)
+- resolution behavior:
+  - exact fixed arity beats varargs
+  - if multiple varargs candidates match and neither is more specific, runtime raises `TypeError("Ambiguous function resolution")`
 
----
+## 4) Case expressions and pattern matching
 
-# 2. Execution Model
+Case arms support:
 
-* Programs are evaluated as expressions
-* There are **no statements**
-* Every construct returns a value
-* Blocks evaluate sequentially and return the last expression
-
----
-
-# 3. Function Model
-
-## 3.1 Function Definitions
-
-### Expression body
-
-```
-inc(x) = x + 1
-```
-
-### Case body
-
-```
-fact(n) =
-  0 -> 1 |
-  n -> n * fact(n - 1)
-```
-
-### Block body
-
-```
-fact(n) {
-  log(n)
-  0 -> 1 |
-  n -> n * fact(n - 1)
-}
-```
-
----
-
-## 3.2 Tuple Semantics (Critical)
-
-All function arguments are treated as a **single tuple**.
-
-```
-f(x, y)
-```
-
-is equivalent to:
-
-```
-f((x, y))
-```
-
-Implications:
-
-* Pattern matching always targets the full argument tuple
-* Multi-argument functions are syntactic sugar
-
----
-
-# 4. Pattern Matching
-
-## 4.1 Case Structure
-
-Each case:
-
-```
+```genia
 pattern -> result
 pattern ? guard -> result
 ```
 
-Cases are separated by:
+Implemented pattern types:
 
-```
-|
-```
+- literal patterns
+- variable binding
+- wildcard `_`
+- tuple patterns
+- list patterns
+- rest pattern `..name` / `.._` (list patterns only; final position only)
+- duplicate binding semantics (same name must match equal value)
 
----
+Case placement rules (enforced):
 
-## 4.2 Evaluation Rules
+- allowed in function body
+- allowed as final expression in block
+- rejected in ordinary subexpressions / call args / non-final block positions
 
-* Cases are evaluated top-to-bottom
-* Pattern must match first
-* Guard (if present) must evaluate to true
-* First matching case is selected
+## 5) Builtins (runtime)
 
----
+### Core I/O and utilities
 
-## 4.3 Examples
+- `log`, `print`, `input`, `stdin`, `help`
+- constants in global env: `pi`, `e`, `true`, `false`, `nil`
 
-### Simple
+### Refs
 
-```
-fact(n) =
-  n ? n <= 1 -> 1 |
-  n -> n * fact(n - 1)
-```
+- `ref([initial])`
+- `ref_get(ref)`
+- `ref_set(ref, value)`
+- `ref_is_set(ref)`
+- `ref_update(ref, updater)`
 
-### Tuple matching
+Behavior: refs are synchronized host objects; `ref_get` / `ref_update` block until value is set when created via `ref()`.
 
-```
-add(x, y) =
-  (0, y) -> y |
-  (x, 0) -> x |
-  (x, y) -> x + y
-```
+### Host-backed concurrency
 
-### List destructuring
+- `spawn(handler)`
+- `send(process, message)`
+- `process_alive?(process)`
 
-```
-sum(list) =
-  [] -> 0 |
-  [head, ...tail] -> head + sum(tail)
-```
+Behavior:
 
----
+- each process has FIFO mailbox
+- one handler invocation at a time per process
+- implemented with host threads
 
-# 5. Case Expression Placement (Strict)
+### String builtins
 
-Case expressions are **NOT general expressions**.
+- `byte_length`, `is_empty`, `concat`
+- `contains`, `starts_with`, `ends_with`, `find`
+- `split`, `split_whitespace`, `join`
+- `trim`, `trim_start`, `trim_end`
+- `lower`, `upper`
 
-They are ONLY allowed in:
+## 6) Autoloaded stdlib
 
-* Function bodies
-* Final expression of a block
+Autoload is keyed by `(name, arity)` and currently registers functions from:
 
-They are NOT allowed in:
+- `std/prelude/list.genia`
+- `std/prelude/fn.genia`
+- `std/prelude/math.genia`
+- `std/prelude/awk.genia`
+- `std/prelude/agent.genia`
 
-* Subexpressions
-* Function arguments
-* Lists or maps
-* Mid-block positions
+Notable autoloaded functions include:
 
----
+- list: `list`, `first`, `rest`, `empty?`, `nil?`, `append`, `length`, `reverse`, `reduce`, `count`, `any?`, `nth`, `take`, `drop`
+- fn: `apply`, `compose`
+- math: `inc`, `dec`, `mod`, `abs`, `min`, `max`, `sum`
+- awk: `awkify`, `awk_filter`, `awk_map`, `awk_count`, `fields`
+- agent: `agent`, `agent_send`, `agent_get`, `agent_state`, `agent_alive?`
 
-# 6. Expression Model
+## 7) Optimization behavior
 
-## 6.1 Ordinary Expressions
+Implemented optimizations:
 
-Include:
+- self tail-call elimination via trampoline for tail-position calls
+- specialized nth-style list traversal rewrite to `IrListTraversalLoop` for a narrow recognized recursion shape
 
-* Literals
-* Identifiers
-* Function calls
-* Arithmetic
-* Comparisons
-* Logical operations
-* Pipelines
-* Lambdas
-* Blocks
+## 8) Debug/runtime tooling
 
----
+- parser/IR nodes carry source spans (filename + line/column ranges)
+- `run_debug_stdio(...)` exposes debugger protocol endpoints used by the VS Code extension
 
-## 6.2 Case Expressions
+## 9) Explicitly not implemented (current)
 
-Separate grammar system.
-
-Symbols reserved for case grammar:
-
-* `->` (pattern mapping)
-* `?` (guard)
-* `|` (case separator)
-
-These do NOT participate in normal operator precedence.
-
----
-
-# 7. Operator Precedence (Ordinary Expressions)
-
-From highest → lowest:
-
-1. grouping (), literals, identifiers
-2. function calls, indexing, member access
-3. unary (-, !)
-4. *, /, %
-5. +, -
-6. comparisons (<, <=, >, >=)
-7. equality (==, !=)
-8. logical AND (&&)
-9. logical OR
-10. pipeline
-
-Constraints:
-
-* Comparisons are non-associative
-* Equality is non-associative
-
----
-
-# 8. Lambda Semantics
-
-Lambda form:
-
-```
-(x) -> x + 1
-```
-
-Important:
-
-* Uses the same `->` symbol as case expressions
-* Meaning is determined by context:
-
-  * expression context → lambda
-  * case context → pattern mapping
-
----
-
-# 9. Blocks
-
-```
-{
-  expr1
-  expr2
-  expr3
-}
-```
-
-Rules:
-
-* Expressions are separated by newlines
-* Indentation is irrelevant
-* Last expression is returned
-
-Constraints:
-
-* At most one case expression per block
-* If present, it must be the final expression
-
----
-
-# 10. Data Types
-
-Core runtime types:
-
-* Number
-* String
-* Boolean
-* Nil
-* List
-* Map
-* Function
-
----
-
-# 11. Data Processing Model
-
-Unified sequence abstraction.
-
-Core operations:
-
-* map
-* filter
-* reduce
-* take
-
-Example:
-
-```
-[1,2,3] |> map(x -> x * 2)
-```
-
----
-
-# 12. I/O Model
-
-* stdin
-* stdout
-* stderr
-
-Logging:
-
-```
-log("message")
-```
-
----
-
-# 13. Error Model (v0.1)
-
-* Pattern match failure → runtime error
-* No exception system in core
-
----
-
-# 14. Structural Constraints (Non-Negotiable)
-
-These must be preserved:
-
-* Case expressions are NOT general expressions
-* Pattern matching always targets full tuple
-* No indentation-based parsing
-* Minimal syntax is preferred over flexibility
-* One clear way to express each concept
-
----
-
-# 15. Known Gaps (Current State)
-
-The following areas are incomplete or evolving:
-
-* Standard library
-* Module system
-* Error handling model
-* AWK-like streaming mode
-* Optimization / IR layer
-* Compiler backend
-
----
-
-# 16. Design Philosophy (Enforcement Rules)
-
-All new features must:
-
-1. Reduce ambiguity
-2. Keep grammar simple
-3. Avoid overlapping concepts
-4. Preserve separation of expression types
-5. Favor composition over special cases
-
----
-
-# 17. Mental Model for AI
-
-Genia is best understood as:
-
-* A pattern-matching function engine
-* With expression evaluation
-* And strict placement rules for control flow
-
----
-
-# 18. Modification Checklist (For AI + Contributors)
-
-Before implementing a change:
-
-* Does this introduce parsing ambiguity?
-* Does it blur case vs expression boundaries?
-* Does it duplicate an existing mechanism?
-* Can it be expressed via composition instead?
-
-If YES → redesign
-
----
-
-# END
+- map literals / map patterns
+- module/import syntax
+- member access syntax
+- index syntax
+- general pipeline operator syntax
+- language-level scheduler/selective receive/timeouts (concurrency remains host-primitive based)

--- a/README.md
+++ b/README.md
@@ -1,376 +1,144 @@
 # Genia
 
-Genia is a small, expressive, functional-first programming language designed to be:
+Genia is a small, functional-first, expression-oriented language prototype.
 
-* Simple to implement
-* Easy to read and write
-* Composable at every level
-* Immediately useful for scripting and data transformation
+This repository currently provides:
 
-Genia emphasizes a minimal core with powerful composition. Most functionality—including the standard library—is written in Genia itself.
+- a parser + evaluator (`src/genia/interpreter.py`)
+- a REPL and file runner (`python3 -m genia.interpreter`)
+- host-backed concurrency primitives (`spawn`, `send`, `process_alive?`)
+- refs (`ref`, `ref_get`, `ref_set`, `ref_update`)
+- autoloaded prelude libraries (lists, math helpers, awk helpers, fn helpers, agents)
+- debug-stdio adapter support for editor integration
 
----
+## Quick start
 
-## ✨ Core Ideas
-
-* **Expression-oriented** — everything returns a value
-* **Functional-first** — functions are the primary building block
-* **Minimal syntax** — few rules, consistently applied
-* **Pattern matching** — replaces most conditional logic
-* **Composable by design** — small pieces combine naturally
-
----
-
-## 🚀 Quick Example
-
-```genia
-fact(n) =
-  0 -> 1 |
-  n -> n * fact(n - 1)
-
-fact(5)
+```bash
+python3 -m genia.interpreter
 ```
 
----
+Run a program:
 
-## 🧠 Language Overview
+```bash
+python3 -m genia.interpreter path/to/program.genia
+```
 
-### Values
+Run tests:
 
-Genia supports a small set of core types:
+```bash
+pytest -q
+```
 
-* Number
-* String
-* Boolean (`true`, `false`)
-* Nil (`nil`)
-* List
-* Function
+## Language snapshot (implemented)
 
----
+### Core values
 
-### Functions
+- Number
+- String (UTF-8 safe helpers available through builtins)
+- Boolean (`true`, `false`)
+- Nil (`nil`)
+- List
+- Function
+- Host-backed reference (`ref`)
+- Host-backed process handle (`spawn`)
 
-Functions are first-class and defined using `=`:
+### Functions and lambdas
 
 ```genia
 square(x) = x * x
-square(5)
+inc = (x) -> x + 1
+list = (..xs) -> xs
 ```
 
-Functions are **dispatched by name and arity**:
+- functions are dispatched by name + arity shape (fixed arity preferred over varargs)
+- varargs supported in named functions and lambdas via `..rest`
+- closures are supported
+
+### Pattern matching
 
 ```genia
-f(x) = x
-f(x, y) = x + y
+head(xs) =
+  [x, .._] -> x
 ```
 
----
+Supported pattern forms:
 
-### Lambdas
+- literals (`0`, `"ok"`, `true`, `nil`)
+- variable bindings
+- wildcard `_`
+- tuple patterns (`(a, b)`)
+- list patterns (`[x, ..rest]`)
+- guards (`pattern ? condition -> result`)
+- duplicate bindings (`[x, x]` only matches equal values)
 
-Anonymous functions:
+### Case placement rules
+
+Case expressions are valid only:
+
+- as a function body
+- as the final expression in a block
+
+### Lists and spread
 
 ```genia
-(x) -> x + 1
-(x, y) -> x + y
+[1, ..[2, 3], 4]
+add(..[20, 22])
 ```
 
-Lambdas:
+- list literal spread is implemented
+- function call argument spread is implemented
 
-* are ordinary expressions
-* can appear anywhere
-* capture surrounding variables (closures)
-
----
-
-### Pattern Matching
-
-Pattern matching is central to control flow:
+### Concurrency and agents
 
 ```genia
-len(xs) =
-  [] -> 0 |
-  [_, ..rest] -> 1 + len(rest)
-```
-
-Rules:
-
-* patterns match the full argument tuple
-* first matching case wins
-* duplicate bindings must agree
-
-```genia
-[x, x]   # matches only if both elements are equal
-```
-
----
-
-### List Patterns
-
-Lists are first-class:
-
-```genia
-[1, 2, 3]
-```
-
-Pattern destructuring:
-
-```genia
-[x, y]
-[x, ..rest]
-```
-
-Rules:
-
-* `..rest` matches zero or more elements
-* `..rest` must be the final element in the pattern
-
----
-
-### Case Expressions
-
-Case expressions define pattern-based behavior:
-
-```genia
-fact(n) =
-  0 -> 1 |
-  n -> n * fact(n - 1)
-```
-
-They are allowed only:
-
-* as a function body
-* as the final expression in a block
-
-They are **not allowed**:
-
-* as arbitrary subexpressions
-* as function arguments
-* inside list literals
-
----
-
-### Blocks
-
-Blocks group multiple expressions:
-
-```genia
-double(x) {
-  log(x)
-  x * 2
-}
-```
-
-Rules:
-
-* expressions are separated by newlines
-* the last expression is returned
-* a block may end with a case expression
-
----
-
-## ⚙️ Host-backed Concurrency (Minimal)
-
-Genia exposes a tiny process/mailbox substrate through builtins:
-
-* `spawn(handler)` → creates a process handle
-* `send(process, message)` → enqueues a message to that process mailbox
-* `process_alive?(process)` → checks whether the host worker thread is alive
-
-### Semantics
-
-* **Process creation**: `spawn` starts a host-backed worker (Python thread) that runs forever and invokes `handler(msg)` for each received message.
-* **Mailbox ordering**: for a single process, messages are handled in FIFO order (`send(p, a)` then `send(p, b)` means `a` is handled before `b`).
-* **Serial processing per process**: each process handles one message at a time; no concurrent handler execution within the same process.
-* **Host-backed concurrency**: this feature is implemented by the runtime host (not as a pure language-level scheduler).
-
-### Runnable Examples
-
-```genia
-# 1) Basic process + send
-inbox = ref([])
-p = spawn((msg) -> ref_update(inbox, (xs) -> append(xs, [msg])))
-send(p, "a")
-send(p, "b")
-send(p, "c")
-ref_get(inbox)  # eventually ["a", "b", "c"]
-```
-
-```genia
-# 2) Ref used with a process
-total = ref(0)
-acc = spawn((msg) -> ref_update(total, (n) -> n + msg))
-send(acc, 10)
-send(acc, 5)
-ref_get(total)  # eventually 15
-```
-
-```genia
-# 3) Simple counter agent (autoloaded from std/prelude/agent.genia)
 counter = agent(0)
 agent_send(counter, (n) -> n + 1)
-agent_send(counter, (n) -> n + 1)
-agent_get(counter)  # eventually 2
+agent_get(counter)
 ```
 
-```genia
-# 4) Logging/background worker pattern
-append_logged(xs, msg) {
-  log(msg)
-  append(xs, [msg])
-}
+- `spawn(handler)` creates a host-thread worker with FIFO mailbox
+- `send(process, message)` enqueues messages
+- `process_alive?(process)` reports worker liveness
+- prelude provides `agent`, `agent_send`, `agent_get`, `agent_state`, `agent_alive?`
 
-logs = ref([])
-logger = spawn((msg) -> ref_update(logs, (xs) -> append_logged(xs, msg)))
-send(logger, "boot")
-send(logger, "request")
-ref_get(logs)  # eventually ["boot", "request"]
-```
+## Builtins
 
-```genia
-# Observe liveness
-p = spawn((msg) -> msg)
-process_alive?(p)  # true
-```
+### Core
 
----
+- `log`, `print`, `input`, `stdin`, `help`
+- constants: `pi`, `e`, `true`, `false`, `nil`
 
-## 📚 Standard Library (Autoloaded)
+### Refs
 
-Genia’s standard library is written in Genia and loaded on demand.
+- `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
 
-Examples:
+### Strings
 
-```genia
-count([1,2,3,4])  # → 4
-sum([1,2,3,4])    # → 10
-```
+- `byte_length`, `is_empty`, `concat`, `contains`, `starts_with`, `ends_with`
+- `find`, `split`, `split_whitespace`, `join`
+- `trim`, `trim_start`, `trim_end`, `lower`, `upper`
 
-These functions are:
+### Concurrency
 
-* **not loaded at startup**
-* loaded automatically when first used
+- `spawn`, `send`, `process_alive?`
 
-Autoload is keyed by:
+## Autoloaded stdlib highlights
 
-```
-(name, arity)
-```
+- list helpers: `list`, `first`, `rest`, `append`, `length`, `reverse`, `nth`, `take`, `drop`, ...
+- fn helpers: `apply`, `compose`
+- math helpers: `inc`, `dec`, `mod`, `abs`, `min`, `max`, `sum`
+- awk-ish helpers: `awkify`, `awk_filter`, `awk_map`, `awk_count`, `fields`
+- agents: `agent`, `agent_send`, `agent_get`, `agent_state`, `agent_alive?`
 
----
+## Not implemented yet
 
-### Example: reduce
+- map literals/patterns
+- module/import syntax
+- member access / indexing syntax
+- general pipeline operator syntax
 
-```genia
-reduce(f, acc, xs) =
-  (f, acc, []) -> acc |
-  (f, acc, [x, ..rest]) -> reduce(f, f(acc, x), rest)
-```
+For stricter implementation details and invariants, see:
 
----
-
-## 🔁 Evaluation Model
-
-* Functions receive arguments as a tuple
-* Patterns are checked top-to-bottom
-* First match wins
-* Guards (future) will refine matches
-* All constructs return values
-
----
-
-## ⚠️ Current Limitations (v0.2)
-
-Genia intentionally keeps the core small. These are **not yet part of the language**:
-
-* Modules / imports (autoload used instead)
-* Static typing
-* Exceptions
-* Objects / classes
-* Protocols
-* Map/dictionary literals (planned)
-
----
-
-## 🧰 VS Code Extension
-
-A minimal VS Code extension lives at `vscode/genia-debugger` and now includes:
-
-* `.genia` file recognition
-* Syntax highlighting
-* Basic editor language configuration (comments, brackets, indentation)
-* Debugging support via the `genia` launch configuration
-
-To run it in dev mode, see `vscode/genia-debugger/README.md`.
-
----
-
-## 🧪 Running Tests
-
-```bash
-uv run pytest -q
-```
-
----
-
-## 🧱 Project Structure
-
-```text
-src/genia/
-  interpreter.py
-
-tests/
-  test_*.py
-  cases/
-
-std/
-  prelude/
-    list.genia
-    math.genia
-```
-
----
-
-## 🔮 Design Direction
-
-Genia grows by layering:
-
-* A minimal core language
-* A Genia-written standard library
-* Lazy loading via autoload
-* Future modules and tooling
-
-The goal is a language that stays small, but becomes powerful through composition.
-
----
-
-## 🧭 Philosophy
-
-Genia is built on a few core principles:
-
-* Prefer fewer concepts used consistently
-* Make behavior explicit and readable
-* Keep parsing simple and predictable
-* Let the standard library do the heavy lifting
-
----
-## Language Constraints
-
-Before modifying the language:
-
-1. Read GENIA_STATE.md (what exists)
-2. Read GENIA_RULES.md (what is allowed)
-
-Violating GENIA_RULES.md is not permitted.
-
-## 🏁 Summary
-
-Genia is:
-
-* Small
-* Functional
-* Pattern-driven
-* Composable
-* Easy to implement
-
-It achieves power not through complexity, but through a minimal set of well-chosen features.
+- `GENIA_STATE.md`
+- `GENIA_RULES.md`
+- `GENIA_REPL_README.md`


### PR DESCRIPTION
### Motivation

- Bring repository documentation into sync with the actual Python runtime implementation in `src/genia/interpreter.py` so readers see the real behavior rather than a wishlist. 
- Clarify REPL/file runner/debug invocation and enumerate implemented features and builtins to reduce confusion when using or extending the runtime. 
- Consolidate and rephrase rule/invariant documents to emphasize currently enforced invariants and the expected developer contract. 

### Description

- Update `GENIA_REPL_README.md` to document how to run the REPL (`python3 -m genia.interpreter`), run files, use `--debug-stdio`, and list the features actually implemented today (literals, lambdas, spreads, patterns, builtins, etc.).
- Rewrite `GENIA_RULES.md` to a concise, current set of implementation invariants focusing on enforced parser/runtime constraints (case placement, pattern validity, spread semantics, function resolution, operator set, refs/concurrency guarantees, error behavior, and test/docs expectations).
- Revise `GENIA_STATE.md` to be the authoritative snapshot of implemented language behavior, including execution model, supported syntax and patterns, function dispatch rules, builtins, host-backed concurrency/ref semantics, autoloaded stdlib, and explicitly-not-implemented items.
- Simplify `README.md` to surface quick start instructions (`python3 -m genia.interpreter`, `python3 -m genia.interpreter path/to/program.genia`, and `pytest -q`), present the implemented language snapshot, and highlight builtins, refs, and concurrency features.

### Testing

- No automated tests were run as part of this documentation-only change.
- Consumers can verify behavior locally using `pytest -q` and exercising `python3 -m genia.interpreter` as documented.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c964eaa06083299ef26b9d2c1bc1ef)