### PR TITLE
Add minimal bytes/JSON/ZIP host bridge and pipeline-friendly zip rewrite helpers

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -70,6 +70,11 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - concurrency: `spawn`, `send`, `process_alive?`
   - phase-1 persistent associative maps: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
   - simulation primitives (phase 2): `rand`, `rand_int`, `sleep`
+  - bytes/json/zip bridge builtins (phase 1):
+    - `utf8_encode`, `utf8_decode`
+    - `json_parse`, `json_pretty`
+    - `zip_entries`, `zip_write`
+    - `entry_name`, `entry_bytes`, `set_entry_bytes`, `update_entry_bytes`, `entry_json`
   - strings: `byte_length`, `is_empty`, `concat`, `contains`, `starts_with`, `ends_with`, `find`, `split`, `split_whitespace`, `join`, `trim`, `trim_start`, `trim_end`, `lower`, `upper`
   - constants: `pi`, `e`, `true`, `false`, `nil`
 
@@ -88,6 +93,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - member access and indexing syntax
 - a language-level scheduler (concurrency is host-thread based)
 - generalized flow semantics (lazy sequences, multi-output stages, backpressure, cancellation)
+- full Flow runtime system (stages/sinks/backpressure/cancellation/multi-port stages)
 
 ## Conditionals in Genia
 
@@ -106,6 +112,17 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - `ValueError` when `ms < 0`
 
 These are blocking builtins only; they do not introduce scheduler/async runtime behavior.
+
+## Bytes / JSON / ZIP bridge semantics
+
+- `utf8_encode(string)` returns an opaque bytes wrapper value.
+- `utf8_decode(bytes)` decodes UTF-8 and raises `ValueError` for invalid byte sequences.
+- `json_parse(string)` parses JSON and raises `ValueError` for invalid JSON text.
+  - JSON objects become runtime map values (same family used by `map_new`/`map_put`).
+- `json_pretty(value)` renders deterministic pretty JSON (`indent=2`, sorted keys).
+- `zip_entries(path)` returns an eager list of zip entry wrapper values in archive order.
+- `zip_write(entries, path)` writes entries in order and returns `path`.
+  - It also accepts `(path, entries)` to stay pipeline-friendly with current `|>` rewrite behavior.
 
 ## Demo note: ants simulation example
 

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -122,7 +122,22 @@ No additional member/index/flow operators should be introduced without explicitl
 - `rand_int(n)` requires a positive integer `n`, returns integer in `[0, n)`
 - `sleep(ms)` requires a non-negative number and blocks current execution for `ms` milliseconds
 - these are simple runtime builtins only: no scheduler, no async/await, no event loop, no new syntax
-## 14) Documentation + tests as contract
+
+## 14) Bytes / JSON / ZIP bridge invariants (host-backed only)
+
+- bytes are runtime wrapper values (not string/list aliases)
+- zip entries are runtime wrapper values with name + bytes payload
+- required builtins:
+  - `utf8_decode`, `utf8_encode`
+  - `json_parse`, `json_pretty`
+  - `zip_entries`, `zip_write`
+  - `entry_name`, `entry_bytes`, `set_entry_bytes`, `update_entry_bytes`, `entry_json`
+- `zip_entries(path)` returns an eager list in this phase (not lazy flow semantics)
+- `zip_write` preserves the order of entries it receives
+- `json_parse` returns runtime map values for JSON objects
+- this bridge does not introduce a generalized Flow system
+
+## 15) Documentation + tests as contract
 
 When changing syntax/semantics/runtime behavior, update together:
 
@@ -132,7 +147,7 @@ When changing syntax/semantics/runtime behavior, update together:
 - `README.md` for user-visible behavior
 - corresponding tests under `tests/`
 
-## 15) Conditional model invariant
+## 16) Conditional model invariant
 
 - Genia has no conditional keyword (`if` or `switch`)
 - branching is expressed only through pattern matching

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -144,6 +144,29 @@ Behavior:
 - `trim`, `trim_start`, `trim_end`
 - `lower`, `upper`
 
