### PR TITLE
Add autoloaded stdlib `range` helper (1/2/3-arity) with docs and tests

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -48,7 +48,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - conditionals expressed only through pattern matching in function definitions/case expressions
 - function resolution with fixed arity + varargs precedence
 - autoloaded stdlib functions keyed by `(name, arity)`
-  - includes list transforms such as `reduce`, `map`, and `filter`
+  - includes list transforms/helpers such as `reduce`, `map`, `filter`, and `range`
 - builtins:
   - I/O: `log`, `print`, `input`, `stdin`, `help`
   - refs: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -145,7 +145,7 @@ Autoload is keyed by `(name, arity)` and currently registers functions from:
 
 Notable autoloaded functions include:
 
-- list: `list`, `first`, `rest`, `empty?`, `nil?`, `append`, `length`, `reverse`, `reduce`, `map`, `filter`, `count`, `any?`, `nth`, `take`, `drop`
+- list: `list`, `first`, `rest`, `empty?`, `nil?`, `append`, `length`, `reverse`, `reduce`, `map`, `filter`, `count`, `any?`, `nth`, `take`, `drop`, `range`
 - fn: `apply`, `compose`
 - math: `inc`, `dec`, `mod`, `abs`, `min`, `max`, `sum`
 - awk: `awkify`, `awk_filter`, `awk_map`, `awk_count`, `fields`

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ agent_get(counter)
 
 ## Autoloaded stdlib highlights
 
-- list helpers: `list`, `first`, `rest`, `append`, `length`, `reverse`, `reduce`, `map`, `filter`, `nth`, `take`, `drop`, ...
+- list helpers: `list`, `first`, `rest`, `append`, `length`, `reverse`, `reduce`, `map`, `filter`, `nth`, `take`, `drop`, `range`, ...
 - fn helpers: `apply`, `compose`
 - math helpers: `inc`, `dec`, `mod`, `abs`, `min`, `max`, `sum`
 - awk-ish helpers: `awkify`, `awk_filter`, `awk_map`, `awk_count`, `fields`

--- a/docs/book/05-lists.md
+++ b/docs/book/05-lists.md
@@ -22,6 +22,7 @@ Core helpers include:
 - `nth`
 - `take`
 - `drop`
+- `range`
 
 ---
 
@@ -69,6 +70,52 @@ Expected behavior:
 
 ---
 
+## `range`
+
+`range` is a recursive stdlib helper that builds numeric lists.
+
+Implemented arities:
+
+- `range(stop)` → delegates to `range(0, stop - 1, 1)`
+- `range(start, stop)` → delegates to `range(start, stop, 1)`
+- `range(start, stop, step)` → inclusive stop model with explicit step control
+
+### Minimal example
+
+```genia
+range(5)
+```
+
+Expected result:
+
+```genia
+[0, 1, 2, 3, 4]
+```
+
+### Edge case example
+
+```genia
+range(5, 1, -2)
+```
+
+Expected result:
+
+```genia
+[5, 3, 1]
+```
+
+### Failure case example
+
+```genia
+range(1, 5, 0)
+```
+
+Expected behavior:
+
+- returns `[]` to avoid non-terminating recursion when step is zero.
+
+---
+
 ## Implementation status
 
 ### ✅ Implemented
@@ -78,6 +125,7 @@ Expected behavior:
 - recursive list helpers in stdlib
 - `reduce`
 - `map` and `filter` as reduce-based stdlib functions
+- `range` helpers for 1-, 2-, and 3-arity calls
 
 ### ⚠️ Partial
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2372,6 +2372,9 @@ Simulation primitives (host-backed builtins):
     env.register_autoload("nth", 2, "std/prelude/list.genia")
     env.register_autoload("take", 2, "std/prelude/list.genia")
     env.register_autoload("drop", 2, "std/prelude/list.genia")
