### PR TITLE
Add runtime `main` entrypoint invocation for file and -c modes

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -120,6 +120,15 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - `aliases`: map alias->canonical name
 - This layer does **not** add shell tokenization, dotted access syntax, or `$` positional variables.
 
+## Program entrypoint behavior
+
+- In **file mode** and **`-c` command mode**, Genia applies a runtime `main` convention after top-level evaluation:
+  1. If `main/1` exists, it runs `main(argv())`.
+  2. Else if `main/0` exists, it runs `main()`.
+  3. Else, no entrypoint call is made (existing behavior is preserved).
+- In **REPL mode**, no automatic `main` invocation is performed.
+- `main` remains a normal function name (not syntax).
+
 ## Simulation primitive semantics
 
 - `rand()` returns a host-RNG float in `[0, 1)`.

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -162,3 +162,13 @@ When changing syntax/semantics/runtime behavior, update together:
   - `options` (list of strings)
   - `aliases` (map of string->string)
 - invalid CLI arg/spec/value types raise clear deterministic `TypeError`; ambiguous grouped short-option-with-value specs raise deterministic `ValueError`
+
+## 18) Program entrypoint invariant (runtime convention only)
+
+- `main` is not a keyword and introduces no parser syntax
+- automatic entrypoint execution applies only in file mode and `-c` command mode
+- entrypoint resolution order is exact arity:
+  - prefer exact `main/1` and call it with `argv()`
+  - else use exact `main/0`
+  - else do nothing
+- no partial matching/coercion is performed by the entrypoint selector

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -13,6 +13,10 @@ This file describes what is **actually implemented now** in the Python runtime.
   - command mode: `genia -c "expr_or_program_source"`
   - REPL mode: `genia` (no file/command arguments)
 - in file/command mode, trailing host CLI arguments are exposed to programs as `argv()` (list of strings)
+- after file/command source evaluation, runtime entrypoint convention is:
+  - if `main/1` exists, call `main(argv())`
+  - else if `main/0` exists, call `main()`
+  - else keep existing result behavior (no implicit call)
 
 ## 2) Implemented syntax and expression forms
 
@@ -118,7 +122,15 @@ Behavior:
   - `flags`: list of names forced to boolean behavior
   - `options`: list of names forced to value-taking behavior
   - `aliases`: map of alias name -> canonical name (string keys/values)
-  - grouped short options with spec raise clear `ValueError` for ambiguous mixes
+- grouped short options with spec raise clear `ValueError` for ambiguous mixes
+
+### Program entrypoint convention (runtime, no syntax)
+
+- `main` is a runtime convention, not parser syntax
+- in file mode and `-c` command mode, `main/1` is preferred over `main/0`
+- arity coercion is not performed by the entrypoint selector:
+  - only exact `main/1` or exact `main/0` are auto-invoked
+  - if neither exists, no entrypoint call is attempted
 
 ### Refs
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,31 @@ agent_get(counter)
 - `cli_flag?(opts, name)`, `cli_option(opts, name)`, `cli_option_or(opts, name, default)` help read options cleanly
 - no `$1`/`$2` syntax is added; positional arguments are list-pattern friendly
 
