### PR TITLE
Remove decide references and standardize conditionals on pattern matching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,19 +71,18 @@ Agents must:
 
 ---
 
-### 3. “decide” Is the Only Conditional
+### 3. Pattern Matching Is the Only Conditional Model
 
 Allowed:
 
-```
-decide
-```
+* Pattern matching in function definitions / case expressions
 
 Forbidden:
 
 * `if`
 * `switch`
 * ternary operators
+* introducing conditional keywords
 
 ---
 
@@ -132,7 +131,7 @@ Agents must map features → chapters:
 | Data / literals  | 01-core-data        |
 | Pattern matching | 02-pattern-matching |
 | Functions        | 03-functions        |
-| decide           | 04-decide           |
+| Conditionals     | 02-pattern-matching |
 | Lists            | 05-lists            |
 | Recursion        | 06-recursion        |
 | repeat           | 07-repeat           |

--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -45,6 +45,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - duplicate-binding equality semantics (`[x, x]`)
   - guards with `?`
 - case expressions in function bodies and as final expression in a block
+- conditionals expressed only through pattern matching in function definitions/case expressions
 - function resolution with fixed arity + varargs precedence
 - autoloaded stdlib functions keyed by `(name, arity)`
 - builtins:
@@ -70,6 +71,12 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - member access and indexing syntax
 - a language-level scheduler (concurrency is host-thread based)
 - general pipeline operator syntax
+
+## Conditionals in Genia
+
+- Genia does **not** use `if` or `switch`.
+- All branching is expressed through pattern matching.
+- There is no dedicated conditional keyword.
 
 ## Simulation primitive semantics
 

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -110,3 +110,8 @@ When changing syntax/semantics/runtime behavior, update together:
 - `GENIA_REPL_README.md`
 - `README.md` for user-visible behavior
 - corresponding tests under `tests/`
+
+## 15) Conditional model invariant
+
+- Genia has no conditional keyword (`if` or `switch`)
+- branching is expressed only through pattern matching

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -57,6 +57,12 @@ Case placement rules (enforced):
 - allowed as final expression in block
 - rejected in ordinary subexpressions / call args / non-final block positions
 
+### Conditionals
+
+- implemented via pattern matching in function definitions and case expressions
+- no dedicated conditional keyword exists
+- `decide` has been removed from the language
+
 ## 5) Builtins (runtime)
 
 ### Core I/O and utilities

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Supported pattern forms:
 - guards (`pattern ? condition -> result`)
 - duplicate bindings (`[x, x]` only matches equal values)
 
+### Conditionals in Genia
+
+- Genia does **not** use `if` or `switch`
+- all conditional logic is expressed with function-based pattern matching
+- pattern matching is the only branching mechanism
+
 ### Case placement rules
 
 Case expressions are valid only:

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -125,18 +125,19 @@ Genia includes minimal host-backed simulation builtins:
 
 These are builtins only. They do **not** add async runtime behavior, a scheduler, or new syntax.
 
-### Random decision example
+### Random branching example
 
 ```genia
-decide rand_int(2) {
-  0 -> print("left")
+pick_direction(n) =
+  0 -> print("left") |
   1 -> print("right")
-}
+
+pick_direction(rand_int(2))
 ```
 
 Expected behavior:
 
-- one branch is selected using random integer output in `[0, 2)`
+- one pattern branch is selected using random integer output in `[0, 2)`
 
 ### Simple loop with sleep
 

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -2,7 +2,7 @@
 
 ## The Question
 
-How does Genia decide what code to run?
+How does Genia choose which branch runs?
 
 ---
 
@@ -194,17 +194,26 @@ Write `last` using pattern matching and recursion.
 * Ordered evaluation
 * List destructuring (`[x, ..rest]`)
 * Variable binding
+* Pattern guards (`pattern ? guard -> result`)
 
 ### ⚠️ Partial
 
 * Error messages for failed matches may be minimal
-* No advanced pattern guards (if not implemented yet)
 
 ### ❌ Missing
 
 * Exhaustiveness checking
-* Pattern guards (e.g., conditions inside patterns)
 * Match optimizations (decision trees, indexing)
+
+---
+
+## Conditionals in Genia
+
+Genia has no dedicated conditional keyword.
+
+* Genia does **not** use `if` or `switch`
+* All conditional logic is expressed via pattern matching
+* Pattern matching is the only branching mechanism
 
 ---
 
