### PR TITLE
docs: sync README and book with implemented pipeline and zip/json bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,20 @@ agent_get(counter)
 
 This is a minimal host-backed bridge for pipeline-first archive transforms; it is **not** the full Flow runtime system.
 
+Example archive rewrite pipeline (list-based in this phase):
+
+```genia
+rewrite_entry(entry) =
+  entry ? entry_json(entry) ->
+    update_entry_bytes(entry, compose(utf8_encode, json_pretty, json_parse, utf8_decode)) |
+  _ -> entry
+
+rewrite_zip(in_path, out_path) =
+  zip_entries(in_path)
+    |> map(rewrite_entry)
+    |> zip_write(out_path)
+```
+
 ### Phase 1 persistent associative maps
 
 - `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -16,7 +16,7 @@ Genia currently supports these runtime value families:
 - **phase-1 host-backed bytes wrappers** (`utf8_encode`, `utf8_decode`)
 - **phase-1 host-backed zip entry wrappers** (`zip_entries`, `entry_*`, `zip_write`)
 
-This chapter focuses on the map bridge because it is the newest core data capability.
+This chapter covers the current Phase-1 host-backed core-data bridges (maps, bytes, and zip entries), starting with maps.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Align the top-level documentation and book chapters with the actual, implemented Phase-1 pipeline (`|>`) and bytes/json/zip bridge builtins so docs reflect runtime truth.
- Remove stale wording that implied the pipeline or bytes/json/zip features were unimplemented or that the chapter only focused on the map bridge.
- Preserve a clear and truthful boundary that this is a Phase-1 host-backed bridge and not the full Flow runtime with backpressure, sinks, or multi-port stages.

### Description
- Added a concrete archive rewrite example to `README.md` demonstrating the pipeline operator `|>` with `zip_entries`, `map`, `zip_write`, `entry_json`, `update_entry_bytes`, `utf8_encode`, `utf8_decode`, `json_parse`, and `json_pretty` to show an executable-style usage pattern.
- Updated `docs/book/01-core-data.md` intro to describe the current Phase-1 host-backed core-data bridges (maps, bytes, and zip entries) instead of implying only the map bridge is new.
- Cross-checked `README.md` against `GENIA_STATE.md`, `GENIA_REPL_README.md`, and `GENIA_RULES.md` for consistency and made no runtime or language-semantic changes in this pass.

### Testing
- Ran `pytest -q tests/test_pipeline_operator.py tests/test_zip_json_pipeline.py` which passed (`17 passed in 0.18s`).
- Executed ripgrep consistency scans across `README.md`, `GENIA_STATE.md`, `GENIA_REPL_README.md`, `GENIA_RULES.md`, and `docs/book/01-core-data.md` to verify the listed builtins and `|>` are documented and that no remaining statements falsely claim `|>` is unimplemented.
- No automated tests failed and no runtime behavior was modified during this documentation sync.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc022b4c4083299377a025155e38da)