### PR TITLE
Add minimal ants-style simulation demo with tests and synchronized docs

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -259,6 +259,21 @@ Result (after mailbox drains):
 15
 ```
 
+---
+
+# 9. Ants-Style Simulation (Minimal, Text Mode)
+
+See `examples/ants.genia` for the full runnable demo.
+
+Characteristics:
+
+- single-ant first
+- wrapped 2D grid
+- world stored in host-backed persistent map keyed by `[x, y]`
+- stochastic movement via `rand_int(4)`
+- recursive stepping with `sleep(ms)` pacing
+- plain text rendering only
+
 ## 8.3 Simple Counter Agent
 
 ```genia

--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -16,6 +16,12 @@ Run a program file:
 python3 -m genia.interpreter path/to/file.genia
 ```
 
+Run the ants demo:
+
+```bash
+python3 -m genia.interpreter examples/ants.genia
+```
+
 Run in stdio debug-adapter mode:
 
 ```bash
@@ -76,3 +82,10 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - `ValueError` when `ms < 0`
 
 These are blocking builtins only; they do not introduce scheduler/async runtime behavior.
+
+## Demo note: ants simulation example
+
+- `examples/ants.genia` is the first in-repo stochastic grid simulation demo.
+- It is text-only, single-ant, recursive, and finite-step.
+- It uses builtins only (`map_*`, `rand_int`, `sleep`, `print`) with no new syntax.
+- It is not actor-based and does not provide a scheduler/event loop abstraction.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -166,3 +166,18 @@ Implemented optimizations:
 - index syntax
 - general pipeline operator syntax
 - language-level scheduler/selective receive/timeouts (concurrency remains host-primitive based)
+
+## 10) Example demos shipped in-repo
+
+- `examples/tic-tac-toe.genia`: interactive text game example
+- `examples/ants.genia`: first minimal ants-style stochastic grid simulation demo
+
+`examples/ants.genia` intentionally uses only currently implemented features:
+
+- host-backed map builtins for persistent world updates
+- `rand_int` for random movement choice
+- recursion for stepping
+- `sleep` for blocking frame delay
+- text rendering via `print`
+
+It is intentionally minimal and single-ant first. It is **not** actor-based, does **not** add a scheduler, and does **not** introduce new language syntax.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository currently provides:
 - simulation primitives (`rand`, `rand_int`, `sleep`)
 - autoloaded prelude libraries (lists, math helpers, awk helpers, fn helpers, agents)
 - debug-stdio adapter support for editor integration
+- runnable demos under `examples/` (including `tic-tac-toe.genia` and `ants.genia`)
 
 ## Quick start
 
@@ -22,6 +23,12 @@ Run a program:
 
 ```bash
 python3 -m genia.interpreter path/to/program.genia
+```
+
+Run the ants demo:
+
+```bash
+python3 -m genia.interpreter examples/ants.genia
 ```
 
 Run tests:
@@ -152,6 +159,7 @@ agent_get(counter)
 - module/import syntax
 - member access / indexing syntax
 - general pipeline operator syntax
+- language-level scheduler/event loop for simulations
 
 For stricter implementation details and invariants, see:
 

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -204,3 +204,82 @@ Expected behavior:
 - scheduler/event loop primitives
 - async/await syntax
 - deterministic RNG seeding controls
+
+---
+
+## First simulation demo: ants (minimal, text mode)
+
+Genia now ships a first working ants-style demo at:
+
+- `examples/ants.genia`
+
+This demo is intentionally minimal and uses only currently implemented builtins and syntax:
+
+- host-backed persistent maps for world state (`map_new`, `map_get`, `map_put`, `map_has?`)
+- random direction selection (`rand_int(4)`)
+- recursive stepping (finite number of steps)
+- blocking frame pacing (`sleep(ms)`)
+- plain text rendering (`print`)
+
+### Minimal example (from the demo)
+
+```genia
+cell_get(world, pos) =
+  (world, pos) ? map_has?(world, pos) -> map_get(world, pos) |
+  (_, _) -> "empty"
+
+step_cell(world, ant_pos, target, target_cell) =
+  (world, ant_pos, target, "ant") -> [world, ant_pos, "blocked"] |
+  (world, ant_pos, target, "food") -> [move_ant(world, ant_pos, target), target, "ate_food"] |
+  (world, ant_pos, target, _) -> [move_ant(world, ant_pos, target), target, "moved"]
+```
+
+This shows the central simulation shape:
+
+- world is a persistent map keyed by `[x, y]`
+- missing cell defaults to `"empty"`
+- each step returns `[next_world, next_ant_pos, event]`
+
+### Edge case example
+
+```genia
+wrap(n, size) =
+  (n, size) ? n < 0 -> size - 1 |
+  (n, size) ? n >= size -> 0 |
+  (n, _) -> n
+```
+
+Expected behavior (demo grid wrapping):
+
+- `wrap(-1, 8)` -> `7`
+- `wrap(8, 8)` -> `0`
+
+### Failure / limitation notes
+
+- The demo is text-mode only (no graphics).
+- The first version is single-ant only.
+- Simulation timing is blocking (`sleep`) and host-dependent.
+- There is still no native map syntax (no map literals, no map patterns).
+- There is still no scheduler/event loop or language-level simulation framework.
+
+### Implementation status for the ants demo
+
+### ✅ Implemented
+
+- runnable finite-step simulation in `examples/ants.genia`
+- random movement + wrapped grid movement
+- persistent map-based world updates
+- default-empty cell lookup via helper function
+- recursive step loop with `sleep` timing
+
+### ⚠️ Partial
+
+- only one ant entity is modeled
+- randomness is non-deterministic host RNG (no seed API)
+- rendering is plain ASCII grid text
+
+### ❌ Not implemented
+
+- actor/scheduler-based simulation runtime
+- native language abstractions for agents, ticks, or worlds
+- native map syntax for simulation state authoring