@@ -225,7 +234,7 @@ Source: parser + runtime
 * Pattern clauses supported: YES
 * Ordered evaluation: YES
 * List destructuring: YES
-* Guards: NO
+* Guards: YES
 * Exhaustiveness checking: NO
 
 <!-- GENERATED:pattern-matching-status:end -->

--- a/docs/book/CHAPTER_TEMPLATE.md
+++ b/docs/book/CHAPTER_TEMPLATE.md
@@ -5,7 +5,7 @@
 Start with a concrete, curiosity-driven question.
 
 > Example:
-> How does Genia decide which pattern to match?
+> How does Genia choose which pattern to match?
 
 ---
 

--- a/examples/tic-tac-toe.genia
+++ b/examples/tic-tac-toe.genia
@@ -1,28 +1,56 @@
-# Tic-Tac-Toe in a single Genia file
+# Tic-Tac-Toe in one Genia file (heavily commented for learning).
 #
-# Assumptions for this draft:
-# - Strings, lists, pattern matching, and recursion exist.
-# - print(...) and input(...) are available.
-# - Equality operators work in guards.
-# - `_` in patterns is a wildcard.
-# - "_" as a string is the empty square value.
+# HOW TO READ THIS FILE
+# ---------------------
+# Genia programs are expression-oriented, and this demo leans on four core ideas:
+# 1) values (strings, lists, booleans),
+# 2) pattern matching (function heads and case-like function bodies),
+# 3) guards (`pattern ? condition -> result`),
+# 4) recursion (the game loop is recursive, not an imperative while-loop).
 #
 # This file is written to be as close as possible to the current Genia direction:
 # - branching via pattern matching
 # - no repeat
 # - no nil for empty squares
 # - control flow through pattern matching + guards + recursion
+#
+# This example intentionally stays simple:
+# - board is a list of 9 strings
+# - empty square is represented by "_" (a plain string)
+# - players are "X" and "O"
+# - moves are entered as characters "0" .. "8"
+#
+# Why strings for moves?
+# `input(...)` returns text, so keeping move comparisons as strings makes
+# pattern matching direct and beginner-friendly.
+#
+# Also note:
+# - `_` in a PATTERN means "wildcard, ignore this value"
+# - "_" as a STRING means "the square is empty"
+# These are different things that happen to look similar.
 
+# Helper to keep "empty square value" in one place.
 empty() = "_"
 
+# Create a fresh 3x3 board as a flat list:
+# indexes are:
+# 0 1 2
+# 3 4 5
+# 6 7 8
 newBoard() = ["_", "_", "_", "_", "_", "_", "_", "_", "_"]
 
+# Toggle whose turn it is.
+# This is a tiny two-case pattern match.
 nextPlayer(player) =
   "X" -> "O" |
   "O" -> "X"
 
+# Kept as a tiny indirection so beginners can later customize rendering
+# (for example, map "_" to "." or "·") in one place.
 showSquare(square) = square
 
+# Destructure all 9 squares and print as 3 rows.
+# Pattern matching gives names (`a`..`i`) to each board position.
 printBoard(board) =
   [a, b, c, d, e, f, g, h, i] -> {
     print("")
@@ -32,6 +60,13 @@ printBoard(board) =
     print("")
   }
 
+# `winner(board)` tries each winning pattern in order.
+# If any line of X matches, return "X".
+# If any line of O matches, return "O".
+# Otherwise return "_" to mean "no winner yet".
+#
+# This is a good Genia-style example of "control flow via pattern matching":
+# we do not calculate rows/columns procedurally; we declare winning shapes.
 winner(board) =
   ["X", "X", "X", .._] -> "X" |
   [_,   _,   _,   "X", "X", "X", _,   _,   _] -> "X" |
@@ -57,10 +92,23 @@ winner(board) =
 
   _ -> "_"
 
+# Ask: does the board still have at least one empty square?
+# `any?` comes from stdlib prelude and checks whether predicate is true
+# for any list element.
 containsEmpty?(board) =
   any?((c) -> c == "_", board)
 
-# setAt replaces the board position at index 0..8.
+# `setAt` returns a NEW board with one square replaced.
+# It does not mutate in place.
+#
+# Each case matches:
+# - current board shape,
+# - move as character ('0' .. '8'),
+# - value to place ("X" or "O").
+#
+# Even though the comment says "index", this function is driven by the
+# move text the user typed. Keeping input as text avoids conversion work
+# inside the game loop.
 setAt(board, index, value) =
   ([_, ..squares], '0', value)              -> [value, ..squares] |
   ([a, _, ..squares], '1', value)           -> [a, value, ..squares] |
