### PR TITLE
Add reduce-based `map` and `filter` to list prelude and autoload

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -47,6 +47,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - case expressions in function bodies and as final expression in a block
 - function resolution with fixed arity + varargs precedence
 - autoloaded stdlib functions keyed by `(name, arity)`
+  - includes list transforms such as `reduce`, `map`, and `filter`
 - builtins:
   - I/O: `log`, `print`, `input`, `stdin`, `help`
   - refs: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -139,7 +139,7 @@ Autoload is keyed by `(name, arity)` and currently registers functions from:
 
 Notable autoloaded functions include:
 
-- list: `list`, `first`, `rest`, `empty?`, `nil?`, `append`, `length`, `reverse`, `reduce`, `count`, `any?`, `nth`, `take`, `drop`
+- list: `list`, `first`, `rest`, `empty?`, `nil?`, `append`, `length`, `reverse`, `reduce`, `map`, `filter`, `count`, `any?`, `nth`, `take`, `drop`
 - fn: `apply`, `compose`
 - math: `inc`, `dec`, `mod`, `abs`, `min`, `max`, `sum`
 - awk: `awkify`, `awk_filter`, `awk_map`, `awk_count`, `fields`

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ agent_get(counter)
 
 ## Autoloaded stdlib highlights
 
-- list helpers: `list`, `first`, `rest`, `append`, `length`, `reverse`, `nth`, `take`, `drop`, ...
+- list helpers: `list`, `first`, `rest`, `append`, `length`, `reverse`, `reduce`, `map`, `filter`, `nth`, `take`, `drop`, ...
 - fn helpers: `apply`, `compose`
 - math helpers: `inc`, `dec`, `mod`, `abs`, `min`, `max`, `sum`
 - awk-ish helpers: `awkify`, `awk_filter`, `awk_map`, `awk_count`, `fields`

--- a/docs/book/05-lists.md
+++ b/docs/book/05-lists.md
@@ -1,0 +1,90 @@
+# Chapter 05: Lists
+
+## What list helpers are implemented today?
+
+Genia ships a small list-focused stdlib in `std/prelude/list.genia`.
+
+Core helpers include:
+
+- `list`
+- `first`
+- `rest`
+- `empty?`
+- `nil?`
+- `append`
+- `length`
+- `reverse`
+- `reduce`
+- `map`
+- `filter`
+- `count`
+- `any?`
+- `nth`
+- `take`
+- `drop`
+
+---
+
+## `map` and `filter` (reduce-driven)
+
+`map` and `filter` are implemented in stdlib using `reduce` and `reverse`.
+
+This keeps the implementation minimal and takes advantage of existing tail-recursive accumulation behavior already used by `reduce`.
+
+### Minimal example
+
+```genia
+map((x) -> x + 1, [1, 2, 3])
+```
+
+Expected result:
+
+```genia
+[2, 3, 4]
+```
+
+### Edge case example
+
+```genia
+filter((x) -> x % 2 == 0, [1, 2, 3, 4, 5])
+```
+
+Expected result:
+
+```genia
+[2, 4]
+```
+
+Order is preserved in output.
+
+### Failure case example
+
+```genia
+map((x) -> x + 1, 123)
+```
+
+Expected behavior:
+
+- runtime match failure, because `map` delegates to list-pattern-based `reduce` and non-list input cannot match those list cases.
+
+---
+
+## Implementation status
+
+### ✅ Implemented
+
+- list literals and list spread
+- list-pattern matching with rest patterns
+- recursive list helpers in stdlib
+- `reduce`
+- `map` and `filter` as reduce-based stdlib functions
+
+### ⚠️ Partial
+
+- list performance is currently interpreter-level; optimizations are selective and pattern-dependent
+
+### ❌ Not implemented
+
+- lazy sequences
+- iterator protocol
+- built-in map/filter syntax (helpers exist only as stdlib functions)

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2365,6 +2365,8 @@ Simulation primitives (host-backed builtins):
     env.register_autoload("length", 1, "std/prelude/list.genia")
     env.register_autoload("reverse", 1, "std/prelude/list.genia")
     env.register_autoload("reduce", 3, "std/prelude/list.genia")
