### PR TITLE
Add Phase 1 pipeline operator (`|>`) with parser-level call-rewrite

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -33,6 +33,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - literals: numbers, strings (single/double quotes + escapes, plus triple-quoted multiline strings), booleans, `nil`
 - variables and top-level assignment (`name = expr`)
 - unary/binary operators: `!`, unary `-`, `+ - * / %`, comparisons, equality, `&&`, `||`
+- pipeline operator (phase 1): `|>` with call-rewrite semantics (`x |> f` → `f(x)`, `x |> f(y)` → `f(y, x)`)
 - function definitions with expression body, block body, or case body
 - optional named-function docstring metadata:
   - `f(x) = """ ... """ x + 1` (multi-line Markdown docstring literal)
@@ -80,7 +81,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - module/import system
 - member access and indexing syntax
 - a language-level scheduler (concurrency is host-thread based)
-- general pipeline operator syntax
+- generalized flow semantics (lazy sequences, multi-output stages, backpressure, cancellation)
 
 ## Conditionals in Genia
 

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -82,8 +82,16 @@ Implemented operators are limited to:
 
 - unary: `-`, `!`
 - binary: `+ - * / % < <= > >= == != && ||`
+- pipeline: `|>`
 
-No implicit pipeline/member/index operators should be introduced without explicitly updating state/rules docs and tests.
+Pipeline rewrite invariant:
+
+- `x |> f` is equivalent to `f(x)`
+- `x |> f(y)` is equivalent to `f(y, x)` (append source value as final arg)
+- chaining is left-associative
+- this is expression-level call rewriting only (no stream runtime semantics)
+
+No additional member/index/flow operators should be introduced without explicitly updating state/rules docs and tests.
 
 ## 10) Ref + concurrency runtime guarantees
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -16,12 +16,20 @@ This file describes what is **actually implemented now** in the Python runtime.
 - function calls
 - unary operators: `-`, `!`
 - binary operators: `+ - * / % < <= > >= == != && ||`
+- pipeline operator: `|>`
 - block expressions: `{ ... }`
 - list literals: `[a, b, c]`
 - list spread in literals: `[..xs]`, `[1, ..xs, 2]`
 - call spread: `f(..xs)`
 - lambdas: `(x) -> x + 1`
 - varargs lambdas: `(..xs) -> xs`, `(a, ..rest) -> rest`
+
+Pipeline (Phase 1) rewrite model:
+
+- `x |> f` rewrites to `f(x)`
+- `x |> f(y)` rewrites to `f(y, x)` (left value appended as the last argument)
+- left associative: `a |> f |> g` rewrites to `g(f(a))`
+- no stream runtime semantics are added in this phase
 
 ## 3) Functions and dispatch
 
@@ -188,7 +196,7 @@ Implemented optimizations:
 - module/import syntax
 - member access syntax
 - index syntax
-- general pipeline operator syntax
+- generalized flow runtime semantics (lazy sequences, multi-output stages, backpressure, cancellation)
 - language-level scheduler/selective receive/timeouts (concurrency remains host-primitive based)
 
 ## 10) Example demos shipped in-repo

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ add(..[20, 22])
 - list literal spread is implemented
 - function call argument spread is implemented
 
