### PR TITLE
Add Phase 1 whole-string `glob"..."` patterns to pattern matching

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -60,6 +60,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - pattern matching:
   - tuple patterns
   - list patterns
+  - glob string patterns (`glob"..."`) with whole-string matching only
   - wildcard `_`
   - rest pattern `..rest` / `.._`
   - duplicate-binding equality semantics (`[x, x]`)
@@ -95,6 +96,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 ## Not implemented (current)
 
 - map/dict literals and map patterns
+- regex patterns / extglob operators
 - `$1` / `$2` / `ARGV`-style special CLI syntax
 - general host interop / FFI
 - module/import system

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -42,6 +42,7 @@ Do not resolve this via precedence hacks.
 Supported patterns:
 
 - literal
+- glob string pattern (`glob"..."`)
 - variable binding
 - wildcard `_`
 - tuple pattern
@@ -51,6 +52,11 @@ Required constraints:
 
 - list rest pattern (`..name` / `.._`) is valid only in final list-pattern position
 - duplicate names in a pattern require equality at match time
+- glob patterns match only string values and must match the entire string
+- glob pattern syntax supports only:
+  - `*`, `?`, `[abc]`, `[a-z]`, `[!abc]`
+  - escapes: `\*`, `\?`, `\[`, `\]`, `\\`
+- malformed glob classes must raise deterministic syntax errors
 
 ## 7) Spread semantics
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -73,12 +73,26 @@ pattern ? guard -> result
 Implemented pattern types:
 
 - literal patterns
+- glob string patterns (`glob"..."`) for whole-string matching
 - variable binding
 - wildcard `_`
 - tuple patterns
 - list patterns
 - rest pattern `..name` / `.._` (list patterns only; final position only)
 - duplicate binding semantics (same name must match equal value)
+
+Glob pattern semantics (Phase 1):
+
+- valid in any pattern position accepted by function clauses / case arms
+- matches only string values (non-string values fail to match)
+- whole-string matching only (no substring mode)
+- supported metacharacters:
+  - `*` (zero or more chars)
+  - `?` (exactly one char)
+  - character classes: `[abc]`, `[a-z]`, `[!abc]`
+- supported escaping inside glob text:
+  - `\*`, `\?`, `\[`, `\]`, `\\`
+- malformed character classes raise deterministic syntax errors
 
 Case placement rules (enforced):
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ head(xs) =
 Supported pattern forms:
 
 - literals (`0`, `"ok"`, `true`, `nil`)
+- glob string patterns (`glob"..."`) for whole-string string matching
 - variable bindings
 - wildcard `_`
 - tuple patterns (`(a, b)`)

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -91,6 +91,65 @@ No conditionals needed.
 
 ---
 