+### Bytes / JSON / ZIP bridge builtins (Phase 1, host-backed)
+
+- `utf8_decode(bytes) -> string`
+- `utf8_encode(string) -> bytes`
+- `json_parse(string) -> value`
+- `json_pretty(value) -> string`
+- `zip_entries(path) -> list of zip entries`
+- `zip_write(entries, path) -> path` (also accepts `(path, entries)` for pipeline ergonomics)
+- `entry_name(entry) -> string`
+- `entry_bytes(entry) -> bytes`
+- `set_entry_bytes(entry, new_bytes) -> entry`
+- `update_entry_bytes(entry, f) -> entry`
+- `entry_json(entry) -> bool`
+
+Behavior:
+
+- bytes are opaque runtime wrappers (`<bytes N>`)
+- zip entries are opaque runtime wrappers (`<zip-entry ...>`) containing entry name + bytes payload
+- `zip_entries` currently returns a strict list (Phase 1) and preserves entry order
+- JSON objects from `json_parse` are represented as persistent runtime map values (`map_*` bridge type)
+- `json_pretty` currently emits deterministic pretty JSON with 2-space indentation and sorted object keys
+- this is a minimal host-backed bridge and is **not** the full flow system
+
 ### Simulation primitives (Phase 2, host-backed builtins)
 
 - `rand()`
@@ -201,6 +224,7 @@ Implemented optimizations:
 - member access syntax
 - index syntax
 - generalized flow runtime semantics (lazy sequences, multi-output stages, backpressure, cancellation)
+- full Flow system (stages/sinks/backpressure/multi-port pipelines)
 - language-level scheduler/selective receive/timeouts (concurrency remains host-primitive based)
 
 ## 10) Example demos shipped in-repo

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ pytest -q
 - Host-backed reference (`ref`)
 - Host-backed process handle (`spawn`)
 - Host-backed persistent associative map (`map_new`, `map_put`, ...)
+- Host-backed bytes wrapper
+- Host-backed zip entry wrapper
 
 ### Functions and lambdas
 
@@ -174,6 +176,18 @@ agent_get(counter)
 - `sleep(ms)` blocks for `ms` milliseconds
 - intentionally simple: no scheduler, no async/await, no event loop
 
