### PR TITLE
Add list-first CLI args and minimal cli_parse runtime helpers

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -16,6 +16,12 @@ Run a program file:
 python3 -m genia.interpreter path/to/file.genia
 ```
 
+Pass raw CLI args into a program:
+
+```bash
+python3 -m genia.interpreter path/to/file.genia --pretty input.txt
+```
+
 Run a command string:
 
 ```bash
@@ -66,6 +72,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - prelude helper docs are Markdown docstrings and display through `help("name")`
 - builtins:
   - I/O: `log`, `print`, `input`, `stdin`, `help`
+  - CLI: `argv`, `cli_parse`, `cli_flag?`, `cli_option`, `cli_option_or`
   - refs: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
   - concurrency: `spawn`, `send`, `process_alive?`
   - phase-1 persistent associative maps: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
@@ -88,6 +95,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 ## Not implemented (current)
 
 - map/dict literals and map patterns
+- `$1` / `$2` / `ARGV`-style special CLI syntax
 - general host interop / FFI
 - module/import system
 - member access and indexing syntax
@@ -100,6 +108,17 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - Genia does **not** use `if` or `switch`.
 - All branching is expressed through pattern matching.
 - There is no dedicated conditional keyword.
+
+## CLI args model (list-first)
+
+- `argv()` returns raw trailing command-line args as a plain list of strings.
+- Positional-only CLI programs should pattern match directly on that list.
+- `cli_parse(args)` returns `[opts, positionals]` where `opts` is a persistent map.
+- `cli_parse(args, spec)` supports minimal map spec keys:
+  - `flags`: list of names forced to boolean
+  - `options`: list of names forced to consume values
+  - `aliases`: map alias->canonical name
+- This layer does **not** add shell tokenization, dotted access syntax, or `$` positional variables.
 
 ## Simulation primitive semantics
 

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -151,3 +151,14 @@ When changing syntax/semantics/runtime behavior, update together:
 
 - Genia has no conditional keyword (`if` or `switch`)
 - branching is expressed only through pattern matching
+
+## 17) CLI args + parsing invariants (runtime-only, list-first)
+
+- raw process args are exposed via `argv()` as a list of strings (no `$1`/`$2` syntax)
+- CLI parsing is runtime builtin behavior (`cli_parse`, `cli_flag?`, `cli_option`, `cli_option_or`), not parser syntax
+- `cli_parse` returns `[opts_map, positionals_list]` where `opts_map` is persistent (`map_put` semantics, last write wins)
+- `cli_parse(args, spec)` accepts minimal map spec keys only:
+  - `flags` (list of strings)
+  - `options` (list of strings)
+  - `aliases` (map of string->string)
+- invalid CLI arg/spec/value types raise clear deterministic `TypeError`; ambiguous grouped short-option-with-value specs raise deterministic `ValueError`

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -12,6 +12,7 @@ This file describes what is **actually implemented now** in the Python runtime.
   - file mode: `genia path/to/file.genia`
   - command mode: `genia -c "expr_or_program_source"`
   - REPL mode: `genia` (no file/command arguments)
+- in file/command mode, trailing host CLI arguments are exposed to programs as `argv()` (list of strings)
 
 ## 2) Implemented syntax and expression forms
 
@@ -91,7 +92,33 @@ Case placement rules (enforced):
 ### Core I/O and utilities
 
 - `log`, `print`, `input`, `stdin`, `help`
+- `argv` (returns raw trailing CLI args as a list of strings)
 - constants in global env: `pi`, `e`, `true`, `false`, `nil`
