### PR TITLE
Add Phase 2 simulation primitives: rand, rand_int, and sleep

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -46,6 +46,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - refs: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
   - concurrency: `spawn`, `send`, `process_alive?`
   - phase-1 persistent associative maps: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
+  - simulation primitives (phase 2): `rand`, `rand_int`, `sleep`
   - strings: `byte_length`, `is_empty`, `concat`, `contains`, `starts_with`, `ends_with`, `find`, `split`, `split_whitespace`, `join`, `trim`, `trim_start`, `trim_end`, `lower`, `upper`
   - constants: `pi`, `e`, `true`, `false`, `nil`
 
@@ -63,3 +64,15 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - member access and indexing syntax
 - a language-level scheduler (concurrency is host-thread based)
 - general pipeline operator syntax
+
+## Simulation primitive semantics
+
+- `rand()` returns a host-RNG float in `[0, 1)`.
+- `rand_int(n)` returns an integer in `[0, n)` and raises:
+  - `TypeError` when `n` is not an integer
+  - `ValueError` when `n <= 0`
+- `sleep(ms)` blocks execution for `ms` milliseconds and raises:
+  - `TypeError` when `ms` is not numeric
+  - `ValueError` when `ms < 0`
+
+These are blocking builtins only; they do not introduce scheduler/async runtime behavior.

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -92,8 +92,16 @@ No implicit pipeline/member/index operators should be introduced without explici
 - unmatched function/case dispatch should raise deterministic runtime errors
 - invalid grammar forms should fail during parse with syntax errors
 - type-invalid builtins (e.g., non-list spread) should raise clear `TypeError`
+- value-invalid builtins should raise clear `ValueError` where appropriate (e.g., `rand_int(0)`, `sleep(-1)`)
 
-## 13) Documentation + tests as contract
+## 13) Simulation primitive builtins (host-backed only)
+
+- supported builtins: `rand`, `rand_int`, `sleep`
+- `rand()` returns a float in `[0, 1)`
+- `rand_int(n)` requires a positive integer `n`, returns integer in `[0, n)`
+- `sleep(ms)` requires a non-negative number and blocks current execution for `ms` milliseconds
+- these are simple runtime builtins only: no scheduler, no async/await, no event loop, no new syntax
+## 14) Documentation + tests as contract
 
 When changing syntax/semantics/runtime behavior, update together:
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -115,6 +115,18 @@ Behavior:
 - `trim`, `trim_start`, `trim_end`
 - `lower`, `upper`
 
+### Simulation primitives (Phase 2, host-backed builtins)
+
+- `rand()`
+- `rand_int(n)`
+- `sleep(ms)`
+
+Behavior:
+
+- `rand()` returns a float in `[0, 1)` using host RNG
+- `rand_int(n)` returns an integer in `[0, n)`; raises clear `TypeError` for non-integer `n` and `ValueError` for `n <= 0`
+- `sleep(ms)` blocks current execution for `ms` milliseconds; raises clear `TypeError` for non-numeric values and `ValueError` for negative values
+
 ## 6) Autoloaded stdlib
 
 Autoload is keyed by `(name, arity)` and currently registers functions from:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository currently provides:
 - a REPL and file runner (`python3 -m genia.interpreter`)
 - host-backed concurrency primitives (`spawn`, `send`, `process_alive?`)
 - refs (`ref`, `ref_get`, `ref_set`, `ref_update`)
+- simulation primitives (`rand`, `rand_int`, `sleep`)
 - autoloaded prelude libraries (lists, math helpers, awk helpers, fn helpers, agents)
 - debug-stdio adapter support for editor integration
 
@@ -122,6 +123,13 @@ agent_get(counter)
 ### Concurrency
 
 - `spawn`, `send`, `process_alive?`
+
+### Simulation primitives (Phase 2)
+
+- `rand()` returns a float in `[0, 1)`
+- `rand_int(n)` returns an integer in `[0, n)` for positive integer `n`
+- `sleep(ms)` blocks for `ms` milliseconds
+- intentionally simple: no scheduler, no async/await, no event loop
 
 ### Phase 1 persistent associative maps
 

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -113,3 +113,94 @@ Expected behavior:
 - member/index syntax for maps
 - general host interop / FFI
 
+---
+
+## Simulation primitives (Phase 2)
+
+Genia includes minimal host-backed simulation builtins:
+
+- `rand()`
+- `rand_int(n)`
+- `sleep(ms)`
+
+These are builtins only. They do **not** add async runtime behavior, a scheduler, or new syntax.
+
+### Random decision example
+
+```genia
+decide rand_int(2) {
+  0 -> print("left")
+  1 -> print("right")
+}
+```
+
+Expected behavior:
+
+- one branch is selected using random integer output in `[0, 2)`
+
+### Simple loop with sleep
+
+```genia
+step(n) =
+  n ? n <= 0 -> "done" |
+  _ -> {
+    print(rand())
+    sleep(5)
+    step(n - 1)
+  }
+```
+
+Expected behavior:
+
+- prints a random float each step
+- blocks briefly each iteration
+- remains single-threaded from language perspective
+
+### Edge case example
+
+```genia
+rand_int(1)
+```
+
+Expected behavior:
+
+- always returns `0`
+
+### Failure case examples
+
+```genia
+rand_int(0)
+```
+
+Expected behavior:
+
+- raises `ValueError` (`n` must be `> 0`)
+
+And:
+
+```genia
+sleep("10")
+```
+
+Expected behavior:
+
+- raises `TypeError` (`ms` must be numeric)
+
+### Implementation status
+
+### ✅ Implemented
+
+- `rand()` returns float in `[0, 1)`
+- `rand_int(n)` validates integer and positive bound, returns integer in `[0, n)`
+- `sleep(ms)` validates non-negative numeric argument and blocks for milliseconds
+
+### ⚠️ Partial
+
+- randomness is host-RNG quality, not seed-controlled by language-level API
+- sleep granularity depends on host scheduler/timer resolution
+
+### ❌ Not implemented
+
+- scheduler/event loop primitives
+- async/await syntax
+- deterministic RNG seeding controls

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -38,6 +38,8 @@ import math
 import os
 import bisect
 import queue