+    env.register_autoload("map", 2, "std/prelude/list.genia")
+    env.register_autoload("filter", 2, "std/prelude/list.genia")
     env.register_autoload("count", 1, "std/prelude/list.genia")
     env.register_autoload("any?", 2, "std/prelude/list.genia")
     env.register_autoload("nth", 2, "std/prelude/list.genia")

--- a/std/prelude/list.genia
+++ b/std/prelude/list.genia
@@ -37,6 +37,15 @@ reduce(f, acc, xs) =
   (f, acc, []) -> acc |
   (f, acc, [x, ..rest]) -> reduce(f, f(acc, x), rest)
 
+map(f, xs) = reverse(reduce((acc, x) -> [f(x)] + acc, [], xs))
+
+filter(predicate, xs) =
+  reverse(reduce((acc, x) -> filter_keep(predicate, acc, x), [], xs))
+
+filter_keep(predicate, acc, x) =
+  (predicate, acc, x) ? predicate(x) == true -> [x] + acc |
+  (_, acc, _) -> acc
+
 count(xs) = reduce((acc, _) -> acc + 1, 0, xs)
 
 any?(predicate, xs) =

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -50,6 +50,13 @@ def test_autoload_reduce_direct():
     assert run_with_env(src) == 10
 
 
+def test_autoload_map_and_filter():
+    src = """
+    [map((x) -> x * 2, [1, 2, 3]), filter((x) -> x > 2, [1, 2, 3, 4])]
+    """
+    assert run_with_env(src) == [[2, 4, 6], [3, 4]]
+
+
 def test_autoload_same_file_loads_helper_too():
     env = make_global_env([])
     assert run_source("count([1, 2, 3])", env) == 3

--- a/tests/test_stdlib_prelude_basics.py
+++ b/tests/test_stdlib_prelude_basics.py
@@ -41,6 +41,16 @@ def test_reverse(run):
     assert run("reverse([1, 2, 3])") == [3, 2, 1]
 
 
+def test_map(run):
+    assert run("map((x) -> x + 1, [])") == []
+    assert run("map((x) -> x + 1, [1, 2, 3])") == [2, 3, 4]
+
+
+def test_filter(run):
+    assert run("filter((x) -> x % 2 == 0, [])") == []
+    assert run("filter((x) -> x % 2 == 0, [1, 2, 3, 4, 5])") == [2, 4]
+
+
 def test_numeric_helpers(run):
     assert run("inc(4)") == 5
     assert run("dec(4)") == 3
@@ -59,3 +69,5 @@ def test_direct_prelude_load_without_autoload():
     run_source(prelude_path.read_text(encoding="utf-8"), env, filename=str(prelude_path.resolve()))
     assert run_source("append([1], [2, 3])", env) == [1, 2, 3]
     assert run_source("reverse([1, 2, 3])", env) == [3, 2, 1]
+    assert run_source("map((x) -> x + 1, [1, 2, 3])", env) == [2, 3, 4]
+    assert run_source("filter((x) -> x % 2 == 1, [1, 2, 3, 4])", env) == [1, 3]


### PR DESCRIPTION
### Motivation
- Provide common list transforms `map` and `filter` in the stdlib while keeping the core language minimal and avoiding new syntax. 
- Implement them in a tail-call-friendly way by reusing the existing `reduce` accumulator pattern so recursion/TCO properties are preserved.

### Description
- Added `map/2`, `filter/2`, and helper `filter_keep/3` to `std/prelude/list.genia`, implemented as `reduce` + `reverse` to preserve order and reuse tail-recursive accumulation. 
- Registered autoload entries for `map` and `filter` in `src/genia/interpreter.py` so they load like other prelude helpers. 
- Added tests exercising direct prelude load and autoload usage in `tests/test_stdlib_prelude_basics.py` and `tests/test_autoload.py`. 
- Updated documentation and state files: `GENIA_STATE.md`, `README.md`, `GENIA_REPL_README.md`, and added `docs/book/05-lists.md` describing the implementation, examples, and status.

### Testing
- Ran `pytest -q tests/test_stdlib_prelude_basics.py tests/test_autoload.py` which passed (`21 passed`).
- Ran `pytest -q tests/test_tco.py` which passed (`5 passed`).
- All added/modified stdlib-related tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8d467c208329af52430992130732)