### PR TITLE
Add named function docstrings and help metadata output

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -34,6 +34,10 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - variables and top-level assignment (`name = expr`)
 - unary/binary operators: `!`, unary `-`, `+ - * / %`, comparisons, equality, `&&`, `||`
 - function definitions with expression body, block body, or case body
+- optional named-function docstring metadata:
+  - `f(x) = "doc text" x + 1`
+  - docstring is attached to function metadata (not evaluated as runtime expression)
+  - lambdas do not support docstrings
 - lambda expressions, including varargs lambdas with `..rest`
 - list literals with spread (`[..xs]`, `[1, ..xs, 2]`)
 - function-call argument spread (`f(..xs)`)
@@ -63,6 +67,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - `:help`
 - `:env`
 - `:quit`
+- `help(name)` to inspect named-function metadata (`name`, arities, docstring, source location when available)
 
 ## Not implemented (current)
 

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -62,6 +62,17 @@ Required constraints:
 
 - fixed-arity match is preferred over varargs match
 - varargs ambiguity must raise `TypeError("Ambiguous function resolution")`
+- named-function groups may carry one canonical docstring:
+  - no docstrings => undocumented
+  - one docstring total => valid
+  - repeated identical docstrings => valid
+  - conflicting docstrings => clear `TypeError`
+
+## 8.1) Named function docstring parse invariant
+
+- parser may treat a string literal as function docstring metadata only for named function definitions after `=`
+- the docstring is metadata, not a runtime expression
+- lambdas do not support docstrings
 
 ## 9) Operator model
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -28,6 +28,10 @@ This file describes what is **actually implemented now** in the Python runtime.
 - named functions are first-class values
 - multiple definitions by arity shape are allowed
 - varargs named functions are supported (`f(a, ..rest) = ...`)
+- named function definitions may include an optional leading docstring string literal after `=`
+  - example: `inc(x) = "increment by one" x + 1`
+  - docstrings are metadata, not runtime body expressions
+  - for multi-clause named functions: zero docstrings = undocumented; one docstring total = valid; repeated identical docstrings = valid; conflicting docstrings raise a clear `TypeError`
 - resolution behavior:
   - exact fixed arity beats varargs
   - if multiple varargs candidates match and neither is more specific, runtime raises `TypeError("Ambiguous function resolution")`
@@ -162,6 +166,11 @@ Implemented optimizations:
 
 - parser/IR nodes carry source spans (filename + line/column ranges)
 - `run_debug_stdio(...)` exposes debugger protocol endpoints used by the VS Code extension
+- `help(name)` displays named-function metadata when available:
+  - function name
+  - arity shape list (including varargs markers)
+  - docstring text (when present)
+  - source location (when available)
 
 ## 9) Explicitly not implemented (current)
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ list = (..xs) -> xs
 
 - functions are dispatched by name + arity shape (fixed arity preferred over varargs)
 - varargs supported in named functions and lambdas via `..rest`
+- named functions may include optional docstring metadata:
+  - `inc(x) = "increment by one" x + 1`
 - closures are supported
 
 ### Pattern matching
@@ -121,6 +123,7 @@ agent_get(counter)
 ### Core
 
 - `log`, `print`, `input`, `stdin`, `help`
+- `help(name)` prints named function metadata (arity shape, docstring, source if available)
 - constants: `pi`, `e`, `true`, `false`, `nil`
 
 ### Refs

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -222,6 +222,7 @@ Genia has no dedicated conditional keyword.
 * Pattern matching is the **core abstraction** of Genia
 * Any feature that introduces branching should integrate with this model
 * Avoid adding alternative conditional constructs