+import random
+import time
 from pathlib import Path
 import argparse
 import re
@@ -2208,6 +2210,11 @@ Persistent map builtins (phase 1, host-backed opaque wrapper):
   map_has?(map, key)
   map_remove(map, key)
   map_count(map)
+
+Simulation primitives (host-backed builtins):
+  rand()                float in [0, 1)
+  rand_int(n)           integer in [0, n), n must be a positive integer
+  sleep(ms)             block for ms milliseconds
 """.strip()
         )
 
@@ -2286,6 +2293,26 @@ Persistent map builtins (phase 1, host-backed opaque wrapper):
         genia_map = _ensure_map(map_value, "map_count")
         return genia_map.count()
 
+    def rand_fn(*args: Any) -> float:
+        if len(args) != 0:
+            raise TypeError(f"rand expected 0 args, got {len(args)}")
+        return random.random()
+
+    def rand_int_fn(n: Any) -> int:
+        if not isinstance(n, int) or isinstance(n, bool):
+            raise TypeError("rand_int expected a positive integer")
+        if n <= 0:
+            raise ValueError("rand_int expected n > 0")
+        return random.randrange(n)
+
+    def sleep_fn(ms: Any) -> None:
+        if not isinstance(ms, (int, float)) or isinstance(ms, bool):
+            raise TypeError("sleep expected a non-negative number")
+        if ms < 0:
+            raise ValueError("sleep expected ms >= 0")
+        time.sleep(ms / 1000.0)
+        return None
+
     env.set("log", log)
     env.set("print", print_fn)
     env.set("input", input_fn)
@@ -2310,6 +2337,9 @@ Persistent map builtins (phase 1, host-backed opaque wrapper):
     env.set("map_has?", map_has_fn)
     env.set("map_remove", map_remove_fn)
     env.set("map_count", map_count_fn)
+    env.set("rand", rand_fn)
+    env.set("rand_int", rand_int_fn)
+    env.set("sleep", sleep_fn)
     env.set("byte_length", byte_length_fn)
     env.set("is_empty", is_empty_fn)
     env.set("concat", concat_fn)

--- a/tests/test_simulation_primitives.py
+++ b/tests/test_simulation_primitives.py
@@ -1,0 +1,46 @@
+import time
+
+import pytest
+
+
+def test_rand_values_are_in_unit_interval(run):
+    samples = [run("rand()") for _ in range(64)]
+    assert all(isinstance(x, float) for x in samples)
+    assert all(0.0 <= x < 1.0 for x in samples)
+
+
+def test_rand_multiple_calls_are_not_constant(run):
+    samples = [run("rand()") for _ in range(64)]
+    assert len(set(samples)) > 1
+
+
+def test_rand_int_values_within_bounds_and_not_constant(run):
+    n = 7
+    samples = [run(f"rand_int({n})") for _ in range(128)]
+    assert all(isinstance(x, int) for x in samples)
+    assert all(0 <= x < n for x in samples)
+    assert len(set(samples)) > 1
+
+
+def test_rand_int_rejects_non_integer_and_non_positive_inputs(run):
+    with pytest.raises(TypeError, match="rand_int expected a positive integer"):
+        run("rand_int(3.5)")
+    with pytest.raises(ValueError, match="rand_int expected n > 0"):
+        run("rand_int(0)")
+    with pytest.raises(ValueError, match="rand_int expected n > 0"):
+        run("rand_int(-1)")
+
+
+def test_sleep_accepts_small_values_and_returns_nil(run):
+    started = time.perf_counter()
+    result = run("sleep(5)")
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    assert result is None
+    assert elapsed_ms >= 1.0
+
+
+def test_sleep_rejects_negative_and_non_numeric_values(run):
+    with pytest.raises(ValueError, match="sleep expected ms >= 0"):
+        run("sleep(-1)")
+    with pytest.raises(TypeError, match="sleep expected a non-negative number"):
+        run('sleep("1")')


### PR DESCRIPTION
### Motivation

- Provide minimal randomness and blocking-timing primitives to enable simple simulations without adding a scheduler, async/await, or any new syntax.
- Keep behavior as host-backed builtins consistent with existing runtime error handling and the project’s documentation-driven workflow.

### Description

- Add host imports `random` and `time` and implement three builtins in the interpreter: `rand()` (float in `[0,1)`), `rand_int(n)` (integer in `[0,n)` with integer/positive validation), and `sleep(ms)` (blocks for `ms` milliseconds with numeric/non-negative validation).
- Wire the builtins into the global environment and REPL help text, preserving blocking single-threaded semantics (no scheduler or async changes).
- Update authoritative docs: `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and add a new "Simulation primitives (Phase 2)" section in `docs/book/01-core-data.md` with examples and failure cases.
- Add tests `tests/test_simulation_primitives.py` covering value ranges, non-constant sanity checks, and invalid-argument behavior for the new builtins.

### Testing

- Ran `pytest -q tests/test_simulation_primitives.py tests/test_basic.py tests/test_maps.py` and observed the selected suites passed.
- Ran the full test suite with `pytest -q` and observed `199 passed`.
- New tests assert correct ranges and types for `rand()` and `rand_int(n)`, error handling for invalid inputs, and that `sleep(ms)` accepts small positive values and rejects invalid inputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c971fbb0808329a2aaa07bd081b43e)