### PR TITLE
Add Phase 1 host-backed persistent map builtins (opaque GeniaMap)

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -45,6 +45,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - I/O: `log`, `print`, `input`, `stdin`, `help`
   - refs: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
   - concurrency: `spawn`, `send`, `process_alive?`
+  - phase-1 persistent associative maps: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
   - strings: `byte_length`, `is_empty`, `concat`, `contains`, `starts_with`, `ends_with`, `find`, `split`, `split_whitespace`, `join`, `trim`, `trim_start`, `trim_end`, `lower`, `upper`
   - constants: `pi`, `e`, `true`, `false`, `nil`
 
@@ -57,8 +58,8 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 ## Not implemented (current)
 
 - map/dict literals and map patterns
+- general host interop / FFI
 - module/import system
 - member access and indexing syntax
 - a language-level scheduler (concurrency is host-thread based)
 - general pipeline operator syntax
-

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -79,13 +79,21 @@ No implicit pipeline/member/index operators should be introduced without explici
 - one handler invocation at a time per process
 - concurrency remains host-backed (threads), not language-scheduled
 
-## 11) Error behavior
+## 11) Host-backed persistent map bridge invariants
+
+- persistent map support is runtime/builtin only (no syntax added)
+- required builtins: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
+- map values are opaque runtime wrappers, not exposed host objects
+- `map_put` / `map_remove` must return new map values (no mutation of prior values)
+- unsupported map input types and unsupported key types must raise clear `TypeError`
+
+## 12) Error behavior
 
 - unmatched function/case dispatch should raise deterministic runtime errors
 - invalid grammar forms should fail during parse with syntax errors
 - type-invalid builtins (e.g., non-list spread) should raise clear `TypeError`
 
-## 12) Documentation + tests as contract
+## 13) Documentation + tests as contract
 
 When changing syntax/semantics/runtime behavior, update together:
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -86,6 +86,27 @@ Behavior:
 - one handler invocation at a time per process
 - implemented with host threads
 
+### Host-backed persistent associative maps (Phase 1 bridge)
+
+- `map_new()`
+- `map_get(map, key)`
+- `map_put(map, key, value)`
+- `map_has?(map, key)`
+- `map_remove(map, key)`
+- `map_count(map)`
+
+Behavior:
+
+- map values are opaque runtime values (`<map N>`) and do not expose host methods
+- `map_new` returns an empty map
+- `map_put` and `map_remove` are persistent (return a new map, do not mutate input map)
+- `map_get` returns stored value or `nil` when key is missing
+- `map_has?` returns `true`/`false`
+- `map_count` returns entry count
+- list keys are supported by stable structural key-freezing in runtime
+- tuple keys are supported by the same runtime key-freezing strategy (runtime-level interop values)
+- invalid map arguments and unsupported key types raise clear `TypeError`
+
 ### String builtins
 
 - `byte_length`, `is_empty`, `concat`
@@ -127,6 +148,7 @@ Implemented optimizations:
 ## 9) Explicitly not implemented (current)
 
 - map literals / map patterns
+- general host interop / FFI layer
 - module/import syntax
 - member access syntax
 - index syntax

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pytest -q
 - Function
 - Host-backed reference (`ref`)
 - Host-backed process handle (`spawn`)
+- Host-backed persistent associative map (`map_new`, `map_put`, ...)
 
 ### Functions and lambdas
 
@@ -122,6 +123,12 @@ agent_get(counter)
 
 - `spawn`, `send`, `process_alive?`
 