+* Function docstrings are metadata only and must not change case/pattern semantics
 
 ---
 

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -1,0 +1,73 @@
+# Chapter 03: Functions
+
+## The Smallest Example
+
+```genia
+inc(x) = x + 1
+```
+
+Named functions are values and dispatch by name + arity shape.
+
+---
+
+## Function Docstrings (Implemented)
+
+A named function may include a leading docstring string literal after `=`:
+
+```genia
+inc(x) = "Increment a number by one." x + 1
+```
+
+The string is metadata for the named function group, not a normal runtime expression.
+
+You can inspect it with:
+
+```genia
+help("inc")
+```
+
+---
+
+## Edge Case Example
+
+Multiple clauses can share one canonical docstring:
+
+```genia
+echo() = "Return value unchanged." nil
+echo(x) = "Return value unchanged." x
+```
+
+This is valid (same docstring text).
+
+---
+
+## Failure Case Example
+
+Conflicting docstrings across clauses raise a clear error:
+
+```genia
+echo() = "First doc." nil
+echo(x) = "Second doc." x
+```
+
+Expected behavior: runtime `TypeError` for conflicting function docstrings.
+
+---
+
+## Implementation Status
+
+### ✅ Implemented
+
+* Named function definitions
+* Arity-based + varargs dispatch
+* Named-function docstring metadata (`f(...) = "doc" ...`)
+* `help(name)` metadata output (name, arities, docstring when present, source when available)
+
+### ⚠️ Partial
+
+* Docstring parsing currently requires the docstring and body expression to be part of the same definition expression sequence (no dedicated block-doc syntax)
+
+### ❌ Not implemented
+
+* Lambda docstrings
+* Separate docstring keywords or block syntax

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -45,7 +45,7 @@ import argparse
 import re
 import sys
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Iterable, Optional
 
 if __package__ in (None, ""):
@@ -424,6 +424,7 @@ class FuncDef(Node):
     name: str
     params: list[str]
     rest_param: str | None
+    docstring: str | None
     body: Node
     span: SourceSpan | None = None
 
@@ -602,6 +603,7 @@ class IrFuncDef(IrNode):
     name: str
     params: list[str]
     rest_param: str | None
+    docstring: str | None
     body: IrNode
     span: SourceSpan | None = None
 
@@ -665,7 +667,14 @@ def lower_node(node: Node) -> IrNode:
     if isinstance(node, Assign):
         return IrAssign(node.name, lower_node(node.expr), span=node.span)
     if isinstance(node, FuncDef):
-        return IrFuncDef(node.name, node.params, node.rest_param, lower_node(node.body), span=node.span)
+        return IrFuncDef(
+            node.name,
+            node.params,
+            node.rest_param,
+            node.docstring,
+            lower_node(node.body),
+            span=node.span,
+        )
     raise RuntimeError(f"Unknown AST node during lowering: {node!r}")
 
 
@@ -788,6 +797,7 @@ def optimize_nth_style_recursion(fn: IrFuncDef) -> IrFuncDef:
         fn.name,
         fn.params,
         fn.rest_param,
+        fn.docstring,
         IrListTraversalLoop(
             counter_var=fn.params[0],
             list_var=fn.params[1],
@@ -1044,11 +1054,20 @@ class Parser:
             if self.at("ASSIGN"):
                 self.eat("ASSIGN")
                 self.skip_separators()
+                docstring: str | None = None
+                if self.at("STRING"):
+                    save = self.i
+                    candidate = parse_string_literal(self.eat("STRING").text)
+                    if self.at_expr_start():
+                        docstring = candidate
+                    else:
+                        self.i = save
                 body = self.parse_function_body_after_intro(len(params))
                 return FuncDef(
                     name,
                     params,
                     rest_param,
+                    docstring,
                     body,
                     span=self.merge_spans(self.span_for_tokens(name_tok, name_tok), body.span),
                 )
@@ -1059,6 +1078,7 @@ class Parser:
                     name,
                     params,
                     rest_param,
+                    None,
                     body,
                     span=self.merge_spans(self.span_for_tokens(name_tok, name_tok), body.span),
                 )
@@ -1075,6 +1095,9 @@ class Parser:
 
         expr = self.parse_expr()
         return ExprStmt(expr, span=expr.span)