+## CLI Programs (`main` Entrypoint Convention)
+
+In file mode (`genia path/to/program.genia`) and command mode (`genia -c "..."`), Genia checks for `main` after top-level evaluation:
+
+1. `main/1` → called as `main(argv())`
+2. else `main/0` → called as `main()`
+3. else → no implicit entrypoint call
+
+`main` is a runtime convention, not syntax.
+
+Example (`main/1` + list pattern matching):
+
+```genia
+main(args) =
+  [] -> print("usage") |
+  ["hello", name] -> print("Hello " + name) |
+  _ -> print("unknown command")
+```
+
+Example (`main/0`):
+
+```genia
+main() = print("Hello world")
+```
+
 ### Refs
 
 - `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -304,6 +304,9 @@ Expected behavior:
 
 * Named function definitions
 * Arity-based + varargs dispatch
+* Runtime `main` entrypoint convention in file/`-c` modes:
+  * `main/1` is preferred and called as `main(argv())`
+  * fallback to `main/0` when `main/1` is absent
 * Pipeline operator `|>` with expression-level call rewriting
 * Named-function docstring metadata (`f(...) = "doc" ...`)
 * `help(name)` output with:
@@ -317,9 +320,43 @@ Expected behavior:
 * Markdown rendering is intentionally minimal and terminal-first (no full Markdown engine, no syntax highlighting)
 * Docstring parsing requires the docstring and body expression to be part of the same definition expression sequence (no dedicated block-doc syntax)
 * Pipeline is only call composition, not a full flow runtime model
+* `main` auto-invocation is only for file/`-c` execution modes (not REPL)
 
 ### ❌ Not implemented
 
 * Lambda docstrings
 * Separate docstring keywords or block syntax
+* Dedicated CLI syntax (`$1`, `$2`, special argument keywords)
 * Generalized flow semantics (lazy streams, multi-output stages, backpressure, cancellation)
+
+---
+
+## CLI Entrypoint with `main` (Runtime Convention)
+
+`main` is just a normal function name with runtime convention behavior in file/`-c` execution.
+No parser syntax is added.
+
+### Minimal example
+
+```genia
+main(args) = length(args)
+```
+
+When run with two trailing args, this returns `2`.
+
+### Edge case example
+
+```genia
+main() = "ok"
+```
+
+If `main/1` is absent, `main/0` is called automatically.
+
+### Failure case example
+
+```genia
+main(args) = args
+main() = "fallback"
+```
+
+`main/1` has precedence, so this returns the argv list rather than `"fallback"`.

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -3025,16 +3025,32 @@ def _main(argv: Optional[list[str]] = None) -> int:
         if args.command is not None:
             parser.error("--debug-stdio cannot be used with --command")
         return run_debug_stdio(args.program)
+
+    def resolve_program_result(run_result: Any, env: Env) -> Any:
+        main_group = env.values.get("main")
+        if not isinstance(main_group, GeniaFunctionGroup):
+            return run_result
+        main_with_args = main_group.get(1)
+        if main_with_args is not None:
+            cli_args = env.get("argv")()
+            return main_with_args(cli_args)
+        main_without_args = main_group.get(0)
+        if main_without_args is not None:
+            return main_without_args()
+        return run_result
+
     if args.command is not None:
         env = make_global_env(cli_args=script_args)
-        result = run_source(args.command, env, filename="<command>")
+        run_result = run_source(args.command, env, filename="<command>")
+        result = resolve_program_result(run_result, env)
         if result is not None:
             print(format_debug(result))
         return 0
     if args.program is not None:
         env = make_global_env(cli_args=script_args)
         with open(args.program, "r", encoding="utf-8") as f:
-            result = run_source(f.read(), env, filename=str(Path(args.program).resolve()))
+            run_result = run_source(f.read(), env, filename=str(Path(args.program).resolve()))
+        result = resolve_program_result(run_result, env)
         if result is not None:
             print(format_debug(result))
         return 0

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -27,3 +27,53 @@ def test_file_mode_passes_remaining_cli_args_into_argv(tmp_path, capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert captured.out.strip() == '["--pretty", "in.txt"]'
+
+
+def test_command_mode_invokes_main_1_with_empty_cli_args(capsys):
+    exit_code = _main(["-c", "main(args) = length(args)"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "0"
+
+
+def test_command_mode_invokes_main_0_when_main_1_missing(capsys):
+    exit_code = _main(["-c", "main() = 42"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "42"
+
+
+def test_command_mode_prefers_main_1_over_main_0(capsys):
+    source = """
+main() = 10
+main(args) = length(args)
+"""
+    exit_code = _main(["-c", source])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "0"
+
+
+def test_command_mode_without_main_preserves_existing_behavior(capsys):
+    exit_code = _main(["-c", "1 + 2"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "3"
+
+
+def test_file_mode_invokes_main_1_with_cli_args(tmp_path, capsys):
+    program = tmp_path / "main_argv.genia"
+    program.write_text("main(args) = length(args)", encoding="utf-8")
+    exit_code = _main([str(program), "in.txt", "out.txt"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "2"
+
+
+def test_file_mode_invokes_main_0_when_main_1_missing(tmp_path, capsys):
+    program = tmp_path / "main_zero.genia"
+    program.write_text("main() = 7", encoding="utf-8")
+    exit_code = _main([str(program)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == "7"


### PR DESCRIPTION
### Motivation

- Provide a conventional program entrypoint so Genia programs can define `main` and be invoked automatically when run from the CLI. 
- Keep this as a runtime convention (no parser or syntax changes) and preserve existing behavior when `main` is absent. 
- Respect arity rules and Genia philosophy: prefer pattern/list-first handling and exact-arity function resolution. 

### Description

- Added runtime entrypoint resolution to the CLI runner in `src/genia/interpreter.py` that, after evaluating program source, checks for `main/1` then `main/0` and invokes `main(argv())` or `main()` respectively. 
- Implemented the resolver as `resolve_program_result(run_result, env)` so original run result is preserved when no `main` is present. 
- Added tests in `tests/test_cli_args.py` covering `main/1` invocation (with and without args), `main/0` fallback, `main/1` precedence, no-`main` behavior, and file-mode invocation with CLI args. 
- Updated documentation to record the runtime-only convention and examples in `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and `docs/book/03-functions.md`. 

### Testing

- Ran the modified CLI tests with `pytest -q tests/test_cli_args.py tests/test_cli_stdlib.py`, which completed with `24 passed`. 
- The CLI behavior tests exercise both `-c` command mode and file mode and confirmed `main/1` is preferred over `main/0` and that no implicit call occurs when `main` is absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1fea74148329a968297d03fb2c6e)