+## Glob String Patterns (Phase 1)
+
+Genia supports a minimal glob pattern form in pattern position:
+
+```
+glob"..."
+```
+
+This is still pattern matching (not regex, not captures).
+
+### Minimal example
+
+```genia
+kind(name) =
+  glob"*.md" -> "markdown" |
+  _ -> "other"
+```
+
+### Edge case example
+
+```genia
+kind(s) =
+  glob"" -> "empty" |
+  glob"*" -> "any" |
+  _ -> "fallback"
+```
+
+- `glob""` matches only `""`
+- `glob"*"` matches every string, including `""`
+
+### Failure case example
+
+Malformed classes fail deterministically:
+
+```genia
+bad(s) =
+  glob"[a-z" -> "nope" |
+  _ -> "ok"
+```
+
+Expected behavior: syntax error for unterminated character class.
+
+Supported glob features in this phase:
+
+- `*` (zero or more chars)
+- `?` (exactly one char)
+- class: `[abc]`
+- range: `[a-z]`
+- negated class: `[!abc]`
+- escapes: `\*`, `\?`, `\[`, `\]`, `\\`
+
+Not part of this phase:
+
+- regex
+- extglob
+- captures/destructuring
+
+---
+
 ## A Failure Case
 
 ```
@@ -195,15 +254,19 @@ Write `last` using pattern matching and recursion.
 * List destructuring (`[x, ..rest]`)
 * Variable binding
 * Pattern guards (`pattern ? guard -> result`)
+* Glob string patterns (`glob"..."`) with whole-string matching only
+* Glob class/range/negated-class matching and minimal escapes
 
 ### ⚠️ Partial
 
 * Error messages for failed matches may be minimal
+* Glob parsing is intentionally small (no regex/extglob/capture syntax)
 
 ### ❌ Missing
 
 * Exhaustiveness checking
 * Match optimizations (decision trees, indexing)
+* Regex patterns, extglob operators, or capture extraction in glob patterns
 
 ---
 
@@ -298,6 +361,7 @@ Source: parser + runtime
 * Pattern clauses supported: YES
 * Ordered evaluation: YES
 * List destructuring: YES
+* Glob string patterns: YES
 * Guards: YES
 * Exhaustiveness checking: NO
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -209,6 +209,23 @@ def lex(source: str) -> list[Token]:
             pos += len(text)
             continue
 
+        if source.startswith('glob"', pos):
+            literal_start = pos + 4
+            i = literal_start + 1
+            while i < length:
+                if source[i] == "\\":
+                    i += 2
+                    continue
+                if source[i] == '"':
+                    text = source[pos:i + 1]
+                    tokens.append(Token("GLOB", text, pos))
+                    pos = i + 1
+                    break
+                i += 1
+            else:
+                raise SyntaxError(f"Unterminated glob pattern literal at {pos}")
+            continue
+
         if ch in "\"'":
             if source.startswith(ch * 3, pos):
                 delim = ch * 3
@@ -313,6 +330,173 @@ def parse_string_literal(text: str) -> str:
     return "".join(out)
 
 
+def parse_glob_literal(text: str) -> str:
+    if not (text.startswith('glob"') and text.endswith('"') and len(text) >= 6):
+        raise SyntaxError(f"Invalid glob literal: {text!r}")
+    content = text[5:-1]
+    out: list[str] = []
+    i = 0
+    while i < len(content):
+        ch = content[i]
+        if ch != "\\":
+            out.append(ch)
+            i += 1
+            continue
+        i += 1
+        if i >= len(content):
+            raise SyntaxError("Invalid glob literal: trailing backslash")
+        esc = content[i]
+        i += 1
+        if esc in {"*", "?", "[", "]", "\\"}:
+            out.append("\\" + esc)
+            continue
+        raise SyntaxError(f"Invalid glob literal escape: \\{esc}")
+    return "".join(out)
+
+
+@dataclass(frozen=True)
+class GlobClassEntry:
+    start: str
+    end: str
+
+
+@dataclass(frozen=True)
+class GlobToken:
+    kind: str
+    value: Any = None
+
+
+@dataclass(frozen=True)
+class CompiledGlobPattern:
+    source: str
+    tokens: tuple[GlobToken, ...]
+
+
+def compile_glob_pattern(text: str) -> CompiledGlobPattern:
+    tokens: list[GlobToken] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\":
+            if i + 1 >= len(text):
+                raise SyntaxError("Invalid glob pattern: trailing backslash")
+            tokens.append(GlobToken("LITERAL", text[i + 1]))
+            i += 2
+            continue
+        if ch == "*":
+            if not tokens or tokens[-1].kind != "STAR":
+                tokens.append(GlobToken("STAR"))
+            i += 1
+            continue
+        if ch == "?":
+            tokens.append(GlobToken("ANY_ONE"))
+            i += 1
+            continue
+        if ch == "[":
+            token, i = _parse_glob_class(text, i)
+            tokens.append(token)
+            continue
+        tokens.append(GlobToken("LITERAL", ch))
+        i += 1
+    return CompiledGlobPattern(source=text, tokens=tuple(tokens))
+
+
+def _parse_glob_class(text: str, start_idx: int) -> tuple[GlobToken, int]:
+    i = start_idx + 1
+    if i >= len(text):
+        raise SyntaxError("Invalid glob pattern: unterminated character class")
+    negated = False
+    if text[i] == "!":
+        negated = True
+        i += 1
+    entries: list[GlobClassEntry] = []
+    saw_entry = False
+    pending_literal: str | None = None
+
+    while i < len(text):
+        ch = text[i]
+        if ch == "]":
+            if pending_literal is not None:
+                entries.append(GlobClassEntry(pending_literal, pending_literal))
+                pending_literal = None
+                saw_entry = True
+            if not saw_entry:
+                raise SyntaxError("Invalid glob pattern: empty character class")
+            return GlobToken("CLASS", (negated, tuple(entries))), i + 1
+
+        if ch == "\\":
+            if i + 1 >= len(text):
+                raise SyntaxError("Invalid glob pattern: trailing backslash in character class")
+            literal = text[i + 1]
+            i += 2
+        else:
+            literal = ch
+            i += 1
+
+        if pending_literal is None:
+            pending_literal = literal
+            continue
+
+        if literal == "-" and i < len(text) and text[i] != "]":
+            if text[i] == "\\":
+                if i + 1 >= len(text):
+                    raise SyntaxError("Invalid glob pattern: trailing backslash in range")
+                range_end = text[i + 1]
+                i += 2
+            else:
+                range_end = text[i]
+                i += 1
+            if ord(pending_literal) > ord(range_end):
+                raise SyntaxError("Invalid glob pattern: descending character range")
+            entries.append(GlobClassEntry(pending_literal, range_end))
+            pending_literal = None
+            saw_entry = True
+            continue
+
+        entries.append(GlobClassEntry(pending_literal, pending_literal))
+        pending_literal = literal
+        saw_entry = True
+
+    raise SyntaxError("Invalid glob pattern: unterminated character class")
+
+
+def glob_match(compiled: CompiledGlobPattern, value: str) -> bool:
+    tokens = compiled.tokens
+    memo: dict[tuple[int, int], bool] = {}
+
+    def go(tok_i: int, str_i: int) -> bool:
+        key = (tok_i, str_i)
+        if key in memo:
+            return memo[key]
+        if tok_i == len(tokens):
+            memo[key] = str_i == len(value)
+            return memo[key]
+        token = tokens[tok_i]
+        if token.kind == "STAR":
+            memo[key] = go(tok_i + 1, str_i) or (str_i < len(value) and go(tok_i, str_i + 1))
+            return memo[key]
+        if str_i >= len(value):
+            memo[key] = False
+            return False
+        ch = value[str_i]
+        if token.kind == "LITERAL":
+            memo[key] = ch == token.value and go(tok_i + 1, str_i + 1)
+            return memo[key]
+        if token.kind == "ANY_ONE":
+            memo[key] = go(tok_i + 1, str_i + 1)
+            return memo[key]
+        if token.kind == "CLASS":
+            negated, entries = token.value
+            in_class = any(entry.start <= ch <= entry.end for entry in entries)
+            if negated:
+                in_class = not in_class
+            memo[key] = in_class and go(tok_i + 1, str_i + 1)
+            return memo[key]
+        raise RuntimeError(f"Unsupported compiled glob token: {token.kind}")
+
+    return go(0, 0)
+
+
 # -----------------------------
 # AST
 # -----------------------------
@@ -399,6 +583,12 @@ class Spread(Node):
 @dataclass
 class ListPattern(Node):
     items: list[Node]
+    span: SourceSpan | None = None
+
+
+@dataclass
+class GlobPattern(Node):
+    pattern: str
     span: SourceSpan | None = None
 
 
@@ -589,6 +779,13 @@ class IrPatList(IrPattern):
 
 
 @dataclass
+class IrPatGlob(IrPattern):
+    """Whole-string glob pattern matcher."""
+
+    matcher: "CompiledGlobPattern"
+
+
+@dataclass
 class IrCaseClause(IrNode):
     """Single case arm with optional guard."""
 
@@ -726,6 +923,8 @@ def lower_pattern(pattern: Node) -> IrPattern:
         return IrPatTuple([lower_pattern(item) for item in pattern.items])
     if isinstance(pattern, ListPattern):
         return IrPatList([lower_pattern(item) for item in pattern.items])
+    if isinstance(pattern, GlobPattern):
+        return IrPatGlob(compile_glob_pattern(pattern.pattern))
     raise RuntimeError(f"Unknown pattern during lowering: {pattern!r}")
 
 
@@ -1202,7 +1401,7 @@ class Parser:
         # single param shorthand cases: 0 ->, name ->, [x, y] ->, name ? ... ->
         # tuple case: ( ... ) ->
         # We only detect enough for v0.1.
-        if self.at("NUMBER", "STRING", "IDENT"):
+        if self.at("NUMBER", "STRING", "IDENT", "GLOB"):
             j = self.i + 1
             while self.tokens[j].kind == "NEWLINE":
                 j += 1
@@ -1269,6 +1468,9 @@ class Parser:
         if tok.kind == "STRING":
             self.i += 1
             return String(parse_string_literal(tok.text), span=self.span_for_tokens(tok, tok))
+        if tok.kind == "GLOB":
+            self.i += 1
+            return GlobPattern(parse_glob_literal(tok.text), span=self.span_for_tokens(tok, tok))
         if tok.kind == "DOTDOT":
             self.i += 1
             if self.at("IDENT"):
@@ -1984,6 +2186,10 @@ class Evaluator:
             return {pattern.name: arg} if pattern.name is not None else {}
         if isinstance(pattern, IrPatBind):
             return {pattern.name: arg}
+        if isinstance(pattern, IrPatGlob):
+            if not isinstance(arg, str):
+                return None
+            return {} if glob_match(pattern.matcher, arg) else None
         if isinstance(pattern, IrPatList):
             if not isinstance(arg, list):
                 return None

--- a/tests/test_glob_patterns.py
+++ b/tests/test_glob_patterns.py
@@ -1,0 +1,123 @@
+import pytest
+
+
+def test_glob_star_matches(run):
+    src = '''
+    classify(s) =
+      glob"a*" -> "yes" |
+      _ -> "no"
+
+    classify("alpha")
+    '''
+    assert run(src) == "yes"
+
+
+def test_glob_question_matches_single_char(run):
+    src = '''
+    classify(s) =
+      glob"a?c" -> "yes" |
+      _ -> "no"
+
+    classify("abc")
+    '''
+    assert run(src) == "yes"
+
+
+def test_glob_character_class_and_range(run):
+    src = '''
+    classify(s) =
+      glob"file[0-9][abc]" -> "ok" |
+      _ -> "no"
+
+    classify("file3b")
+    '''
+    assert run(src) == "ok"
+
+
+def test_glob_negated_class(run):
+    src = '''
+    classify(s) =
+      glob"[!a-z]" -> "non-lower" |
+      _ -> "other"
+
+    classify("Q")
+    '''
+    assert run(src) == "non-lower"
+
+
+def test_glob_escaped_metacharacters(run):
+    src = r'''
+    classify(s) =
+      glob"\*\?\[\]\\" -> "literal" |
+      _ -> "no"
+
+    classify("*?[]\\")
+    '''
+    assert run(src) == "literal"
+
+
+def test_glob_empty_and_any_string_behavior(run):
+    src_empty = '''
+    classify(s) =
+      glob"" -> "empty" |
+      _ -> "no"
+
+    classify("")
+    '''
+    assert run(src_empty) == "empty"
+
+    src_star = '''
+    classify(s) =
+      glob"*" -> "any" |
+      _ -> "no"
+
+    classify("")
+    '''
+    assert run(src_star) == "any"
+
+
+def test_glob_non_string_mismatch(run):
+    src = '''
+    classify(v) =
+      glob"*" -> "string" |
+      _ -> "other"
+
+    classify(123)
+    '''
+    assert run(src) == "other"
+
+
+def test_glob_malformed_class_error(run):
+    src = '''
+    classify(s) =
+      glob"[a-z" -> "ok" |
+      _ -> "no"
+
+    classify("a")
+    '''
+    with pytest.raises(SyntaxError, match="unterminated character class"):
+        run(src)
+
+
+def test_glob_in_case_expression(run):
+    src = '''
+    classify(v) {
+      "noop"
+      glob"*.md" -> "markdown" |
+      _ -> "other"
+    }
+
+    classify("readme.md")
+    '''
+    assert run(src) == "markdown"
+
+
+def test_glob_in_function_definition_case_body(run):
+    src = '''
+    classify(v) =
+      glob"*.md" -> "markdown" |
+      _ -> "other"
+
+    classify("readme.md")
+    '''
+    assert run(src) == "markdown"


### PR DESCRIPTION
### Motivation

- Introduce a minimal, intentional Phase 1 glob pattern form to make common whole-string wildcard checks available in pattern positions without adding regex, captures, or new conditional syntax. 
- Keep the change small and pattern-matching-first: globs must be whole-string, string-only, and limited to `*`, `?`, character classes/ranges, negation, and simple escaping.

### Description

- Add lexer support for a `GLOB` token and a `glob"..."` literal surface form parsed by `parse_glob_literal`. 
- Add AST/IR nodes `GlobPattern` and `IrPatGlob`, and lower `GlobPattern` to `IrPatGlob` via `compile_glob_pattern`. 
- Implement a tiny compiled-glob model (`CompiledGlobPattern`, `GlobToken`, `GlobClassEntry`) and parser helpers (`compile_glob_pattern`, `_parse_glob_class`) with deterministic syntax errors on malformed classes. 
- Implement a simple boolean matcher `glob_match` (memoized recursive matcher) and integrate it into `Evaluator.match_pattern_atom` so `IrPatGlob` matches only `str` values and only when the entire string matches. 
- Preserve invariants: no captures/destructuring from globs, no regex or extglob, and no new conditional keywords are introduced. 
- Update authoritative docs: `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and `docs/book/02-pattern-matching.md` to reflect implemented behavior. 
- Add tests `tests/test_glob_patterns.py` covering `*`, `?`, classes, ranges, negation, escaped metacharacters, empty-string and `*` behavior, non-string mismatch, malformed-class errors, and usage in both function case bodies and block-final case expressions.

### Testing

- Ran `pytest -q tests/test_glob_patterns.py tests/test_lists_and_patterns.py tests/test_cases.py` and the targeted tests passed successfully. 
- Ran full test suite with `pytest -q` which completed successfully (`271 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc9dcf55f083298ce42ab05fcc6566)