### PR TITLE
Add -c/--command support for inline Genia source execution

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -16,6 +16,12 @@ Run a program file:
 python3 -m genia.interpreter path/to/file.genia
 ```
 
+Run a command string:
+
+```bash
+python3 -m genia.interpreter -c "[1,2,3] |> count"
+```
+
 Run the ants demo:
 
 ```bash

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -8,6 +8,10 @@ This file describes what is **actually implemented now** in the Python runtime.
 - top-level assignment is supported (`name = expr`)
 - blocks evaluate expressions in order and return the last value
 - no statement/declaration split at runtime level
+- CLI entry points support three execution modes:
+  - file mode: `genia path/to/file.genia`
+  - command mode: `genia -c "expr_or_program_source"`
+  - REPL mode: `genia` (no file/command arguments)
 
 ## 2) Implemented syntax and expression forms
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Run a program:
 python3 -m genia.interpreter path/to/program.genia
 ```
 
+Run inline source from the command line:
+
+```bash
+genia -c "[1,2,3] |> count"
+```
+
 Run the ants demo:
 
 ```bash

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2673,13 +2673,25 @@ def run_debug_stdio(
 def _main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(prog="genia.interpreter")
     parser.add_argument("program", nargs="?")
+    parser.add_argument("-c", "--command")
     parser.add_argument("--debug-stdio", action="store_true")
     args = parser.parse_args(argv)
+
+    if args.program is not None and args.command is not None:
+        parser.error("program path and --command cannot be used together")
 
     if args.debug_stdio:
         if args.program is None:
             parser.error("--debug-stdio requires a program path")
+        if args.command is not None:
+            parser.error("--debug-stdio cannot be used with --command")
         return run_debug_stdio(args.program)
+    if args.command is not None:
+        env = make_global_env()
+        result = run_source(args.command, env, filename="<command>")
+        if result is not None:
+            print(format_debug(result))
+        return 0
     if args.program is not None:
         env = make_global_env()
         with open(args.program, "r", encoding="utf-8") as f:

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -1,0 +1,20 @@
+import pytest
+
+from genia.interpreter import _main
+
+
+def test_command_flag_executes_source_and_prints_result(capsys):
+    exit_code = _main(["-c", "[1,2,3] |> count"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "3"
+
+
+def test_command_flag_rejects_program_path_combination():
+    with pytest.raises(SystemExit):
+        _main(["examples/ants.genia", "-c", "1 + 1"])
+
+
+def test_command_flag_rejects_debug_stdio_combination():
+    with pytest.raises(SystemExit):
+        _main(["--debug-stdio", "-c", "1 + 1"])


### PR DESCRIPTION
### Motivation

- Provide a simple CLI mode to execute a small Genia program or expression passed as a string so the tool can be used like `genia -c "[1,2,3] |> count"`.
- Keep CLI behavior explicit and reject ambiguous combinations of modes (file path, debug stdio, and inline command).

### Description

- Add a `-c/--command` argument to the CLI handler in `src/genia/interpreter.py` and execute the provided source with `run_source(..., filename="<command>")`.
- Validate argument combinations and raise parser errors if `program` and `--command` are used together or if `--debug-stdio` is combined with `--command`.
- Print the evaluated result (via `format_debug`) and exit when running in command mode.
- Add `tests/test_cli_args.py` covering successful `-c` execution and invalid argument combinations, and update `README.md`, `GENIA_REPL_README.md`, and `GENIA_STATE.md` to document the new CLI mode.

### Testing

- Ran `pytest -q tests/test_cli_args.py tests/test_smoke.py`, all tests passed (`5 passed`).
- New CLI tests exercise: successful `-c` execution output, `program + -c` rejection, and `--debug-stdio + -c` rejection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe789b100832985a0727a4d25ad8f)