--- a/examples/ants.genia
+++ b/examples/ants.genia
@@ -1,0 +1,107 @@
+# Minimal ants-style simulation demo (single ant, text mode)
+# Uses only currently implemented builtins and syntax.
+
+width() = 8
+height() = 5
+
+empty_cell() = "empty"
+food_cell() = "food"
+ant_cell() = "ant"
+
+ant_start() = [2, 2]
+
+wrap(n, size) =
+  (n, size) ? n < 0 -> size - 1 |
+  (n, size) ? n >= size -> 0 |
+  (n, _) -> n
+
+pos_add(pos, delta) =
+  ([x, y], [dx, dy]) -> [
+    wrap(x + dx, width()),
+    wrap(y + dy, height())
+  ]
+
+cell_get(world, pos) =
+  (world, pos) ? map_has?(world, pos) -> map_get(world, pos) |
+  (_, _) -> empty_cell()
+
+cell_put(world, pos, value) = map_put(world, pos, value)
+
+cell_char(cell) =
+  "ant" -> "A" |
+  "food" -> "*" |
+  _ -> "."
+
+seed_world() =
+  map_put(
+    map_put(
+      map_put(
+        map_put(map_new(), ant_start(), ant_cell()),
+        [0, 0],
+        food_cell()
+      ),
+      [5, 1],
+      food_cell()
+    ),
+    [7, 4],
+    food_cell()
+  )
+
+move_ant(world, from, to) =
+  cell_put(cell_put(world, from, empty_cell()), to, ant_cell())
+
+dir_from_int(n) =
+  0 -> [1, 0] |
+  1 -> [-1, 0] |
+  2 -> [0, 1] |
+  _ -> [0, -1]
+
+random_dir() = dir_from_int(rand_int(4))
+
+step(world, ant_pos) = step_with_dir(world, ant_pos, random_dir())
+
+step_with_dir(world, ant_pos, dir) =
+  step_target(world, ant_pos, pos_add(ant_pos, dir))
+
+step_target(world, ant_pos, target) =
+  step_cell(world, ant_pos, target, cell_get(world, target))
+
+step_cell(world, ant_pos, target, target_cell) =
+  (world, ant_pos, target, "ant") -> [world, ant_pos, "blocked"] |
+  (world, ant_pos, target, "food") -> [move_ant(world, ant_pos, target), target, "ate_food"] |
+  (world, ant_pos, target, _) -> [move_ant(world, ant_pos, target), target, "moved"]
+
+render_cell(world, pos) =
+  (world, [x, y]) -> cell_char(cell_get(world, [x, y]))
+
+render_row(world, y, x) =
+  (world, y, x) ? x >= width() -> "" |
+  (world, y, x) -> render_cell(world, [x, y]) + render_row(world, y, x + 1)
+
+render_rows(world, y) =
+  (world, y) ? y >= height() -> nil |
+  (world, y) -> {
+    print(render_row(world, y, 0))
+    render_rows(world, y + 1)
+  }
+
+render(world) = render_rows(world, 0)
+
+run_after_step(step_result, steps_left, delay_ms) =
+  ([world2, ant2, event], steps_left, delay_ms) -> {
+    print(event)
+    sleep(delay_ms)
+    run(world2, ant2, steps_left - 1, delay_ms)
+  }
+
+run(world, ant_pos, steps_left, delay_ms) =
+  (_, _, steps_left, _) ? steps_left <= 0 -> "done" |
+  (world, ant_pos, steps_left, delay_ms) -> {
+    print("-----")
+    render(world)
+    run_after_step(step(world, ant_pos), steps_left, delay_ms)
+  }
+
+main() = run(seed_world(), ant_start(), 12, 80)
+
+main()