+    env.register_autoload("range", 1, "std/prelude/list.genia")
+    env.register_autoload("range", 2, "std/prelude/list.genia")
+    env.register_autoload("range", 3, "std/prelude/list.genia")
     env.register_autoload("apply", 2, "std/prelude/fn.genia")
     env.register_autoload("compose", 1, "std/prelude/fn.genia")
 

--- a/std/prelude/list.genia
+++ b/std/prelude/list.genia
@@ -67,3 +67,13 @@ drop(n, xs) =
   (_, []) -> [] |
   (0, xs) -> xs |
   (n, [_, ..rest]) -> drop(n - 1, rest)
+
+range(stop) = range(0, stop - 1, 1)
+
+range(start, stop) = range(start, stop, 1)
+
+range(start, stop, step) =
+  (_, _, 0) -> [] |
+  (start, stop, step) ? step > 0 && start > stop -> [] |
+  (start, stop, step) ? step < 0 && start < stop -> [] |
+  (start, stop, step) -> [start] + range(start + step, stop, step)

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -28,6 +28,12 @@ def test_autoload_length_and_reverse():
     assert run_with_env("reverse([1, 2, 3])") == [3, 2, 1]
 
 
+def test_autoload_range():
+    assert run_with_env("range(4)") == [0, 1, 2, 3]
+    assert run_with_env("range(1, 4)") == [1, 2, 3, 4]
+    assert run_with_env("range(1, 7, 3)") == [1, 4, 7]
+
+
 def test_autoload_math_helpers():
     assert run_with_env("inc(41)") == 42
     assert run_with_env("abs(-9)") == 9

--- a/tests/test_stdlib_prelude_basics.py
+++ b/tests/test_stdlib_prelude_basics.py
@@ -51,6 +51,16 @@ def test_filter(run):
     assert run("filter((x) -> x % 2 == 0, [1, 2, 3, 4, 5])") == [2, 4]
 
 
+def test_range(run):
+    assert run("range(5)") == [0, 1, 2, 3, 4]
+    assert run("range(2, 5)") == [2, 3, 4, 5]
+    assert run("range(2, 8, 2)") == [2, 4, 6, 8]
+    assert run("range(5, 1, -2)") == [5, 3, 1]
+    assert run("range(5, 1)") == []
+    assert run("range(1, 5, -1)") == []
+    assert run("range(1, 5, 0)") == []
+
+
 def test_numeric_helpers(run):
     assert run("inc(4)") == 5
     assert run("dec(4)") == 3


### PR DESCRIPTION
### Motivation
- Provide a simple recursive `range` helper that builds numeric lists with 1-, 2-, and 3-arity forms to match the requested API (`range(stop)`, `range(start, stop)`, `range(start, stop, step)`).
- Keep stdlib behavior minimal and consistent with existing list helpers and the autoload model so `range` is available in fresh environments like other prelude functions.

### Description
- Implemented `range` in `std/prelude/list.genia` with three arities where `range(stop) = range(0, stop - 1, 1)`, `range(start, stop) = range(start, stop, 1)`, and `range(start, stop, step)` includes guards for `step == 0` and direction-based termination and otherwise recurses producing `[start] + range(start + step, stop, step)`.
- Registered autoload entries for `range` at arities `1`, `2`, and `3` in `make_global_env` (`src/genia/interpreter.py`) so the function autoloads like other prelude helpers.
- Added unit tests in `tests/test_stdlib_prelude_basics.py` and `tests/test_autoload.py` covering positive-step, negative-step, empty-result direction mismatches, and `step == 0` cases.
- Updated synchronized documentation/state files: `docs/book/05-lists.md`, `GENIA_STATE.md`, `GENIA_REPL_README.md`, and `README.md` to list and describe the new `range` helper.

### Testing
- Ran `pytest -q tests/test_stdlib_prelude_basics.py tests/test_autoload.py` and all tests in those files passed (`23 passed`).
- The change was exercised both via direct prelude load and via autoload resolution in a fresh environment with the added tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca939c54e8832985d66cc7ce2907f8)