### PR TITLE
Add Markdown-aware docstring rendering and improved REPL help output

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -38,6 +38,8 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - `f(x) = "doc text" x + 1`
   - docstring is attached to function metadata (not evaluated as runtime expression)
   - lambdas do not support docstrings
+  - `help(name)` renders docstrings as lightweight Markdown text (headings, lists, inline code, fenced code blocks)
+  - help output normalizes docstring indentation/blank lines and strips optional outer triple-quote wrappers in docstring text
 - lambda expressions, including varargs lambdas with `..rest`
 - list literals with spread (`[..xs]`, `[1, ..xs, 2]`)
 - function-call argument spread (`f(..xs)`)
@@ -67,7 +69,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - `:help`
 - `:env`
 - `:quit`
-- `help(name)` to inspect named-function metadata (`name`, arities, docstring, source location when available)
+- `help(name)` to inspect named-function metadata (`name/shape`, source location, rendered docstring, undocumented fallback)
 
 ## Not implemented (current)
 

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -73,6 +73,7 @@ Required constraints:
 - parser may treat a string literal as function docstring metadata only for named function definitions after `=`
 - the docstring is metadata, not a runtime expression
 - lambdas do not support docstrings
+- docstring text is interpreted as Markdown for `help(...)` display with lightweight formatting only (no full Markdown engine)
 
 ## 9) Operator model
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -167,10 +167,11 @@ Implemented optimizations:
 - parser/IR nodes carry source spans (filename + line/column ranges)
 - `run_debug_stdio(...)` exposes debugger protocol endpoints used by the VS Code extension
 - `help(name)` displays named-function metadata when available:
-  - function name
-  - arity shape list (including varargs markers)
-  - docstring text (when present)
-  - source location (when available)
+  - function signature header (`name/shape`, shapes include `+` for varargs)
+  - source location (`Defined at file:line`) when available
+  - Markdown-aware docstring rendering (headings, bullet lists, inline code, fenced code blocks, paragraph spacing)
+  - docstring normalization (trim outer blank lines, dedent indentation, optional triple-quote wrapper stripping, collapse excessive blank lines)
+  - undocumented fallback message (`No documentation available.`)
 
 ## 9) Explicitly not implemented (current)
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ list = (..xs) -> xs
 - varargs supported in named functions and lambdas via `..rest`
 - named functions may include optional docstring metadata:
   - `inc(x) = "increment by one" x + 1`
+  - `help(name)` renders docstrings with lightweight Markdown-aware formatting
 - closures are supported
 
 ### Pattern matching
@@ -123,7 +124,7 @@ agent_get(counter)
 ### Core
 
 - `log`, `print`, `input`, `stdin`, `help`
-- `help(name)` prints named function metadata (arity shape, docstring, source if available)
+- `help(name)` prints named function metadata (`name/shape`, source if available, rendered docstring, or undocumented fallback)
 - constants: `pi`, `e`, `true`, `false`, `nil`
 
 ### Refs

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -19,11 +19,19 @@ inc(x) = "Increment a number by one." x + 1
 ```
 
 The string is metadata for the named function group, not a normal runtime expression.
+Docstrings are rendered by `help(...)` as lightweight Markdown text.
 
 You can inspect it with:
 
 ```genia
 help("inc")
