### PR TITLE
CLI: accept bare positional and option-like trailing args in `-c` mode and forward to `argv()`

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -13,6 +13,7 @@ This file describes what is **actually implemented now** in the Python runtime.
   - command mode: `genia -c "expr_or_program_source"`
   - REPL mode: `genia` (no file/command arguments)
 - in file/command mode, trailing host CLI arguments are exposed to programs as `argv()` (list of strings)
+  - command mode accepts both bare positionals (`a`) and option-like args (`--pretty`) as trailing args
 - after file/command source evaluation, runtime entrypoint convention is:
   - if `main/1` exists, call `main(argv())`
   - else if `main/0` exists, call `main()`

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -307,6 +307,7 @@ Expected behavior:
 * Runtime `main` entrypoint convention in file/`-c` modes:
   * `main/1` is preferred and called as `main(argv())`
   * fallback to `main/0` when `main/1` is absent
+  * trailing CLI args in `-c` mode are passed through to `argv()` (including bare positional values)
 * Pipeline operator `|>` with expression-level call rewriting
 * Named-function docstring metadata (`f(...) = "doc" ...`)
 * `help(name)` output with:

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -3009,22 +3009,24 @@ def run_debug_stdio(
 
 def _main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(prog="genia.interpreter")
-    parser.add_argument("program", nargs="?")
     parser.add_argument("-c", "--command")
     parser.add_argument("--debug-stdio", action="store_true")
-    args, script_args = parser.parse_known_args(argv)
+    args, remaining_args = parser.parse_known_args(argv)
 
-    if args.program is not None and args.command is not None:
-        parser.error("program path and --command cannot be used together")
-    if args.program is None and args.command is None and script_args:
-        parser.error(f"unexpected arguments: {' '.join(script_args)}")
+    program_path: Optional[str] = None
+    script_args: list[str] = []
+    if args.command is not None:
+        script_args = remaining_args
+    elif remaining_args:
+        program_path = remaining_args[0]
+        script_args = remaining_args[1:]
 
     if args.debug_stdio:
-        if args.program is None:
+        if program_path is None:
             parser.error("--debug-stdio requires a program path")
         if args.command is not None:
             parser.error("--debug-stdio cannot be used with --command")
-        return run_debug_stdio(args.program)
+        return run_debug_stdio(program_path)
 
     def resolve_program_result(run_result: Any, env: Env) -> Any:
         main_group = env.values.get("main")
@@ -3046,10 +3048,10 @@ def _main(argv: Optional[list[str]] = None) -> int:
         if result is not None:
             print(format_debug(result))
         return 0
-    if args.program is not None:
+    if program_path is not None:
         env = make_global_env(cli_args=script_args)
-        with open(args.program, "r", encoding="utf-8") as f:
-            run_result = run_source(f.read(), env, filename=str(Path(args.program).resolve()))
+        with open(program_path, "r", encoding="utf-8") as f:
+            run_result = run_source(f.read(), env, filename=str(Path(program_path).resolve()))
         result = resolve_program_result(run_result, env)
         if result is not None:
             print(format_debug(result))

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -10,9 +10,11 @@ def test_command_flag_executes_source_and_prints_result(capsys):
     assert captured.out.strip() == "3"
 
 
-def test_command_flag_rejects_program_path_combination():
-    with pytest.raises(SystemExit):
-        _main(["examples/ants.genia", "-c", "1 + 1"])
+def test_command_mode_treats_non_option_trailing_tokens_as_cli_args(capsys):
+    exit_code = _main(["-c", "main(args) = args", "examples/ants.genia"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == '["examples/ants.genia"]'
 
 
 def test_command_flag_rejects_debug_stdio_combination():
@@ -34,6 +36,13 @@ def test_command_mode_invokes_main_1_with_empty_cli_args(capsys):
     captured = capsys.readouterr()
     assert exit_code == 0
     assert captured.out.strip() == "0"
+
+
+def test_command_mode_passes_bare_cli_args_into_main_1(capsys):
+    exit_code = _main(["-c", "main(args) = args", "a"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip() == '["a"]'
 
 
 def test_command_mode_invokes_main_0_when_main_1_missing(capsys):


### PR DESCRIPTION
### Motivation

- Align `-c` command mode with file mode by allowing trailing bare positional and option-like arguments to be passed through to `argv()` for programs.
- Fix inconsistent handling of remaining CLI tokens and enable using a program path alongside non-option trailing args when not using `-c`.

### Description

- Update `src/genia/interpreter.py` `_main` to use `parse_known_args` results as `remaining_args` and determine `program_path` and `script_args` based on presence of `--command` (`-c`).
- Treat non-option trailing tokens as CLI args for `-c` mode by populating `script_args` from `remaining_args` when `args.command` is present, and consume the first remaining token as `program_path` for file mode when appropriate.
- Adjust `--debug-stdio` validation to require a resolved `program_path` and route debug invocation via `run_debug_stdio(program_path)`.
- Update documentation files `GENIA_STATE.md` and `docs/book/03-functions.md` to reflect that command mode accepts bare positional and option-like trailing args, and modify `tests/test_cli_args.py` to add and revise tests for the new behavior.

### Testing

- Ran the updated test file with `pytest tests/test_cli_args.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc288c86e48329a50d5566b457488f)