+
+### CLI argument helpers (host-backed builtin layer)
+
+- `cli_parse(args) -> [opts, positionals]`
+- `cli_parse(args, spec) -> [opts, positionals]`
+- `cli_flag?(opts, name) -> bool`
+- `cli_option(opts, name) -> value_or_nil`
+- `cli_option_or(opts, name, default) -> value`
+
+Behavior:
+
+- raw args are list-first data (`argv()`), intended for normal list pattern matching
+- `cli_parse` returns a persistent map (`opts`) and remaining positional args list
+- default parsing:
+  - `--name` => boolean `true` unless followed by a non-option token (then `--name value`)
+  - `--name=value` => string value
+  - `-abc` => grouped short boolean flags
+  - `-o value` => short option value when next token is non-option
+  - `--` terminates option parsing
+  - repeated keys are deterministic last-one-wins (`map_put` replacement semantics)
+- `cli_parse(args, spec)` supports a minimal map-based spec:
+  - `flags`: list of names forced to boolean behavior
+  - `options`: list of names forced to value-taking behavior
+  - `aliases`: map of alias name -> canonical name (string keys/values)
+  - grouped short options with spec raise clear `ValueError` for ambiguous mixes
 
 ### Refs
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository currently provides:
 - a REPL and file runner (`python3 -m genia.interpreter`)
 - host-backed concurrency primitives (`spawn`, `send`, `process_alive?`)
 - refs (`ref`, `ref_get`, `ref_set`, `ref_update`)
+- list-first CLI args + parsing helpers (`argv`, `cli_parse`, `cli_flag?`, `cli_option`, `cli_option_or`)
 - simulation primitives (`rand`, `rand_int`, `sleep`)
 - autoloaded prelude libraries (lists, math helpers, awk helpers, fn helpers, agents)
 - debug-stdio adapter support for editor integration
@@ -23,6 +24,12 @@ Run a program:
 
 ```bash
 python3 -m genia.interpreter path/to/program.genia
+```
+
+Pass raw trailing CLI args into the running program:
+
+```bash
+python3 -m genia.interpreter path/to/program.genia --pretty input.txt
 ```
 
 Run inline source from the command line:
@@ -154,6 +161,13 @@ agent_get(counter)
 - `help(name)` prints named function metadata (`name/shape`, source if available, rendered docstring, or undocumented fallback)
 - stdlib prelude helpers include Markdown docstrings for learn-by-inspection via `help("name")`
 - constants: `pi`, `e`, `true`, `false`, `nil`
+
+### CLI args / options (runtime layer)
+
+- `argv()` exposes raw trailing CLI args as a plain list of strings
+- `cli_parse(args)` and `cli_parse(args, spec)` return `[opts_map, positionals]`
+- `cli_flag?(opts, name)`, `cli_option(opts, name)`, `cli_option_or(opts, name, default)` help read options cleanly
+- no `$1`/`$2` syntax is added; positional arguments are list-pattern friendly
 
 ### Refs
 

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -217,6 +217,69 @@ Genia has no dedicated conditional keyword.
 
 ---
 
+## CLI parsing + pattern matching
+
+Genia keeps CLI handling list-first:
+
+- raw args: `argv()` (list of strings)
+- parsed args: `cli_parse(args)` -> `[opts, positionals]`
+
+You can parse flags/options first, then pattern match the remaining positional list.
+
+### Minimal example
+
+```genia
+main(args) =
+  run_parsed(cli_parse(args))
+
+run_parsed(parsed) =
+  ([opts, [input]]) -> [cli_flag?(opts, "pretty"), input] |
+  ([opts, [input, output]]) -> [cli_flag?(opts, "pretty"), input, output] |
+  _ -> "usage"
+```
+
+### Edge case example
+
+Use `--` to stop option parsing:
+
+```genia
+cli_parse(["--pretty", "--", "--literal"])
+```
+
+Expected positional remainder includes `"--literal"`.
+
+### Failure case example
+
+```genia
+cli_parse(["-ab"], map_put(map_new(), "options", ["a", "b"]))
+```
+
+Expected behavior:
+
+- deterministic `ValueError` for ambiguous grouped short option parsing.
+
+### CLI parsing status
+
+### ✅ Implemented
+
+* list-first raw args via `argv()`
+* `cli_parse(args)` and minimal `cli_parse(args, spec)`
+* helper readers: `cli_flag?`, `cli_option`, `cli_option_or`
+* no parser changes required for CLI support
+
+### ⚠️ Partial
+
+* `spec` support is intentionally small: `flags`, `options`, `aliases`
+* no advanced argparse-style validation/actions
+
+### ❌ Missing
+
+* `$1`, `$2`, `$NF`, `ARGV`, or any special positional-variable syntax
+* shell tokenization/quoting logic (Genia operates on host-tokenized args)
+* full argparse/subcommand system
+
+---
+
 ## Notes for Contributors
 
 * Pattern matching is the **core abstraction** of Genia