+### Phase 1 persistent associative maps
+
+- `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
+- implemented as an opaque host-backed runtime wrapper (no map syntax added)
+- persistent semantics from Genia perspective (`map_put`/`map_remove` return new map values)
+
 ## Autoloaded stdlib highlights
 
 - list helpers: `list`, `first`, `rest`, `append`, `length`, `reverse`, `nth`, `take`, `drop`, ...
@@ -133,6 +140,7 @@ agent_get(counter)
 ## Not implemented yet
 
 - map literals/patterns
+- general host interop / FFI
 - module/import syntax
 - member access / indexing syntax
 - general pipeline operator syntax

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -1,0 +1,115 @@
+# Chapter 01: Core Data
+
+## What data exists in Genia today?
+
+Genia currently supports these runtime value families:
+
+- numbers
+- strings
+- booleans (`true`, `false`)
+- `nil`
+- lists
+- functions
+- refs (`ref`)
+- process handles (`spawn`)
+- **phase-1 host-backed persistent associative maps** (`map_new`, `map_put`, ...)
+
+This chapter focuses on the map bridge because it is the newest core data capability.
+
+---
+
+## Phase 1 map bridge (what it is)
+
+Genia does **not** have map literals or map patterns yet.
+
+Instead, Genia now exposes a minimal runtime/builtin bridge:
+
+- `map_new()`
+- `map_get(m, key)`
+- `map_put(m, key, value)`
+- `map_has?(m, key)`
+- `map_remove(m, key)`
+- `map_count(m)`
+
+Implementation note: this is a **Phase 1 host-backed opaque map bridge**, not full native map syntax.
+
+---
+
+## Minimal example
+
+```genia
+world0 = map_new()
+world1 = map_put(world0, [10, 12], "food")
+world2 = map_put(world1, [11, 12], "ant")
+print(map_get(world2, [10, 12]))
+```
+
+Expected behavior:
+
+- prints `food`
+- `world0` is still empty
+- `world1` and `world2` are new values
+
+---
+
+## Edge case example
+
+```genia
+m0 = map_new()
+m1 = map_put(m0, [1, 2], "a")
+m2 = map_put(m1, [1, 2], "b")
+[map_count(m1), map_count(m2), map_get(m1, [1, 2]), map_get(m2, [1, 2])]
+```
+
+Expected result:
+
+```genia
+[1, 1, "a", "b"]
+```
+
+This shows persistent update semantics with key replacement.
+
+---
+
+## Failure case example
+
+```genia
+map_put(1, "k", 10)
+```
+
+Expected behavior:
+
+- raises `TypeError` with a clear message because first argument must be a map value.
+
+Another failure case:
+
+```genia
+map_put(map_new(), ref(1), 10)
+```
+
+Expected behavior:
+
+- raises `TypeError` because this phase supports only stable key types.
+
+---
+
+## Implementation status
+
+### ✅ Implemented
+
+- opaque runtime map value wrapper
+- map builtins (`map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`)
+- persistent behavior for `map_put` and `map_remove`
+- missing-key lookup returns `nil`
+
+### ⚠️ Partial
+
+- key support is intentionally minimal and runtime-defined (stable structural strategy for list/tuple-compatible keys and scalar keys)
+
+### ❌ Not implemented
+
+- map literals
+- map pattern matching
+- member/index syntax for maps
+- general host interop / FFI
+

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -1543,6 +1543,52 @@ class GeniaRef:
             return "<ref <unset>>"
 
 
+def _freeze_map_key(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, list):
+        return ("list", tuple(_freeze_map_key(item) for item in value))
+    if isinstance(value, tuple):
+        return ("tuple", tuple(_freeze_map_key(item) for item in value))
+    raise TypeError(f"map key type is not supported: {type(value).__name__}")
+
+
+class GeniaMap:
+    def __init__(self, entries: dict[Any, tuple[Any, Any]] | None = None):
+        self._entries = {} if entries is None else entries
+
+    def get(self, key: Any) -> Any:
+        frozen_key = _freeze_map_key(key)
+        entry = self._entries.get(frozen_key)
+        if entry is None:
+            return None
+        return entry[1]
+
+    def put(self, key: Any, value: Any) -> "GeniaMap":
+        frozen_key = _freeze_map_key(key)
+        next_entries = dict(self._entries)
+        next_entries[frozen_key] = (key, value)
+        return GeniaMap(next_entries)
+
+    def has(self, key: Any) -> bool:
+        frozen_key = _freeze_map_key(key)
+        return frozen_key in self._entries
+
+    def remove(self, key: Any) -> "GeniaMap":
+        frozen_key = _freeze_map_key(key)
+        if frozen_key not in self._entries:
+            return self
+        next_entries = dict(self._entries)
+        del next_entries[frozen_key]
+        return GeniaMap(next_entries)
+
+    def count(self) -> int:
+        return len(self._entries)
+
+    def __repr__(self) -> str:
+        return f"<map {len(self._entries)}>"
+
+
 class GeniaProcess:
     def __init__(self, handler: Callable[[Any], Any]):
         self._handler = handler
@@ -2154,6 +2200,14 @@ Concurrency builtins (host-backed):
   spawn(handler)          create a process with a mailbox
   send(process, message)  enqueue a message for that process
   process_alive?(process) check whether process worker thread is alive
+
+Persistent map builtins (phase 1, host-backed opaque wrapper):
+  map_new()
+  map_get(map, key)
+  map_put(map, key, value)
+  map_has?(map, key)
+  map_remove(map, key)
+  map_count(map)
 """.strip()
         )
 
@@ -2202,6 +2256,36 @@ Concurrency builtins (host-backed):
             raise TypeError("process_alive? expected a process")
         return process.is_alive()
 
+    def _ensure_map(value: Any, name: str) -> GeniaMap:
+        if not isinstance(value, GeniaMap):
+            raise TypeError(f"{name} expected a map as first argument")
+        return value
+
+    def map_new_fn(*args: Any) -> GeniaMap:
+        if len(args) != 0:
+            raise TypeError(f"map_new expected 0 args, got {len(args)}")
+        return GeniaMap()
+
+    def map_get_fn(map_value: Any, key: Any) -> Any:
+        genia_map = _ensure_map(map_value, "map_get")
+        return genia_map.get(key)
+
+    def map_put_fn(map_value: Any, key: Any, value: Any) -> GeniaMap:
+        genia_map = _ensure_map(map_value, "map_put")
+        return genia_map.put(key, value)
+
+    def map_has_fn(map_value: Any, key: Any) -> bool:
+        genia_map = _ensure_map(map_value, "map_has?")
+        return genia_map.has(key)
+
+    def map_remove_fn(map_value: Any, key: Any) -> GeniaMap:
+        genia_map = _ensure_map(map_value, "map_remove")
+        return genia_map.remove(key)
+
+    def map_count_fn(map_value: Any) -> int:
+        genia_map = _ensure_map(map_value, "map_count")
+        return genia_map.count()
+
     env.set("log", log)
     env.set("print", print_fn)
     env.set("input", input_fn)
@@ -2220,6 +2304,12 @@ Concurrency builtins (host-backed):
     env.set("spawn", spawn_fn)
     env.set("send", send_fn)
     env.set("process_alive?", process_alive_fn)
+    env.set("map_new", map_new_fn)
+    env.set("map_get", map_get_fn)
+    env.set("map_put", map_put_fn)
+    env.set("map_has?", map_has_fn)
+    env.set("map_remove", map_remove_fn)
+    env.set("map_count", map_count_fn)
     env.set("byte_length", byte_length_fn)
     env.set("is_empty", is_empty_fn)
     env.set("concat", concat_fn)

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,0 +1,90 @@
+import pytest
+
+
+def test_map_new_creates_empty_map(run):
+    assert run("map_count(map_new())") == 0
+
+
+def test_map_get_missing_returns_nil(run):
+    assert run('map_get(map_new(), "missing")') is None
+
+
+def test_map_put_returns_new_map_without_mutating_original(run):
+    src = '''
+    m0 = map_new()
+    m1 = map_put(m0, "k", 10)
+    [map_count(m0), map_count(m1), map_get(m0, "k"), map_get(m1, "k")]
+    '''
+    assert run(src) == [0, 1, None, 10]
+
+
+def test_map_remove_returns_new_map_without_mutating_original(run):
+    src = '''
+    m0 = map_put(map_new(), "k", 10)
+    m1 = map_remove(m0, "k")
+    [map_has?(m0, "k"), map_has?(m1, "k"), map_count(m0), map_count(m1)]
+    '''
+    assert run(src) == [True, False, 1, 0]
+
+
+def test_map_has_works_for_present_and_absent_keys(run):
+    src = '''
+    m = map_put(map_new(), "present", 1)
+    [map_has?(m, "present"), map_has?(m, "absent")]
+    '''
+    assert run(src) == [True, False]
+
+
+def test_map_count_tracks_entries(run):
+    src = '''
+    m0 = map_new()
+    m1 = map_put(m0, "a", 1)
+    m2 = map_put(m1, "b", 2)
+    m3 = map_put(m2, "a", 3)
+    [map_count(m0), map_count(m1), map_count(m2), map_count(m3)]
+    '''
+    assert run(src) == [0, 1, 2, 2]
+
+
+def test_map_list_and_tuple_keys_follow_stable_value_semantics(run):
+    src = '''
+    m0 = map_new()
+    m1 = map_put(m0, [1, 2], "list")
+    [map_get(m1, [1, 2]), map_has?(m1, [1, 2]), map_has?(m1, [2, 1])]
+    '''
+    assert run(src) == ["list", True, False]
+
+
+def test_map_tuple_keys_runtime_behavior():
+    from genia import make_global_env, run_source
+
+    env = make_global_env([])
+    map_value = run_source("map_new()", env)
+    env.set("m", map_value)
+    env.set("k", ("tuple", 1))
+    run_source('m2 = map_put(m, k, "value")', env)
+    assert run_source("map_get(m2, k)", env) == "value"
+    assert run_source("map_has?(m2, k)", env) is True
+
+
+def test_map_invalid_types_raise_clear_type_errors(run):
+    with pytest.raises(TypeError, match="map_get expected a map as first argument"):
+        run('map_get(1, "k")')
+
+    with pytest.raises(TypeError, match="map_put expected a map as first argument"):
+        run('map_put(1, "k", 2)')
+
+    with pytest.raises(TypeError, match="map_remove expected a map as first argument"):
+        run('map_remove(1, "k")')
+
+    with pytest.raises(TypeError, match="map_has\\? expected a map as first argument"):
+        run('map_has?(1, "k")')
+
+    with pytest.raises(TypeError, match="map_count expected a map as first argument"):
+        run("map_count(1)")
+
+    with pytest.raises(TypeError, match="map key type is not supported"):
+        run("map_put(map_new(), ref(1), 2)")
+
+    with pytest.raises(TypeError, match="map_new expected 0 args, got 1"):
+        run("map_new(1)")


### PR DESCRIPTION
### Motivation
- Provide a small, pragmatic Phase 1 bridge so Genia programs can use persistent associative collections without adding new syntax or a general host-FFI layer. 
- Keep maps opaque to Genia code and ensure persistent (immutable-from-Genia) semantics for updates so future native-map or host-backed interop can replace the backend cleanly. 

### Description
- Added a runtime opaque wrapper `GeniaMap` and a key-freezing helper `_freeze_map_key` to implement stable structural keys for scalars, lists, and tuples. 
- Exposed the required builtin API in the global environment: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, and `map_count`, each raising clear `TypeError` on invalid arguments. 
- Implemented persistent semantics so `map_put` and `map_remove` return new `GeniaMap` instances and do not mutate the original map, and `map_get` returns `nil` when a key is absent. 
- Synchronized docs and examples by updating `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and adding `docs/book/01-core-data.md`, and added focused tests in `tests/test_maps.py`. 

### Testing
- Added `tests/test_maps.py` which validates empty map creation, missing-key lookup (`nil`), persistent `put`/`remove` semantics, `has?`/`count`, list/tuple key behavior, and `TypeError` behavior for invalid usage. 
- Ran `pytest -q tests/test_maps.py` which passed (`9 passed`). 
- Ran the full test suite with `pytest -q` which passed (`193 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c96cda78fc8329bed27a5dbb3d0563)