--- a/tests/test_ants_demo.py
+++ b/tests/test_ants_demo.py
@@ -1,0 +1,76 @@
+ANTS_CORE = """
+width() = 8
+height() = 5
+
+empty_cell() = "empty"
+food_cell() = "food"
+ant_cell() = "ant"
+
+wrap(n, size) =
+  (n, size) ? n < 0 -> size - 1 |
+  (n, size) ? n >= size -> 0 |
+  (n, _) -> n
+
+pos_add(pos, delta) =
+  ([x, y], [dx, dy]) -> [
+    wrap(x + dx, width()),
+    wrap(y + dy, height())
+  ]
+
+cell_get(world, pos) =
+  (world, pos) ? map_has?(world, pos) -> map_get(world, pos) |
+  (_, _) -> empty_cell()
+
+cell_put(world, pos, value) = map_put(world, pos, value)
+
+move_ant(world, from, to) =
+  cell_put(cell_put(world, from, empty_cell()), to, ant_cell())
+
+step_target(world, ant_pos, target) =
+  step_cell(world, ant_pos, target, cell_get(world, target))
+
+step_cell(world, ant_pos, target, target_cell) =
+  (world, ant_pos, target, "ant") -> [world, ant_pos, "blocked"] |
+  (world, ant_pos, target, "food") -> [move_ant(world, ant_pos, target), target, "ate_food"] |
+  (world, ant_pos, target, _) -> [move_ant(world, ant_pos, target), target, "moved"]
+"""
+
+
+def test_ants_wrap_behavior(run):
+    src = ANTS_CORE + "\n[wrap(-1, 8), wrap(8, 8), wrap(3, 8)]"
+    assert run(src) == [7, 0, 3]
+
+
+def test_ants_position_update_with_wrapping(run):
+    src = ANTS_CORE + "\n[pos_add([7, 4], [1, 1]), pos_add([0, 0], [-1, -1])]"
+    assert run(src) == [[0, 0], [7, 4]]
+
+
+def test_ants_move_ant_returns_updated_world(run):
+    src = (
+        ANTS_CORE
+        + '\n'
+        + 'w0 = map_put(map_new(), [1, 1], "ant")\n'
+        + 'w1 = move_ant(w0, [1, 1], [2, 1])\n'
+        + '[cell_get(w0, [1, 1]), cell_get(w1, [1, 1]), cell_get(w1, [2, 1])]'
+    )
+    assert run(src) == ["ant", "empty", "ant"]
+
+
+def test_ants_missing_cell_defaults_to_empty(run):
+    src = ANTS_CORE + '\ncell_get(map_new(), [99, 99])'
+    assert run(src) == "empty"
+
+
+def test_ants_step_target_result_shape_and_event(run):
+    src = (
+        ANTS_CORE
+        + '\n'
+        + 'w0 = map_put(map_new(), [2, 2], "ant")\n'
+        + 'step_target(w0, [2, 2], [3, 2])'
+    )
+    result = run(src)
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert result[1] == [3, 2]
+    assert result[2] == "moved"


### PR DESCRIPTION
### Motivation

- Provide a first, minimal ants-style simulation that demonstrates Genia can run a small stochastic grid using only currently implemented builtins (maps, RNG, sleep, recursion, printing). 
- Keep repository learning materials and authoritative state synchronized with the implementation per the documentation contract. 
- Validate core helper logic with focused, pure-style tests to prove the demo shape without adding new syntax or runtime features.

### Description

- Add `examples/ants.genia`, a runnable single-ant, wrapped 2D grid demo that stores world state in host-backed persistent maps and uses `rand_int`, `sleep`, recursion, and `print` for text rendering. 
- Add `tests/test_ants_demo.py` with focused tests for `wrap`, `pos_add` (wrapping), `move_ant` world updates, missing-cell default behavior, and `step_target` result shape/events. 
- Update authoritative/docs files to reflect the new demo and its constraints: `GENIA_STATE.md`, `GENIA_REPL_README.md`, `README.md`, `docs/book/01-core-data.md`, and `EXAMPLES.md`. 
- The demo and tests strictly use existing language/runtime features and preserve constraints (no new syntax, no map literals/patterns, no scheduler, no `if`, pattern-matching-first style). 

### Testing

- Ran `pytest -q tests/test_ants_demo.py` which passed (`5 passed`).
- Ran `pytest -q tests/test_maps.py tests/test_simulation_primitives.py` to ensure map and primitive behavior remained correct (both suites passed; combined output showed `15 passed`).
- Executed the demo with `PYTHONPATH=src python3 -m genia.interpreter examples/ants.genia`, which ran to completion and printed the finite-step ASCII simulation output (`"done"`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9799d845c832986d88eee36591c8e)