+### Pipeline operator (Phase 1)
+
+```genia
+[1, 2, 3] |> map(inc)
+```
+
+- `x |> f` rewrites to `f(x)`
+- `x |> f(y)` rewrites to `f(y, x)` (append piped value as final argument)
+- left-associative chaining is supported (`a |> f |> g`)
+- this is expression-level composition only (not full flow runtime semantics)
+
 ### Concurrency and agents
 
 ```genia
@@ -177,7 +188,7 @@ agent_get(counter)
 - general host interop / FFI
 - module/import syntax
 - member access / indexing syntax
-- general pipeline operator syntax
+- generalized flow semantics (lazy sequences, multi-output stages, backpressure, cancellation)
 - language-level scheduler/event loop for simulations
 
 For stricter implementation details and invariants, see:

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -243,12 +243,63 @@ No documentation available.
 
 ---
 
+## Pipeline Operator (Phase 1)
+
+Genia now supports a minimal pipeline operator for left-to-right function composition:
+
+`left |> right`
+
+Rewrite rules (implemented):
+
+* `x |> f` becomes `f(x)`
+* `x |> f(y)` becomes `f(y, x)` (the piped value is appended as the final argument)
+* chaining is left-associative: `a |> f |> g` becomes `g(f(a))`
+
+### Minimal example
+
+```genia
+inc(x) = x + 1
+4 |> inc
+```
+
+Result:
+
+```genia
+5
+```
+
+### Edge case example
+
+```genia
+pair(a, b) = [a, b]
+9 |> pair(1)
+```
+
+Result:
+
+```genia
+[1, 9]
+```
+
+### Failure case example
+
+```genia
+1 |> 2
+```
+
+Expected behavior:
+
+* runtime `TypeError` because `2` is not callable.
+
+---
+
 ## Implementation Status
 
 ### ✅ Implemented
 
 * Named function definitions
 * Arity-based + varargs dispatch
+* Pipeline operator `|>` with expression-level call rewriting
 * Named-function docstring metadata (`f(...) = "doc" ...`)
 * `help(name)` output with:
   * signature header (`name/shape`)
@@ -260,8 +311,10 @@ No documentation available.
 
 * Markdown rendering is intentionally minimal and terminal-first (no full Markdown engine, no syntax highlighting)
 * Docstring parsing requires the docstring and body expression to be part of the same definition expression sequence (no dedicated block-doc syntax)
+* Pipeline is only call composition, not a full flow runtime model
 
 ### ❌ Not implemented
 
 * Lambda docstrings
 * Separate docstring keywords or block syntax
+* Generalized flow semantics (lazy streams, multi-output stages, backpressure, cancellation)

--- a/docs/book/05-lists.md
+++ b/docs/book/05-lists.md
@@ -58,6 +58,14 @@ Expected result:
 
 Order is preserved in output.
 
+Pipeline form (Phase 1):
+
+```genia
+[1, 2, 3] |> map(inc)
+```
+
+This works through the pipeline rewrite rule `x |> f(y)` → `f(y, x)`.
+
 ### Failure case example
 
 ```genia
@@ -165,4 +173,5 @@ Expected behavior:
 
 - lazy sequences
 - iterator protocol
+- flow-aware list pipelines (backpressure/cancellation/multi-output stages)
 - built-in map/filter syntax (helpers exist only as stdlib functions)

--- a/docs/book/10-concurrency.md
+++ b/docs/book/10-concurrency.md
@@ -51,3 +51,7 @@ Expected behavior:
 - language-level scheduler
 - selective receive
 - timeouts in message receive syntax