+```
+
+Markdown-aware example:
+
+```genia
+sum(xs) = "# sum\n\nReturn the total from `xs`.\n\n## Params\n- xs: list of numbers" 0
+help("sum")
 ```
 
 ---
@@ -61,11 +69,16 @@ Expected behavior: runtime `TypeError` for conflicting function docstrings.
 * Named function definitions
 * Arity-based + varargs dispatch
 * Named-function docstring metadata (`f(...) = "doc" ...`)
-* `help(name)` metadata output (name, arities, docstring when present, source when available)
+* `help(name)` output with:
+  * signature header (`name/shape`)
+  * source location when available
+  * Markdown-aware docstring rendering (headings/lists/inline code/fenced code blocks)
+  * undocumented fallback (`No documentation available.`)
 
 ### ⚠️ Partial
 
-* Docstring parsing currently requires the docstring and body expression to be part of the same definition expression sequence (no dedicated block-doc syntax)
+* Markdown rendering is intentionally minimal and terminal-first (no full Markdown engine, no syntax highlighting)
+* Docstring parsing requires the docstring and body expression to be part of the same definition expression sequence (no dedicated block-doc syntax)
 
 ### ❌ Not implemented
 

--- a/src/genia/docstrings.py
+++ b/src/genia/docstrings.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import textwrap
+
+
+def normalize_docstring(raw: str) -> str:
+    text = raw.replace("\r\n", "\n").replace("\r", "\n")
+    stripped = text.strip()
+    if (stripped.startswith('"""') and stripped.endswith('"""')) or (
+        stripped.startswith("'''") and stripped.endswith("'''")
+    ):
+        stripped = stripped[3:-3]
+    dedented = textwrap.dedent(stripped)
+    lines = dedented.split("\n")
+
+    while lines and lines[0].strip() == "":
+        lines.pop(0)
+    while lines and lines[-1].strip() == "":
+        lines.pop()
+
+    out: list[str] = []
+    blank_count = 0
+    in_fence = False
+    for line in lines:
+        trimmed = line.rstrip() if not in_fence else line
+        if trimmed.strip().startswith("```"):
+            in_fence = not in_fence
+            blank_count = 0
+            out.append(trimmed)
+            continue
+        if trimmed.strip() == "":
+            blank_count += 1
+            if blank_count <= 1:
+                out.append("")
+            continue
+        blank_count = 0
+        out.append(trimmed)
+    return "\n".join(out).strip()
+
+
+def render_markdown_docstring(raw: str) -> str:
+    return normalize_docstring(raw)

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -57,7 +57,9 @@ if __package__ in (None, ""):
         format_display,
         utf8_byte_length,
     )
+    from genia.docstrings import render_markdown_docstring
 else:
