### PR TITLE
Fix examples to avoid double-running main entrypoint

### DIFF
--- a/examples/ants.genia
+++ b/examples/ants.genia
@@ -419,5 +419,3 @@ Run the ants simulation example.
 main()
 ```
 """ run(seed_world(), ant_start(), 12, 80)
-
-main()

--- a/examples/tic-tac-toe.genia
+++ b/examples/tic-tac-toe.genia
@@ -164,5 +164,3 @@ Run the Tic-Tac-Toe example.
   print("6 7 8")
   play(newBoard(), "X")
 }
-
-main()


### PR DESCRIPTION
### Motivation
- The runtime auto-invokes `main/0` in file mode, so example files that also contained a trailing explicit `main()` call would run twice and could immediately restart (causing EOF errors in non-interactive runs). 

### Description
- Removed the trailing explicit `main()` invocations from `examples/tic-tac-toe.genia` and `examples/ants.genia` so each example defines `main/0` only and relies on the runtime’s file-mode auto-entrypoint. 

### Testing
- Ran the Tic-Tac-Toe example with scripted input via `PYTHONPATH=src python src/genia/interpreter.py examples/tic-tac-toe.genia` and the game now exits after a single run (no restart). 
- Ran `PYTHONPATH=src pytest -q tests/test_function_docstrings.py tests/test_ants_demo.py` and the test suite passed (`13 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc9449d320832981cc91f6cc77ae4c)