+### Bytes / JSON / ZIP bridge builtins (Phase 1)
+
+- `utf8_encode(string) -> bytes`
+- `utf8_decode(bytes) -> string`
+- `json_parse(string) -> value` (objects become runtime map values)
+- `json_pretty(value) -> string`
+- `zip_entries(path) -> list of zip entries`
+- `zip_write(entries, path) -> path` (also accepts `(path, entries)` for pipeline style)
+- `entry_name(entry)`, `entry_bytes(entry)`, `set_entry_bytes(entry, bytes)`, `update_entry_bytes(entry, f)`, `entry_json(entry)`
+
+This is a minimal host-backed bridge for pipeline-first archive transforms; it is **not** the full Flow runtime system.
+
 ### Phase 1 persistent associative maps
 
 - `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
@@ -195,6 +209,7 @@ agent_get(counter)
 - module/import syntax
 - member access / indexing syntax
 - generalized flow semantics (lazy sequences, multi-output stages, backpressure, cancellation)
+- full Flow system (stages/sinks/backpressure/multi-port pipelines)
 - language-level scheduler/event loop for simulations
 
 For stricter implementation details and invariants, see:

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -13,6 +13,8 @@ Genia currently supports these runtime value families:
 - refs (`ref`)
 - process handles (`spawn`)
 - **phase-1 host-backed persistent associative maps** (`map_new`, `map_put`, ...)
+- **phase-1 host-backed bytes wrappers** (`utf8_encode`, `utf8_decode`)
+- **phase-1 host-backed zip entry wrappers** (`zip_entries`, `entry_*`, `zip_write`)
 
 This chapter focuses on the map bridge because it is the newest core data capability.
 
@@ -112,6 +114,83 @@ Expected behavior:
 - map pattern matching
 - member/index syntax for maps
 - general host interop / FFI
+
+---
+
+## Bytes / JSON / ZIP bridge (phase 1)
+
+Genia now includes a minimal host-backed bridge for byte-safe JSON rewriting inside zip archives.
+
+Flat pipeline-friendly API (no member/dot syntax):
+
+- `utf8_encode(string) -> bytes`
+- `utf8_decode(bytes) -> string`
+- `json_parse(string) -> value`
+- `json_pretty(value) -> string`
+- `zip_entries(path) -> list of zip entries`
+- `zip_write(entries, path) -> path`
+- `entry_name(entry)`, `entry_bytes(entry)`, `set_entry_bytes(entry, bytes)`, `update_entry_bytes(entry, f)`, `entry_json(entry)`
+
+### Minimal example
+
+```genia
+format_json_bytes(bytes) =
+  compose(utf8_encode, json_pretty, json_parse, utf8_decode)(bytes)
+```
+
+### Edge case example
+
+```genia
+rewrite_entry(entry) =
+  entry ? entry_json(entry) -> update_entry_bytes(entry, format_json_bytes) |
+  _ -> entry
+```
+
+Expected behavior:
+
+- `entry_json(entry)` true: bytes are reformatted JSON
+- `entry_json(entry)` false: bytes are unchanged
+
+### Failure case examples
+
+```genia
+utf8_decode("not-bytes")
+```
+
+Expected behavior:
+
+- raises `TypeError` (`utf8_decode expected bytes`)
+
+And:
+
+```genia
+json_parse("{\"x\":")
+```
+
+Expected behavior:
+
+- raises `ValueError` with parse location details
+
+### Implementation status
+
+### ✅ Implemented
+
+- opaque bytes runtime wrapper values
+- opaque zip entry runtime wrapper values
+- UTF-8 encode/decode builtins
+- JSON parse/pretty builtins
+- zip read/write builtins with preserved entry order
+- JSON objects mapped to runtime map values
+
+### ⚠️ Partial
+
+- `zip_entries` is eager list-based in this phase (not lazy sequences)
+- `zip_write` supports both `(entries, path)` and `(path, entries)` to stay compatible with current pipeline rewrite shape
+
+### ❌ Not implemented
+
+- full Flow runtime (stages, backpressure, cancellation, multi-port stages)
+- stream-native zip processing or lazy archive sequences
 
 ---
 

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -281,6 +281,11 @@ Result:
 [1, 9]
 ```
 