+- generalized flow runtime semantics (`|>` is expression-level composition only in Phase 1)
+- lazy sequences
+- multi-output flow stages
+- backpressure and cancellation

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -93,6 +93,7 @@ TOKEN_SPEC = [
     ("GE", r">="),
     ("AND", r"&&"),
     ("OR", r"\|\|"),
+    ("PIPE_FWD", r"\|>"),
     ("ASSIGN", r"="),
     ("LT", r"<"),
     ("GT", r">"),
@@ -127,6 +128,7 @@ PUNCTUATION_TOKENS = [
     ("GE", ">="),
     ("AND", "&&"),
     ("OR", "||"),
+    ("PIPE_FWD", "|>"),
     ("DOTDOT", ".."),
     ("ASSIGN", "="),
     ("LT", "<"),
@@ -876,6 +878,7 @@ def recursive_call_count(node: IrNode, fn_name: str) -> int:
 # -----------------------------
 
 PRECEDENCE = {
+    "PIPE_FWD": 5,
     "OR": 10,
     "AND": 20,
     "EQEQ": 30,
@@ -1314,8 +1317,17 @@ class Parser:
             op = tok.kind
             self.i += 1
             right = self.parse_expr(prec + 1)
-            left = Binary(left, op, right, span=self.merge_spans(left.span, right.span))
+            if op == "PIPE_FWD":
+                left = self.rewrite_pipeline(left, right)
+            else:
+                left = Binary(left, op, right, span=self.merge_spans(left.span, right.span))
         return left
+
+    def rewrite_pipeline(self, left: Node, right: Node) -> Call:
+        if isinstance(right, Call):
+            args = [*right.args, left]
+            return Call(right.fn, args, span=self.merge_spans(left.span, right.span))
+        return Call(right, [left], span=self.merge_spans(left.span, right.span))
 
     def parse_prefix(self) -> Node:
         tok = self.peek()

--- a/tests/test_lexer_symbols.py
+++ b/tests/test_lexer_symbols.py
@@ -31,3 +31,15 @@ def test_plus_and_slash_are_operators_but_hyphenated_names_are_identifiers():
         ("SLASH", "/"),
         ("IDENT", "name"),
     ]
+
+
+def test_pipeline_operator_tokenizes_as_pipe_fwd():
+    tokens = _kinds_texts("x |> f(y)")
+    assert tokens == [
+        ("IDENT", "x"),
+        ("PIPE_FWD", "|>"),
+        ("IDENT", "f"),
+        ("LPAREN", "("),
+        ("IDENT", "y"),
+        ("RPAREN", ")"),
+    ]

--- a/tests/test_pipeline_operator.py
+++ b/tests/test_pipeline_operator.py
@@ -1,0 +1,82 @@
+import pytest
+
+
+def test_pipeline_minimal_call(run):
+    src = """
+    inc(x) = x + 1
+    4 |> inc
+    """
+    assert run(src) == 5
+
+
+def test_pipeline_appends_left_value_to_existing_call_args(run):
+    src = """
+    pair(a, b) = [a, b]
+    9 |> pair(1)
+    """
+    assert run(src) == [1, 9]
+
+
+def test_pipeline_precedence_with_arithmetic(run):
+    src = """
+    double(x) = x * 2
+    1 + 2 |> double
+    """
+    assert run(src) == 6
+
+
+def test_pipeline_is_left_associative(run):
+    src = """
+    inc(x) = x + 1
+    double(x) = x * 2
+    3 |> inc |> double
+    """
+    assert run(src) == 8
+
+
+def test_pipeline_nested_in_call_argument(run):
+    src = """
+    inc(x) = x + 1
+    identity(x) = x
+    identity(1 |> inc)
+    """
+    assert run(src) == 2
+
+
+def test_pipeline_with_lambda_rhs(run):
+    src = """
+    4 |> ((x) -> x * x)
+    """
+    assert run(src) == 16
+
+
+def test_pipeline_with_block_rhs(run):
+    src = """
+    inc(x) = x + 1
+    9 |> { inc }
+    """
+    assert run(src) == 10
+
+
+def test_pipeline_with_list_helpers(run):
+    src = """
+    inc(x) = x + 1
+    [1, 2, 3] |> map(inc)
+    """
+    assert run(src) == [2, 3, 4]
+
+
+def test_pipeline_with_case_expression_still_rejected_in_subexpression(run):
+    src = """
+    id(x) = x
+    1 |> id((
+      1 -> 2
+    ))
+    """
+    with pytest.raises(SyntaxError):
+        run(src)
+
+
+def test_pipeline_failure_when_rhs_is_not_callable(run):
+    with pytest.raises(TypeError):
+        run("1 |> 2")


### PR DESCRIPTION
### Motivation

- Introduce a minimal, orthogonal pipeline operator as Phase 1 of a Flow model while keeping language surface area and invariants small. 
- Provide left-to-right call composition without adding stream/runtime flow semantics yet. 
- Preserve existing case-expression and `->` parsing invariants and avoid any conditional keywords or list-spread changes. 

### Description

- Add a new lexer/token `PIPE_FWD` for the `|>` token and register it in `PUNCTUATION_TOKENS`. 
- Add low precedence binding for `PIPE_FWD` (`PRECEDENCE[

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbddf1760883298b50ff327ff725ff)