### PR TITLE
Avoid duplicate reduce/3 autoload collision by renaming math helper and adding regression test

### DIFF
--- a/std/prelude/math.genia
+++ b/std/prelude/math.genia
@@ -49,9 +49,9 @@ max_impl(a, b) =
   (a, b) ? a >= b -> a |
   (a, b) -> b
 
-reduce(f, acc, xs) =
+sum_reduce(f, acc, xs) =
   (f, acc, []) -> acc |
-  (f, acc, [x, ..rest]) -> reduce(f, f(acc, x), rest)
+  (f, acc, [x, ..rest]) -> sum_reduce(f, f(acc, x), rest)
 
 sum(xs) = """
 # sum
@@ -63,4 +63,4 @@ Add all numeric elements of a list.
 ```genia
 sum([1, 2, 3, 4]) -> 10
 ```
-""" reduce((acc, x) -> acc + x, 0, xs)
+""" sum_reduce((acc, x) -> acc + x, 0, xs)

--- a/tests/test_autoload.py
+++ b/tests/test_autoload.py
@@ -39,6 +39,12 @@ def test_autoload_math_helpers():
     assert run_with_env("abs(-9)") == 9
 
 
+def test_autoload_math_then_list_no_duplicate_function_error():
+    env = make_global_env([])
+    assert run_source("inc(1)", env) == 2
+    assert run_source("[1, 2, 3] |> map(inc)", env) == [2, 3, 4]
+
+
 def test_autoload_awkify():
     src = """
     odd_rows(n, row) =


### PR DESCRIPTION
### Motivation
- Autoloading `inc` could load `std/prelude/math.genia` which defined a `reduce/3` helper that collided with `std/prelude/list.genia`'s `reduce/3`, producing `TypeError: Duplicate function definition: reduce/3` when the list prelude was autoloaded later.

### Description
- Rename the recursive helper `reduce/3` to `sum_reduce/3` in `std/prelude/math.genia` and update `sum/1` to call `sum_reduce/3` to preserve behavior while removing the name collision.
- Add a regression test `test_autoload_math_then_list_no_duplicate_function_error` to `tests/test_autoload.py` that runs `inc(1)` then `[1, 2, 3] |> map(inc)` in the same environment to ensure no duplicate-definition error occurs.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_autoload.py tests/test_pipeline_operator.py` and the test suite completed successfully (`23 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe207b4d48329a62ab2084b35e5fe)