+Pipeline-friendly API design note:
+
+- With current rewrite semantics (`x |> f(y)` => `f(y, x)`), functions that are commonly terminal pipeline steps often use destination/config args first.
+- Example: `entries |> zip_write("out.zip")` calls `zip_write("out.zip", entries)` in this phase.
+
 ### Failure case example
 
 ```genia

--- a/docs/book/05-lists.md
+++ b/docs/book/05-lists.md
@@ -175,3 +175,42 @@ Expected behavior:
 - iterator protocol
 - flow-aware list pipelines (backpressure/cancellation/multi-output stages)
 - built-in map/filter syntax (helpers exist only as stdlib functions)
+
+---
+
+## List-based archive pipelines (Phase 1 bridge)
+
+`zip_entries(path)` currently returns a **list**, so existing list helpers (`map`, `filter`, `count`) work directly.
+
+### Minimal example
+
+```genia
+zip_entries("in.zip")
+  |> map(entry_name)
+```
+
+Expected result:
+
+- list of entry names in archive order
+
+### Edge case example
+
+```genia
+zip_entries("in.zip")
+  |> map((e) -> e ? entry_json(e) -> entry_name(e) | _ -> nil)
+```
+
+Expected behavior:
+
+- preserves list ordering
+- emits `nil` for non-JSON entries
+
+### Failure case example
+
+```genia
+zip_entries("missing.zip")
+```
+
+Expected behavior:
+
+- raises clear file error for unreadable/missing archive path

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -37,9 +37,11 @@ from __future__ import annotations
 import math
 import os
 import bisect
+import json
 import queue
 import random
 import time
+import zipfile
 from pathlib import Path
 import argparse
 import re
@@ -1716,6 +1718,23 @@ class GeniaProcess:
         return f"<process {status}>"
 
 
+class GeniaBytes:
+    def __init__(self, value: bytes):
+        self.value = value
+
+    def __repr__(self) -> str:
+        return f"<bytes {len(self.value)}>"
+
+
+class GeniaZipEntry:
+    def __init__(self, name: str, data: GeniaBytes):
+        self.name = name
+        self.data = data
+
+    def __repr__(self) -> str:
+        return f"<zip-entry {self.name!r} {len(self.data.value)}>"
+
+
 def eval_with_tco(
     fn: Any,
     args: tuple[Any, ...],
@@ -2180,6 +2199,42 @@ def make_global_env(
             raise TypeError(f"{name} expected a string")
         return value
 
+    def _ensure_bytes(value: Any, name: str) -> GeniaBytes:
+        if not isinstance(value, GeniaBytes):
+            raise TypeError(f"{name} expected bytes")
+        return value
+
+    def _ensure_zip_entry(value: Any, name: str) -> GeniaZipEntry:
+        if not isinstance(value, GeniaZipEntry):
+            raise TypeError(f"{name} expected a zip entry")
+        return value
+
+    def _json_from_runtime(value: Any) -> Any:
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, list):
+            return [_json_from_runtime(item) for item in value]
+        if isinstance(value, GeniaMap):
+            data: dict[str, Any] = {}
+            for _, (original_key, original_value) in value._entries.items():
+                if not isinstance(original_key, str):
+                    raise TypeError("json_pretty expected object keys to be strings")
+                data[original_key] = _json_from_runtime(original_value)
+            return data
+        raise TypeError(f"json_pretty expected a JSON-compatible value, got {type(value).__name__}")
+
+    def _json_to_runtime(value: Any) -> Any:
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, list):
+            return [_json_to_runtime(item) for item in value]
+        if isinstance(value, dict):
+            result = GeniaMap()
+            for k, v in value.items():
+                result = result.put(k, _json_to_runtime(v))
+            return result
+        raise TypeError(f"json_parse produced unsupported host value: {type(value).__name__}")
+
     def byte_length_fn(value: Any) -> int:
         return utf8_byte_length(_ensure_string(value, "byte_length"))
 
@@ -2375,6 +2430,19 @@ Simulation primitives (host-backed builtins):
   rand()                float in [0, 1)
   rand_int(n)           integer in [0, n), n must be a positive integer
   sleep(ms)             block for ms milliseconds
+
+Bytes / JSON / ZIP builtins (host-backed runtime bridge):
+  utf8_encode(string)        bytes wrapper
+  utf8_decode(bytes)         string
+  json_parse(string)         runtime value (objects become map values)
+  json_pretty(value)         stable pretty JSON string
+  zip_entries(path)          list of zip entries
+  zip_write(entries, path)   writes zip and returns path
+  entry_name(entry)
+  entry_bytes(entry)
+  set_entry_bytes(entry, bytes)
+  update_entry_bytes(entry, updater)
+  entry_json(entry)
 """.strip()
         )
 
@@ -2473,6 +2541,91 @@ Simulation primitives (host-backed builtins):
         time.sleep(ms / 1000.0)
         return None
 
+    def utf8_encode_fn(value: Any) -> GeniaBytes:
+        text = _ensure_string(value, "utf8_encode")
+        return GeniaBytes(text.encode("utf-8"))
+
+    def utf8_decode_fn(value: Any) -> str:
+        encoded = _ensure_bytes(value, "utf8_decode")
+        try:
+            return encoded.value.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(f"utf8_decode invalid UTF-8: {exc}") from exc
+
+    def json_parse_fn(value: Any) -> Any:
+        text = _ensure_string(value, "json_parse")
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"json_parse invalid JSON: {exc.msg} at line {exc.lineno} column {exc.colno}") from exc
+        return _json_to_runtime(parsed)
+
+    def json_pretty_fn(value: Any) -> str:
+        return json.dumps(_json_from_runtime(value), indent=2, ensure_ascii=False, sort_keys=True)
+
+    def zip_entries_fn(path: Any) -> list[GeniaZipEntry]:
+        zip_path = _ensure_string(path, "zip_entries")
+        try:
+            with zipfile.ZipFile(zip_path, "r") as archive:
+                entries: list[GeniaZipEntry] = []
+                for info in archive.infolist():
+                    if info.is_dir():
+                        continue
+                    entries.append(GeniaZipEntry(info.filename, GeniaBytes(archive.read(info.filename))))
+                return entries
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"zip_entries could not read zip file: {zip_path}") from exc
+        except zipfile.BadZipFile as exc:
+            raise ValueError(f"zip_entries invalid zip archive: {zip_path}") from exc
+        except OSError as exc:
+            raise OSError(f"zip_entries could not read zip file: {zip_path}") from exc
+
+    def entry_name_fn(entry: Any) -> str:
+        return _ensure_zip_entry(entry, "entry_name").name
+
+    def entry_bytes_fn(entry: Any) -> GeniaBytes:
+        return _ensure_zip_entry(entry, "entry_bytes").data
+
+    def set_entry_bytes_fn(entry: Any, new_bytes: Any) -> GeniaZipEntry:
+        zip_entry = _ensure_zip_entry(entry, "set_entry_bytes")
+        data = _ensure_bytes(new_bytes, "set_entry_bytes")
+        return GeniaZipEntry(zip_entry.name, data)
+
+    def update_entry_bytes_fn(entry: Any, updater: Any) -> GeniaZipEntry:
+        zip_entry = _ensure_zip_entry(entry, "update_entry_bytes")
+        if not callable(updater):
+            raise TypeError("update_entry_bytes expected a function as second argument")
+        next_data = updater(zip_entry.data)
+        if not isinstance(next_data, GeniaBytes):
+            raise TypeError("update_entry_bytes updater must return bytes")
+        return GeniaZipEntry(zip_entry.name, next_data)
+
+    def entry_json_fn(entry: Any) -> bool:
+        zip_entry = _ensure_zip_entry(entry, "entry_json")
+        return zip_entry.name.lower().endswith(".json")
+
+    def zip_write_fn(first: Any, second: Any) -> str:
+        if isinstance(first, str) and isinstance(second, list):
+            out_path = first
+            entries = second
+        elif isinstance(first, list) and isinstance(second, str):
+            entries = first
+            out_path = second
+        else:
+            raise TypeError("zip_write expected (entries, path) or (path, entries)")
+
+        for item in entries:
+            if not isinstance(item, GeniaZipEntry):
+                raise TypeError("zip_write expected a list of zip entries")
+
+        try:
+            with zipfile.ZipFile(out_path, "w") as archive:
+                for item in entries:
+                    archive.writestr(item.name, item.data.value)
+        except OSError as exc:
+            raise OSError(f"zip_write could not write zip file: {out_path}") from exc
+        return out_path
+
     env.set("log", log)
     env.set("print", print_fn)
     env.set("input", input_fn)
@@ -2515,6 +2668,17 @@ Simulation primitives (host-backed builtins):
     env.set("trim_end", trim_end_fn)
     env.set("lower", lower_fn)
     env.set("upper", upper_fn)
+    env.set("utf8_decode", utf8_decode_fn)
+    env.set("utf8_encode", utf8_encode_fn)
+    env.set("json_parse", json_parse_fn)
+    env.set("json_pretty", json_pretty_fn)
+    env.set("zip_entries", zip_entries_fn)
+    env.set("zip_write", zip_write_fn)
+    env.set("entry_name", entry_name_fn)
+    env.set("entry_bytes", entry_bytes_fn)
+    env.set("set_entry_bytes", set_entry_bytes_fn)
+    env.set("update_entry_bytes", update_entry_bytes_fn)
+    env.set("entry_json", entry_json_fn)
 
     env.register_autoload("list", 0, "std/prelude/list.genia")
     env.register_autoload("first", 1, "std/prelude/list.genia")

--- a/tests/test_zip_json_pipeline.py
+++ b/tests/test_zip_json_pipeline.py
@@ -1,0 +1,111 @@
+import zipfile
+
+import pytest
+
+from genia import make_global_env, run_source
+from genia.interpreter import GeniaBytes, GeniaZipEntry
+
+
+def _run(src: str):
+    env = make_global_env([])
+    return run_source(src, env)
+
+
+def test_utf8_round_trip():
+    src = """
+    utf8_decode(utf8_encode("hello 漢字 🙂"))
+    """
+    assert _run(src) == "hello 漢字 🙂"
+
+
+def test_json_pretty_from_parsed_json():
+    src = r"""
+    json_pretty(json_parse("{\"b\":2,\"a\":1}"))
+    """
+    assert _run(src) == '{\n  "a": 1,\n  "b": 2\n}'
+
+
+def test_zip_rewrite_happy_path_with_pipeline_and_order(tmp_path):
+    in_zip = tmp_path / "in.zip"
+    out_zip = tmp_path / "out.zip"
+
+    with zipfile.ZipFile(in_zip, "w") as zf:
+        zf.writestr("a.json", '{"z":1,"a":2}')
+        zf.writestr("notes.txt", b"raw\x00bytes")
+        zf.writestr("b.json", '{"x":[3,2,1]}')
+
+    env = make_global_env([])
+    env.set("in_path", str(in_zip))
+    env.set("out_path", str(out_zip))
+    src = """
+    rewrite_entry(entry) =
+      entry ? entry_json(entry) -> update_entry_bytes(entry, compose(utf8_encode, json_pretty, json_parse, utf8_decode)) |
+      _ -> entry
+
+    rewrite_zip(in_path, out_path) =
+      zip_entries(in_path) |> map(rewrite_entry) |> zip_write(out_path)
+
+    rewrite_zip(in_path, out_path)
+    """
+    assert run_source(src, env) == str(out_zip)
+
+    with zipfile.ZipFile(out_zip, "r") as zf:
+        names = [info.filename for info in zf.infolist() if not info.is_dir()]
+        assert names == ["a.json", "notes.txt", "b.json"]
+        assert zf.read("a.json").decode("utf-8") == '{\n  "a": 2,\n  "z": 1\n}'
+        assert zf.read("notes.txt") == b"raw\x00bytes"
+        assert zf.read("b.json").decode("utf-8") == '{\n  "x": [\n    3,\n    2,\n    1\n  ]\n}'
+
+
+def test_invalid_json_failure_is_clear_and_deterministic(tmp_path):
+    in_zip = tmp_path / "bad_json.zip"
+    out_zip = tmp_path / "out.zip"
+    with zipfile.ZipFile(in_zip, "w") as zf:
+        zf.writestr("bad.json", '{"x":')
+
+    env = make_global_env([])
+    env.set("in_path", str(in_zip))
+    env.set("out_path", str(out_zip))
+    src = """
+    rewrite_entry(entry) =
+      entry ? entry_json(entry) -> update_entry_bytes(entry, compose(utf8_encode, json_pretty, json_parse, utf8_decode)) |
+      _ -> entry
+
+    zip_entries(in_path) |> map(rewrite_entry) |> zip_write(out_path)
+    """
+    with pytest.raises(ValueError, match=r"json_parse invalid JSON"):
+        run_source(src, env)
+
+
+def test_invalid_utf8_failure_is_clear_and_deterministic():
+    env = make_global_env([])
+    env.set("bad", GeniaBytes(b"\xff\xfe"))
+    with pytest.raises(ValueError, match=r"utf8_decode invalid UTF-8"):
+        run_source("utf8_decode(bad)", env)
+
+
+def test_type_errors_for_wrong_argument_types():
+    with pytest.raises(TypeError, match="utf8_encode expected a string"):
+        _run("utf8_encode(123)")
+    with pytest.raises(TypeError, match="zip_entries expected a string"):
+        _run("zip_entries(123)")
+    with pytest.raises(TypeError, match="entry_name expected a zip entry"):
+        _run("entry_name(123)")
+    env = make_global_env([])
+    env.set("entry", GeniaZipEntry("x.json", GeniaBytes(b"{}")))
+    with pytest.raises(TypeError, match="update_entry_bytes expected a function as second argument"):
+        run_source("update_entry_bytes(entry, 1)", env)
+
+
+def test_zip_entries_missing_and_invalid_archive_errors(tmp_path):
+    missing = tmp_path / "missing.zip"
+    env = make_global_env([])
+    env.set("missing", str(missing))
+    with pytest.raises(FileNotFoundError, match="zip_entries could not read zip file"):
+        run_source("zip_entries(missing)", env)
+
+    bad_zip = tmp_path / "bad.zip"
+    bad_zip.write_bytes(b"not-a-zip")
+    env.set("bad_zip", str(bad_zip))
+    with pytest.raises(ValueError, match="zip_entries invalid zip archive"):
+        run_source("zip_entries(bad_zip)", env)


### PR DESCRIPTION
### Motivation
- Provide the minimal stdlib/runtime slice required to support pipeline-first zip-entry JSON rewriting without adding Flow semantics. 
- Expose a flat, no-dot API that is pipeline-friendly and keeps archive entry values opaque to the runtime. 
- Keep the implementation minimal and host-backed, reusing the existing `map_*` bridge for JSON objects and preserving Genia’s pattern-matching-first philosophy. 

### Description
- Add opaque runtime wrappers `GeniaBytes` and `GeniaZipEntry` and register host-backed builtins: `utf8_encode`, `utf8_decode`, `json_parse`, `json_pretty`, `zip_entries`, `zip_write`, `entry_name`, `entry_bytes`, `set_entry_bytes`, `update_entry_bytes`, and `entry_json` in `src/genia/interpreter.py`.
- Represent JSON objects parsed by `json_parse` as the existing runtime `GeniaMap` values and implement `json_pretty` to emit deterministic pretty JSON (`indent=2`, `sort_keys=True`) while validating keys are strings.
- Implement `zip_entries(path)` to return a strict list of `GeniaZipEntry` preserving archive order and `zip_write(entries, path)` to write entries in order; `zip_write` accepts `(entries, path)` or `(path, entries)` to be pipeline-friendly with the current `|>` rewrite model.
- Add deterministic error handling and messages for invalid UTF-8 (`utf8_decode`), invalid JSON (`json_parse`), unreadable/missing zip files, invalid zip archives, and type-mismatch argument errors for the new builtins; keep API flat and avoid new syntax.
- Update documentation and state files: `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and book chapters `docs/book/01-core-data.md`, `docs/book/03-functions.md`, and `docs/book/05-lists.md` to reflect implemented behavior, limitations (Phase‑1 bridge, eager `zip_entries` list), examples, edge cases, and failure examples.

### Testing
- Added `tests/test_zip_json_pipeline.py` with focused tests for UTF-8 roundtrip, JSON pretty printing, zip read/write happy path, mixed JSON/non-JSON entries, entry-order preservation, invalid JSON/UTF-8 failure cases, and type errors for wrong argument types; these tests exercise the pipeline-style rewrite use case.
- Ran targeted test subset: `pytest -q tests/test_zip_json_pipeline.py tests/test_pipeline_operator.py tests/test_strings_utf8.py tests/test_maps.py` and the full test suite: `pytest -q`; all tests passed (`239 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbf701cf188329ad495d50ed3b64d2)