+
+    def at_expr_start(self) -> bool:
+        return self.at("NUMBER", "STRING", "IDENT", "MINUS", "BANG", "LPAREN", "LBRACK", "LBRACE")
 
     def leading_parenthesized_item_count_before_arrow(self) -> int | None:
         if not self.at("LPAREN"):
@@ -1432,13 +1455,13 @@ class Env:
     def define_function(self, fn: "GeniaFunction") -> None:
         existing = self.values.get(fn.name)
         if existing is None:
-            self.values[fn.name] = {fn.arity: fn}
+            group = GeniaFunctionGroup(fn.name)
+            group.add_clause(fn)
+            self.values[fn.name] = group
             return
-        if not isinstance(existing, dict) or not all(isinstance(k, int) for k in existing):
+        if not isinstance(existing, GeniaFunctionGroup):
             raise TypeError(f"Cannot define function {fn.name}/{fn.arity}: name already bound to non-function value")
-        if fn.arity in existing:
-            raise TypeError(f"Duplicate function definition: {fn.name}/{fn.arity}")
-        existing[fn.arity] = fn
+        existing.add_clause(fn)
 
     def register_autoload(self, name: str, arity: int, path: str) -> None:
         root = self.root()
@@ -1475,10 +1498,52 @@ class Env:
 
 
 @dataclass
+class GeniaFunctionGroup:
+    name: str
+    functions: dict[int, "GeniaFunction"] = field(default_factory=dict)
+    docstring: str | None = None
+
+    def add_clause(self, fn: "GeniaFunction") -> None:
+        existing = self.functions.get(fn.arity)
+        if existing is not None:
+            raise TypeError(f"Duplicate function definition: {fn.name}/{fn.arity}")
+        self._merge_docstring(fn.docstring)
+        self.functions[fn.arity] = fn
+
+    def _merge_docstring(self, candidate: str | None) -> None:
+        if candidate is None:
+            return
+        if self.docstring is None:
+            self.docstring = candidate
+            return
+        if self.docstring != candidate:
+            raise TypeError(
+                f"Conflicting docstrings for function {self.name}: got {candidate!r}, expected {self.docstring!r}"
+            )
+
+    def __iter__(self):
+        return iter(self.functions)
+
+    def __getitem__(self, key: int) -> "GeniaFunction":
+        return self.functions[key]
+
+    def get(self, key: int) -> "GeniaFunction | None":
+        return self.functions.get(key)
+
+    def values(self):
+        return self.functions.values()
+
+    def sorted_arities(self) -> list[int]:
+        return sorted(self.functions)
+
+
+
+@dataclass
 class GeniaFunction:
     name: str
     params: list[str]
     rest_param: str | None
+    docstring: str | None
     body: IrNode
     closure: Env
     span: SourceSpan | None = None
@@ -1786,10 +1851,10 @@ class Evaluator:
         callee_node: IrNode | None = None,
     ) -> Any:
 
-        if isinstance(fn, dict) and all(isinstance(k, int) for k in fn):
+        if isinstance(fn, GeniaFunctionGroup):
             arity = len(args)
 
-            def resolve_target(functions: dict[int, Any], call_arity: int) -> Any | None:
+            def resolve_target(functions: GeniaFunctionGroup, call_arity: int) -> Any | None:
                 exact = functions.get(call_arity)
                 if exact is not None:
                     return exact
@@ -1819,12 +1884,12 @@ class Evaluator:
             if target is None and isinstance(callee_node, IrVar):
                 if self.env.try_autoload(callee_node.name, arity):
                     fn = self.env.get(callee_node.name)
-                    if isinstance(fn, dict) and all(isinstance(k, int) for k in fn):
+                    if isinstance(fn, GeniaFunctionGroup):
                         target = resolve_target(fn, arity)
 
             if target is None:
                 callee = callee_node.name if isinstance(callee_node, IrVar) else "function"
-                available = ", ".join(f"{callee}/{n}" for n in sorted(fn))
+                available = ", ".join(f"{callee}/{n}" for n in fn.sorted_arities())
                 raise TypeError(f"No matching function: {callee}/{arity}. Available: {available}")
             if tail_position and not self.debug_mode:
                 return TailCall(target, tuple(args))