--- a/docs/book/05-lists.md
+++ b/docs/book/05-lists.md
@@ -78,6 +78,44 @@ Expected behavior:
 
 ---
 
+## CLI args as lists (implemented)
+
+Genia exposes raw CLI args with `argv()`, and that value is just a list of strings.
+This means optional positional arguments can use ordinary list patterns.
+
+### Minimal example
+
+```genia
+main(args) =
+  ([input]) -> ["one", input] |
+  ([input, output]) -> ["two", input, output] |
+  _ -> "usage"
+
+main(argv())
+```
+
+### Edge case example
+
+```genia
+main(args) =
+  [] -> "no args" |
+  [first, ..rest] -> [first, length(rest)]
+```
+
+This stays pure list matching with no special CLI variable syntax.
+
+### Failure case example
+
+```genia
+cli_parse(1)
+```
+
+Expected behavior:
+
+- raises `TypeError` (`cli_parse expected a list of strings`)
+
+---
+
 ## `nth`, `take`, and `drop`
 
 ### Minimal example

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2170,6 +2170,7 @@ def truthy(value: Any) -> bool:
 def make_global_env(
     stdin_data: Optional[list[str]] = None,
     stdin_provider: Optional[Callable[[], list[str]]] = None,
+    cli_args: Optional[list[str]] = None,
     debug_hooks: DebugHooks | None = None,
     debug_mode: bool = False,
     output_handler: Optional[Callable[[str], None]] = None,
@@ -2294,6 +2295,8 @@ def make_global_env(
     def input_fn(prompt: str = "") -> str:
         return input(prompt)
 
+    argv_cache = list(cli_args or [])
+
     stdin_cache: Optional[list[str]] = None
 
     def stdin_fn() -> list[str]:
@@ -2306,6 +2309,9 @@ def make_global_env(
             else:
                 stdin_cache = sys.stdin.read().splitlines()
         return stdin_cache
+
+    def argv_fn() -> list[str]:
+        return list(argv_cache)
 
     def _emit_help(text: str) -> None:
         output = text + "\n"
@@ -2391,6 +2397,7 @@ Examples:
     (x, y) -> x + y
 
   print(stdin())
+  print(argv())
   count([1, 2, 3])
   print([1, 2, 3])
 
@@ -2412,6 +2419,14 @@ Commands:
   :env    show defined names
   :help   show this help
   help(name)   show metadata for a named function
+
+CLI builtins (list-first):
+  argv()                     trailing command-line args as [string]
+  cli_parse(args)            [opts_map, positionals]
+  cli_parse(args, spec)      same with minimal spec map (flags/options/aliases)
+  cli_flag?(opts, name)      boolean option check
+  cli_option(opts, name)     option value or nil
+  cli_option_or(opts, name, default)
 
 Concurrency builtins (host-backed):
   spawn(handler)          create a process with a mailbox
@@ -2495,6 +2510,159 @@ Bytes / JSON / ZIP builtins (host-backed runtime bridge):
         if not isinstance(value, GeniaMap):
             raise TypeError(f"{name} expected a map as first argument")
         return value
+
+    def _ensure_list_of_strings(value: Any, name: str) -> list[str]:
+        if not isinstance(value, list):
+            raise TypeError(f"{name} expected a list of strings")
+        if not all(isinstance(item, str) for item in value):
+            raise TypeError(f"{name} expected a list of strings")
+        return value
+
+    def _parse_cli_spec(spec: Any) -> tuple[set[str], set[str], dict[str, str]]:
+        if spec is None:
+            return set(), set(), {}
+        if not isinstance(spec, GeniaMap):
+            raise TypeError("cli_parse expected spec to be a map")
+
+        flags_raw = spec.get("flags")
+        options_raw = spec.get("options")
+        aliases_raw = spec.get("aliases")
+
+        flags = set(_ensure_list_of_strings(flags_raw, "cli_parse spec.flags")) if flags_raw is not None else set()
+        options = set(_ensure_list_of_strings(options_raw, "cli_parse spec.options")) if options_raw is not None else set()
+        aliases: dict[str, str] = {}
+
+        if aliases_raw is not None:
+            if not isinstance(aliases_raw, GeniaMap):
+                raise TypeError("cli_parse spec.aliases expected a map")
+            for _, (raw_key, raw_value) in aliases_raw._entries.items():
+                if not isinstance(raw_key, str) or not isinstance(raw_value, str):
+                    raise TypeError("cli_parse spec.aliases expected string keys and values")
+                aliases[raw_key] = raw_value
+
+        return flags, options, aliases
+
+    def _cli_option_like(token: str) -> bool:
+        return token != "-" and token.startswith("-")
+
+    def _cli_put(opts: GeniaMap, name: str, value: Any) -> GeniaMap:
+        if name == "":
+            raise ValueError("cli_parse encountered an empty option name")
+        return opts.put(name, value)
+
+    def cli_parse_fn(*args: Any) -> list[Any]:
+        if len(args) == 1:
+            raw_args = _ensure_list_of_strings(args[0], "cli_parse")
+            flags, options, aliases = set(), set(), {}
+        elif len(args) == 2:
+            raw_args = _ensure_list_of_strings(args[0], "cli_parse")
+            flags, options, aliases = _parse_cli_spec(args[1])
+        else:
+            raise TypeError(f"cli_parse expected 1 or 2 args, got {len(args)}")
+
+        opts = GeniaMap()
+        positionals: list[str] = []
+        parsing_options = True
+        i = 0
+
+        while i < len(raw_args):
+            token = raw_args[i]
+
+            if not parsing_options:
+                positionals.append(token)
+                i += 1
+                continue
+
+            if token == "--":
+                parsing_options = False
+                i += 1
+                continue
+
+            if token.startswith("--") and len(token) > 2:
+                body = token[2:]
+                if "=" in body:
+                    name, value = body.split("=", 1)
+                    name = aliases.get(name, name)
+                    opts = _cli_put(opts, name, value)
+                    i += 1
+                    continue
+
+                name = aliases.get(body, body)
+                uses_explicit_option = name in options
+                has_value = i + 1 < len(raw_args)
+                next_token = raw_args[i + 1] if has_value else None
+                should_consume_next = has_value and (uses_explicit_option or (name not in flags and not _cli_option_like(next_token)))
+                if should_consume_next:
+                    opts = _cli_put(opts, name, next_token)
+                    i += 2
+                    continue
+                opts = _cli_put(opts, name, True)
+                i += 1
+                continue
+
+            if token.startswith("-") and token != "-" and len(token) > 1:
+                body = token[1:]
+                if len(body) == 1:
+                    name = aliases.get(body, body)
+                    uses_explicit_option = name in options
+                    has_value = i + 1 < len(raw_args)
+                    next_token = raw_args[i + 1] if has_value else None
+                    should_consume_next = has_value and (uses_explicit_option or (name not in flags and not _cli_option_like(next_token)))
+                    if should_consume_next:
+                        opts = _cli_put(opts, name, next_token)
+                        i += 2
+                        continue
+                    opts = _cli_put(opts, name, True)
+                    i += 1
+                    continue
+
+                if options:
+                    option_chars = [ch for ch in body if aliases.get(ch, ch) in options]
+                    if len(option_chars) > 1:
+                        raise ValueError(f"cli_parse ambiguous short option group: -{body}")
+                    if len(option_chars) == 1:
+                        option_char = option_chars[0]
+                        option_idx = body.index(option_char)
+                        if option_idx != 0:
+                            raise ValueError(f"cli_parse ambiguous short option group: -{body}")
+                        name = aliases.get(option_char, option_char)
+                        inline_value = body[1:]
+                        if inline_value != "":
+                            opts = _cli_put(opts, name, inline_value)
+                            i += 1
+                            continue
+                        if i + 1 >= len(raw_args):
+                            raise ValueError(f"cli_parse missing value for -{option_char}")
+                        opts = _cli_put(opts, name, raw_args[i + 1])
+                        i += 2
+                        continue
+
+                for ch in body:
+                    name = aliases.get(ch, ch)
+                    opts = _cli_put(opts, name, True)
+                i += 1
+                continue
+
+            positionals.append(token)
+            i += 1
+
+        return [opts, positionals]
+
+    def cli_flag_fn(opts: Any, name: Any) -> bool:
+        genia_map = _ensure_map(opts, "cli_flag?")
+        key = _ensure_string(name, "cli_flag?")
+        return bool(genia_map.get(key))
+
+    def cli_option_fn(opts: Any, name: Any) -> Any:
+        genia_map = _ensure_map(opts, "cli_option")
+        key = _ensure_string(name, "cli_option")
+        return genia_map.get(key)
+
+    def cli_option_or_fn(opts: Any, name: Any, default: Any) -> Any:
+        genia_map = _ensure_map(opts, "cli_option_or")
+        key = _ensure_string(name, "cli_option_or")
+        value = genia_map.get(key)
+        return default if value is None else value
 
     def map_new_fn(*args: Any) -> GeniaMap:
         if len(args) != 0:
@@ -2630,6 +2798,7 @@ Bytes / JSON / ZIP builtins (host-backed runtime bridge):
     env.set("print", print_fn)
     env.set("input", input_fn)
     env.set("stdin", stdin_fn)
+    env.set("argv", argv_fn)
     env.set("help", help_fn)
     env.set("pi", math.pi)
     env.set("e", math.e)
@@ -2679,6 +2848,10 @@ Bytes / JSON / ZIP builtins (host-backed runtime bridge):
     env.set("set_entry_bytes", set_entry_bytes_fn)
     env.set("update_entry_bytes", update_entry_bytes_fn)
     env.set("entry_json", entry_json_fn)
+    env.set("cli_parse", cli_parse_fn)
+    env.set("cli_flag?", cli_flag_fn)
+    env.set("cli_option", cli_option_fn)
+    env.set("cli_option_or", cli_option_or_fn)
 
     env.register_autoload("list", 0, "std/prelude/list.genia")
     env.register_autoload("first", 1, "std/prelude/list.genia")
@@ -2839,10 +3012,12 @@ def _main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("program", nargs="?")
     parser.add_argument("-c", "--command")
     parser.add_argument("--debug-stdio", action="store_true")
-    args = parser.parse_args(argv)
+    args, script_args = parser.parse_known_args(argv)
 
     if args.program is not None and args.command is not None:
         parser.error("program path and --command cannot be used together")
+    if args.program is None and args.command is None and script_args:
+        parser.error(f"unexpected arguments: {' '.join(script_args)}")
 
     if args.debug_stdio:
         if args.program is None:
@@ -2851,13 +3026,13 @@ def _main(argv: Optional[list[str]] = None) -> int:
             parser.error("--debug-stdio cannot be used with --command")
         return run_debug_stdio(args.program)
     if args.command is not None:
-        env = make_global_env()
+        env = make_global_env(cli_args=script_args)
         result = run_source(args.command, env, filename="<command>")
         if result is not None:
             print(format_debug(result))
         return 0
     if args.program is not None:
-        env = make_global_env()
+        env = make_global_env(cli_args=script_args)
         with open(args.program, "r", encoding="utf-8") as f:
             result = run_source(f.read(), env, filename=str(Path(args.program).resolve()))
         if result is not None:

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -18,3 +18,12 @@ def test_command_flag_rejects_program_path_combination():
 def test_command_flag_rejects_debug_stdio_combination():
     with pytest.raises(SystemExit):
         _main(["--debug-stdio", "-c", "1 + 1"])
+
+
+def test_file_mode_passes_remaining_cli_args_into_argv(tmp_path, capsys):
+    program = tmp_path / "argv_echo.genia"
+    program.write_text("argv()", encoding="utf-8")
+    exit_code = _main([str(program), "--pretty", "in.txt"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == '["--pretty", "in.txt"]'

--- a/tests/test_cli_stdlib.py
+++ b/tests/test_cli_stdlib.py
@@ -1,0 +1,118 @@
+import pytest
+
+from genia import make_global_env, run_source
+
+
+def test_argv_exposed_as_plain_string_list():
+    env = make_global_env(cli_args=["input.txt", "--pretty"])
+    assert run_source("argv()", env) == ["input.txt", "--pretty"]
+
+
+def test_positional_pattern_matching_with_argv():
+    env = make_global_env(cli_args=["in.txt", "out.txt"])
+    source = """
+main(args) =
+  ([input]) -> ["one", input] |
+  ([input, output]) -> ["two", input, output] |
+  _ -> "usage"
+
+main(argv())
+"""
+    assert run_source(source, env) == ["two", "in.txt", "out.txt"]
+
+
+def test_cli_parse_empty():
+    env = make_global_env()
+    assert run_source("map_count(first(cli_parse([])))", env) == 0
+    assert run_source("rest(cli_parse([]))", env) == [[]]
+
+
+def test_cli_parse_long_boolean_flag():
+    env = make_global_env()
+    assert run_source('cli_flag?(first(cli_parse(["--pretty"])), "pretty")', env) is True
+
+
+def test_cli_parse_long_option_equals():
+    env = make_global_env()
+    assert run_source('cli_option(first(cli_parse(["--indent=4"])), "indent")', env) == "4"
+
+
+def test_cli_parse_long_option_with_next_value():
+    env = make_global_env()
+    assert run_source('cli_option(first(cli_parse(["--indent", "2"])), "indent")', env) == "2"
+
+
+def test_cli_parse_grouped_short_flags():
+    env = make_global_env()
+    source = """
+opts = first(cli_parse(["-abc"]))
+[cli_flag?(opts, "a"), cli_flag?(opts, "b"), cli_flag?(opts, "c")]
+"""
+    assert run_source(source, env) == [True, True, True]
+
+
+def test_cli_parse_short_option_value():
+    env = make_global_env()
+    assert run_source('cli_option(first(cli_parse(["-o", "file.txt"])), "o")', env) == "file.txt"
+
+
+def test_cli_parse_terminator():
+    env = make_global_env()
+    assert run_source('cli_flag?(first(cli_parse(["--pretty", "--", "--raw", "input.txt"])), "pretty")', env) is True
+    assert run_source('rest(cli_parse(["--pretty", "--", "--raw", "input.txt"]))', env) == [["--raw", "input.txt"]]
+
+
+def test_cli_parse_mixed_and_last_wins():
+    env = make_global_env()
+    assert run_source('cli_option(first(cli_parse(["--indent=2", "in", "--indent", "4", "-p", "out"])), "indent")', env) == "4"
+    assert run_source('rest(cli_parse(["--indent=2", "in", "--indent", "4", "-p", "out"]))', env) == [["in"]]
+
+
+def test_cli_helpers():
+    env = make_global_env()
+    source = """
+opts = map_put(map_new(), "pretty", true)
+opts2 = map_put(opts, "indent", "3")
+[cli_flag?(opts2, "pretty"), cli_option(opts2, "indent"), cli_option_or(opts2, "missing", "2")]
+"""
+    assert run_source(source, env) == [True, "3", "2"]
+
+
+def test_cli_parse_type_errors_are_deterministic():
+    env = make_global_env()
+    with pytest.raises(TypeError, match="cli_parse expected a list of strings"):
+        run_source("cli_parse(1)", env)
+    with pytest.raises(TypeError, match="cli_parse expected a list of strings"):
+        run_source('cli_parse([1])', env)
+    with pytest.raises(TypeError, match="cli_flag\\? expected a map as first argument"):
+        run_source('cli_flag?([], "a")', env)
+
+
+def test_cli_parse_with_minimal_spec_aliases_and_options():
+    env = make_global_env()
+    source = """
+aliases = map_put(map_new(), "p", "pretty")
+spec0 = map_put(map_new(), "flags", ["pretty"])
+spec1 = map_put(spec0, "options", ["indent"])
+spec = map_put(spec1, "aliases", aliases)
+parsed = cli_parse(["-p", "--indent", "2", "input.txt"], spec)
+opts = first(parsed)
+positionals = first(rest(parsed))
+[cli_flag?(opts, "pretty"), cli_option(opts, "indent"), positionals]
+"""
+    assert run_source(source, env) == [True, "2", ["input.txt"]]
+
+
+def test_cli_parse_pattern_matching_over_positionals():
+    env = make_global_env()
+    source = """
+spec = map_put(map_new(), "flags", ["pretty"])
+
+run_parsed(parsed) =
+  ([opts, [input]]) -> [cli_flag?(opts, "pretty"), input] |
+  ([opts, [input, output]]) -> [cli_flag?(opts, "pretty"), input, output] |
+  _ -> "usage"
+
+run_parsed(cli_parse(["--pretty", "a.txt", "b.txt"], spec))
+"""
+    assert run_source(source, env) == [True, "a.txt", "b.txt"]


### PR DESCRIPTION
### Motivation

- Expose raw trailing process CLI arguments as plain list data so programs can pattern-match on them instead of using special positional variables.  
- Provide a minimal, truthful stdlib parsing layer that converts tokenized args into a persistent options map plus remaining positionals to keep CLI handling list-first and pattern-matching-friendly.  
- Keep the change runtime/stdlib-only with a very small spec surface and no new parser syntax or `$`-style variables.

### Description

- Add `argv()` runtime builtin and wiring in `make_global_env(cli_args=...)` and `_main` so trailing script/command args are forwarded into the Genia environment.  
- Implement `cli_parse(args)` and `cli_parse(args, spec)` plus helpers `cli_flag?`, `cli_option`, and `cli_option_or` as host-backed runtime functions in `src/genia/interpreter.py` with deterministic semantics (long flags, `--name=value`, `--name value`, `-abc` grouped shorts, `-o value`, `--` terminator, last-one-wins).  
- Support a minimal spec model via runtime maps with keys `flags`, `options`, and `aliases` (documented and validated; ambiguous grouped short-option-with-value cases raise clear `ValueError`).  
- Add focused tests (`tests/test_cli_stdlib.py`, updates to `tests/test_cli_args.py`) and update authoritative docs (`GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and relevant `docs/book/*` chapters) to reflect implemented behavior and limits.

### Testing

- Ran the focused test subset with `pytest -q tests/test_cli_stdlib.py tests/test_cli_args.py`, and the tests passed.  
- Ran the full test suite with `pytest -q` and all tests passed (`254 passed`).  
- New tests exercise raw `argv()` exposure, positional-only pattern matching, `cli_parse([])`, `--name` and `--name=value` parsing, `--name value`, grouped short flags and short option values, `--` terminator behavior, mixed/last-wins semantics, helper functions, spec handling, and deterministic type/ambiguity errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc14ae7ff08329a1dad4d2bbe7a15b)