+    from .docstrings import render_markdown_docstring
     from .utf8 import (
         format_debug,
         format_display,
@@ -2225,7 +2227,7 @@ def make_global_env(
     def _format_span(span: SourceSpan | None) -> str | None:
         if span is None:
             return None
-        return f"{span.filename}:{span.line}:{span.column}"
+        return f"{span.filename}:{span.line}"
 
     def _format_function_shapes(group: GeniaFunctionGroup) -> str:
         shapes: list[str] = []
@@ -2244,15 +2246,16 @@ def make_global_env(
         return min(spans, key=lambda s: (s.line, s.column, s.end_line, s.end_column))
 
     def _describe_function_group(group: GeniaFunctionGroup) -> str:
-        lines = [
-            f"{group.name}",
-            f"  arities: {_format_function_shapes(group)}",
-        ]
-        if group.docstring is not None:
-            lines.append(f"  doc: {group.docstring}")
+        shapes = _format_function_shapes(group)
+        lines = [f"{group.name}/{shapes}"]
         span_text = _format_span(_group_span(group))
         if span_text is not None:
-            lines.append(f"  source: {span_text}")
+            lines.append(f"Defined at {span_text}")
+        lines.append("")
+        if group.docstring is not None:
+            lines.append(render_markdown_docstring(group.docstring))
+        else:
+            lines.append("No documentation available.")
         return "\n".join(lines)
 
     def help_fn(*args: Any) -> None:

--- a/tests/test_function_docstrings.py
+++ b/tests/test_function_docstrings.py
@@ -18,10 +18,9 @@ def test_help_displays_function_docstring_and_source_location():
     src = 'inc(x) = "increment by one" x + 1\nhelp("inc")\n'
     run_source(src, env, filename="doc.genia")
     out = "".join(outputs)
-    assert "inc" in out
-    assert "arities: 1" in out
-    assert "doc: increment by one" in out
-    assert "source: doc.genia:1:1" in out
+    assert "inc/1" in out
+    assert "Defined at doc.genia:1" in out
+    assert "increment by one" in out
 
 
 def test_multiple_identical_docstrings_are_allowed():
@@ -34,8 +33,8 @@ def test_multiple_identical_docstrings_are_allowed():
     """
     run_source(src, env, filename="echo.genia")
     out = "".join(outputs)
-    assert "doc: echo helper" in out
-    assert "arities: 0, 1" in out
+    assert "echo/0, 1" in out
+    assert "echo helper" in out
 
 
 def test_conflicting_docstrings_raise_clear_error():
@@ -46,3 +45,44 @@ def test_conflicting_docstrings_raise_clear_error():
     """
     with pytest.raises(TypeError, match="Conflicting docstrings for function fn"):
         run_source(src, env)
+
+
+def test_help_renders_markdown_docstring_with_normalized_whitespace():
+    outputs: list[str] = []
+    env = make_global_env([], output_handler=outputs.append)
+    src = """
+    sum(xs) = "# sum\\n\\nReturn total from `xs`.\\n\\n## Params\\n- xs: numbers\\n\\n\\n\\n## Examples\\n```genia\\nsum([]) -> 0\\n```" 0
+    help("sum")
+    """
+    run_source(src, env, filename="sum.genia")
+    out = "".join(outputs)
+    assert "sum/1" in out
+    assert "# sum" in out
+    assert "Return total from `xs`." in out
+    assert "## Params" in out
+    assert "- xs: numbers" in out
+    assert "```genia" in out
+    assert "sum([]) -> 0" in out
+    assert "\n\n\n" not in out
+
+
+def test_help_undocumented_function_fallback():
+    outputs: list[str] = []
+    env = make_global_env([], output_handler=outputs.append)
+    run_source("sum(xs) = 0\nhelp(\"sum\")\n", env, filename="sum.genia")
+    out = "".join(outputs)
+    assert "sum/1" in out
+    assert "No documentation available." in out
+
+
+def test_help_docstring_normalizes_triple_quote_wrappers_and_indentation():
+    outputs: list[str] = []
+    env = make_global_env([], output_handler=outputs.append)
+    src = r'''
+    sum(xs) = "\"\"\"\n        # sum\n\n          - xs: list of numbers\n    \"\"\"" 0
+    help("sum")
+    '''
+    run_source(src, env, filename="sum.genia")
+    out = "".join(outputs)
+    assert "# sum" in out
+    assert "- xs: list of numbers" in out


### PR DESCRIPTION
### Motivation
- Make docstrings first-class, terminal-friendly documentation by interpreting existing string docstrings as lightweight Markdown and improving the REPL `help` display. 
- Preserve existing semantics for named-function docstrings (single canonical docstring per function group, lambdas unaffected, conflicting-docstring errors) while providing clearer, readable output.

### Description
- Add a small formatter `src/genia/docstrings.py` implementing `normalize_docstring` / `render_markdown_docstring` to normalize indentation, trim outer blank lines and optional triple-quote wrappers, preserve fenced code blocks, collapse excessive blank lines, and keep headings/bullets/inline code intact.  
- Wire the renderer into the REPL: `make_global_env(...).help` now prints a concise signature header (`name/shape`), `Defined at file:line` when available, followed by rendered docstring text or the explicit fallback `No documentation available.` (changes in `src/genia/interpreter.py`).  
- Update tests in `tests/test_function_docstrings.py` to cover Markdown rendering (headings, bullets, inline code, fenced blocks), whitespace/triple-quote normalization, undocumented fallback, and to reflect the new `name/shape` and `Defined at` formatting.  
- Update source-of-truth docs and the book to match behavior (`GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, `docs/book/03-functions.md`).

### Testing
- Ran `pytest -q tests/test_function_docstrings.py` and the suite passed (`7 passed`).
- Ran `pytest -q tests/test_autoload.py tests/test_fn_stdlib.py` and those suites passed (`16 passed`).
- The changes are covered by the added/updated tests that assert docstring normalization, Markdown rendering, canonical docstring merging, conflicting-docstring error behavior, and undocumented fallback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cab1a5b974832985743dbedae206c3)