@@ -72,6 +120,8 @@ setAt(board, index, value) =
   ([a, b, c, d, e, f, g, _, i], '7', value) -> [a, b, c, d, e, f, g, value, i] |
   ([a, b, c, d, e, f, g, h, _], '8', value) -> [a, b, c, d, e, f, g, h, value]
 
+# Convert move text to number for `nth(...)` lookup.
+# Invalid input becomes `nil` (and then legal-move check fails).
 parseMove(s) =
   "0" -> 0 |
   "1" -> 1 |
@@ -84,38 +134,53 @@ parseMove(s) =
   "8" -> 8 |
   _   -> nil
 
-# A move is legal only if the chosen square is currently empty.
+# A move is legal when the chosen board square currently contains "_".
+# If parseMove(move) returns nil, nth(nil, board) won't equal "_",
+# so invalid text is treated as an illegal move.
 isLegalMove(board, move) = nth(parseMove(move), board) == "_"
 
-
+# Prompt user and return typed text.
 readMove(player) {
   input("Player " + player + ", enter a move from 0 to 8:")
 }
 
+# `playTurn` uses a guard:
+# - if move is legal, apply move and recurse to next turn
+# - otherwise fall through to retry path
 playTurn(board, player, move) =
   (b, p, m) ? isLegalMove(b, m) -> play(setAt(b, m, p), nextPlayer(p)) |
   (b, p, _) -> retryTurn(b, p)
 
+# Friendly error path for illegal moves.
 retryTurn(board, player) {
   print("That square is not available. Try again.")
   play(board, player)
 }
 
+# Main recursive game loop:
+# 1) render board
+# 2) compute "winner?" and "any empty squares?"
+# 3) determine whether to finish or ask for next move
 play(board, player) {
   printBoard(board)
   finishOrContinue(board, player, winner(board), containsEmpty?(board))
 }
 
-
+# Terminal-state dispatcher.
+# Note how tuple-style matching lets us ignore values we don't care about
+# in each branch by using `_`.
 finishOrContinue(board, player, whoWon, hasEmpty) =
   (_, _, "X", _) -> print("X wins!") |
   (_, _, "O", _) -> print("O wins!") |
   (_, _, "_", false) -> print("Draw!") |
   (_, _, "_", true) -> promptMove(board, player)
 
+# Split out prompt+playTurn call for readability.
 promptMove(board, player) =
   playTurn(board, player, readMove(player))
 
+# Program entry point.
+# It prints index help text, then starts game with empty board and player X.
 main() {
   print("Tic-Tac-Toe")
   print("Use positions 0 through 8.")

--- a/examples/tic-tac-toe.genia
+++ b/examples/tic-tac-toe.genia
@@ -8,7 +8,7 @@
 # - "_" as a string is the empty square value.
 #
 # This file is written to be as close as possible to the current Genia direction:
-# - no decide
+# - branching via pattern matching
 # - no repeat
 # - no nil for empty squares
 # - control flow through pattern matching + guards + recursion


### PR DESCRIPTION
### Motivation

- Remove the undocumented/unused `decide` construct from the repository content and align documentation with the actual runtime behavior. 
- Emphasize that Genia expresses branching only via pattern matching in function definitions/case expressions to preserve language philosophy and avoid introducing new conditional keywords. 

### Description

- Replaced the `decide` example with a function-based pattern-matching example (e.g., `pick_direction(rand_int(2))`) in `docs/book/01-core-data.md`. 
- Added an explicit "Conditionals in Genia" statement and related wording to `README.md`, `GENIA_REPL_README.md`, `docs/book/02-pattern-matching.md`, and `GENIA_RULES.md` to declare that `if`/`switch`/new conditional keywords are not used and branching is done via pattern matching. 
- Recorded the change in the authoritative state file `GENIA_STATE.md` noting that conditionals are implemented via pattern matching and that `decide` has been removed, and updated contributor guidance and templates in `AGENTS.md` and `docs/book/CHAPTER_TEMPLATE.md` to avoid `decide` framing; also updated `examples/tic-tac-toe.genia` header comment. 
- No parser/grammar or runtime code changes were required because there was no `decide` implementation in the interpreter; changes are documentation-only and keep examples runnable under the current interpreter. 

### Testing

- Ran the test suite with `pytest -q` and received `204 passed` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c97b0cab0c832982092c8043a0ac46)