@@ -1989,6 +2054,7 @@ class Evaluator:
                 node.name,
                 node.params,
                 node.rest_param,
+                node.docstring,
                 node.body,
                 self.env,
                 span=node.span,
@@ -2149,8 +2215,63 @@ def make_global_env(
                 stdin_cache = sys.stdin.read().splitlines()
         return stdin_cache
 
-    def help_fn() -> None:
-        print(
+    def _emit_help(text: str) -> None:
+        output = text + "\n"
+        if output_handler is None:
+            print(output, end="")
+        else:
+            output_handler(output)
+
+    def _format_span(span: SourceSpan | None) -> str | None:
+        if span is None:
+            return None
+        return f"{span.filename}:{span.line}:{span.column}"
+
+    def _format_function_shapes(group: GeniaFunctionGroup) -> str:
+        shapes: list[str] = []
+        for arity in group.sorted_arities():
+            fn_value = group.get(arity)
+            if fn_value is None:
+                continue
+            suffix = "+" if fn_value.rest_param is not None else ""
+            shapes.append(f"{arity}{suffix}")
+        return ", ".join(shapes) if shapes else "unknown"
+
+    def _group_span(group: GeniaFunctionGroup) -> SourceSpan | None:
+        spans = [fn.span for fn in group.values() if isinstance(fn, GeniaFunction) and fn.span is not None]
+        if not spans:
+            return None
+        return min(spans, key=lambda s: (s.line, s.column, s.end_line, s.end_column))
+
+    def _describe_function_group(group: GeniaFunctionGroup) -> str:
+        lines = [
+            f"{group.name}",
+            f"  arities: {_format_function_shapes(group)}",
+        ]
+        if group.docstring is not None:
+            lines.append(f"  doc: {group.docstring}")
+        span_text = _format_span(_group_span(group))
+        if span_text is not None:
+            lines.append(f"  source: {span_text}")
+        return "\n".join(lines)
+
+    def help_fn(*args: Any) -> None:
+        if len(args) > 1:
+            raise TypeError(f"help expected 0 or 1 args, got {len(args)}")
+        if len(args) == 1:
+            target = args[0]
+            if isinstance(target, str):
+                target = env.get(target)
+            if isinstance(target, GeniaFunctionGroup):
+                _emit_help(_describe_function_group(target))
+                return
+            if isinstance(target, GeniaFunction):
+                singleton = GeniaFunctionGroup(target.name, functions={target.arity: target}, docstring=target.docstring)
+                _emit_help(_describe_function_group(singleton))
+                return
+            raise TypeError("help expected a function name or named function")
+
+        _emit_help(
             """
 Genia prototype help
 --------------------
@@ -2197,6 +2318,7 @@ Commands:
   :quit   exit
   :env    show defined names
   :help   show this help
+  help(name)   show metadata for a named function
 
 Concurrency builtins (host-backed):
   spawn(handler)          create a process with a mailbox

--- a/std/prelude/fn.genia
+++ b/std/prelude/fn.genia
@@ -1,6 +1,6 @@
-apply(f, args) = f(..args)
+apply(f, args) = "Call f with a list of positional args." f(..args)
 
-compose(..fns) = (..args) -> compose_apply(fns, args)
+compose(..fns) = "Compose functions right-to-left into one callable." (..args) -> compose_apply(fns, args)
 
 compose_apply(fns, args) =
   ([f], args) -> apply(f, args) |

--- a/std/prelude/list.genia
+++ b/std/prelude/list.genia
@@ -1,10 +1,8 @@
-list(..xs) = xs
+list(..xs) = "Build a list from all provided arguments." xs
 
-first(xs) =
-  [x, .._] -> x
+first(xs) = "Return the first element of a non-empty list." ([x, .._]) -> x
 
-rest(xs) =
-  [_, ..tail] -> tail
+rest(xs) = "Return every element after the head of a non-empty list." ([_, ..tail]) -> tail
 
 empty?(xs) =
   [] -> true |
@@ -21,7 +19,7 @@ append(xs, ys) =
   (xs, []) -> xs |
   (xs, ys) -> [..xs, ..ys]
 
-length(xs) = length_acc(xs, 0)
+length(xs) = "Count the number of elements in a list." length_acc(xs, 0)
 
 length_acc(xs, acc) =
   ([], acc) -> acc |

--- a/tests/test_function_docstrings.py
+++ b/tests/test_function_docstrings.py
@@ -1,0 +1,48 @@
+import pytest
+
+from genia.interpreter import FuncDef, Parser, lex
+from genia import make_global_env, run_source
+
+
+def test_parser_captures_named_function_docstring_metadata():
+    src = 'inc(x) = "increment by one" x + 1\n'
+    ast = Parser(lex(src), source=src, filename="doc.genia").parse_program()
+    fn = ast[0]
+    assert isinstance(fn, FuncDef)
+    assert fn.docstring == "increment by one"
+
+
+def test_help_displays_function_docstring_and_source_location():
+    outputs: list[str] = []
+    env = make_global_env([], output_handler=outputs.append)
+    src = 'inc(x) = "increment by one" x + 1\nhelp("inc")\n'
+    run_source(src, env, filename="doc.genia")
+    out = "".join(outputs)
+    assert "inc" in out
+    assert "arities: 1" in out
+    assert "doc: increment by one" in out
+    assert "source: doc.genia:1:1" in out
+
+
+def test_multiple_identical_docstrings_are_allowed():
+    outputs: list[str] = []
+    env = make_global_env([], output_handler=outputs.append)
+    src = """
+    echo() = "echo helper" nil
+    echo(x) = "echo helper" x
+    help("echo")
+    """
+    run_source(src, env, filename="echo.genia")
+    out = "".join(outputs)
+    assert "doc: echo helper" in out
+    assert "arities: 0, 1" in out
+
+
+def test_conflicting_docstrings_raise_clear_error():
+    env = make_global_env([])
+    src = """
+    fn() = "first" nil
+    fn(x) = "second" x
+    """
+    with pytest.raises(TypeError, match="Conflicting docstrings for function fn"):
+        run_source(src, env)


### PR DESCRIPTION
### Motivation

- Provide a minimal way to document named functions in Genia by attaching a string literal as metadata to named function definitions without changing runtime semantics. 
- Keep the design small and book-driven: attach docstrings to the function/group value (not evaluate them), preserve parser/case invariants, and surface the metadata via `help`.

### Description

- Parser/AST/IR: allow an optional leading `STRING` token immediately after `=` in named function definitions and store it on `FuncDef` / `IrFuncDef` via a new `docstring` field (parsing guarded so ordinary expressions are unaffected). 
- Runtime: introduced `GeniaFunction.docstring` and a `GeniaFunctionGroup` value to hold per-name clauses and a single canonical `docstring`, merging identical docstrings and raising `TypeError` on conflicting docstrings; preserved existing function-resolution logic and ambiguity/error messages. 
- REPL/help: extended `help` to accept `help(name)` and print function name, arity/shape list (including varargs marker), docstring text when present, and best-available source location. 
- Stdlib & docs: added example docstrings to selected prelude functions and updated `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and `docs/book/03-functions.md` to reflect implemented behavior. 

### Testing

- Added unit tests `tests/test_function_docstrings.py` covering parser capture, `help` output, identical-docstring acceptance, and conflicting-docstring error, and ran them successfully with `pytest -q tests/test_function_docstrings.py`.
- Ran targeted and broad test runs (`pytest -q tests/test_ir.py tests/test_debug_foundation.py tests/test_autoload.py tests/test_function_resolution_precedence.py tests/test_ants_demo.py`) and the full suite (`pytest -q`), and all tests passed (final run: 211 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caa9cbdcec8329b9165ea3bedbf0b1)