### PR TITLE
Allow newlines inside list patterns (multiline list pattern parsing)

### DIFF
--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -51,6 +51,7 @@ Supported patterns:
 Required constraints:
 
 - list rest pattern (`..name` / `.._`) is valid only in final list-pattern position
+- parser ignores newlines between list-pattern delimiters and items
 - duplicate names in a pattern require equality at match time
 - glob patterns match only string values and must match the entire string
 - glob pattern syntax supports only:

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -82,6 +82,7 @@ Implemented pattern types:
 - list patterns
 - rest pattern `..name` / `.._` (list patterns only; final position only)
 - duplicate binding semantics (same name must match equal value)
+- multiline list pattern formatting is accepted (newlines inside `[...]` pattern shapes)
 
 Glob pattern semantics (Phase 1):
 

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -91,6 +91,46 @@ No conditionals needed.
 
 ---
 
+## Multiline list patterns (implemented)
+
+List pattern shapes can span lines inside `[...]`.
+
+### Minimal example
+
+```genia
+first3(xs) =
+  [
+    a, b, c,
+    .._
+  ] -> [a, b, c]
+```
+
+### Edge case example
+
+```genia
+head_or_none(xs) =
+  [
+    x,
+    .._
+  ] -> x |
+  [] -> "none"
+```
+
+### Failure case example
+
+```genia
+bad(xs) =
+  [
+    a,
+    ..rest,
+    b
+  ] -> a
+```
+
+Expected behavior: parse error (`..rest must be the final item in a list pattern`).
+
+---
+
 ## Glob String Patterns (Phase 1)
 
 Genia supports a minimal glob pattern form in pattern position:

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -1500,6 +1500,7 @@ class Parser:
             start = self.eat("LBRACK")
             items: list[Node] = []
             saw_rest = False
+            self.skip_newlines()
             if not self.at("RBRACK"):
                 while True:
                     item = self.parse_pattern_atom()
@@ -1508,8 +1509,10 @@ class Parser:
                     items.append(item)
                     if isinstance(item, RestPattern):
                         saw_rest = True
+                    self.skip_newlines()
                     if not self.maybe("COMMA"):
                         break
+                    self.skip_newlines()
             end = self.eat("RBRACK")
             return ListPattern(items, span=self.span_for_tokens(start, end))
         raise SyntaxError(f"Invalid pattern token {tok.text!r} ({tok.kind}) at {tok.pos}")

--- a/tests/test_lists_and_patterns.py
+++ b/tests/test_lists_and_patterns.py
@@ -23,6 +23,20 @@ def test_rest_pattern_and_wildcard(run):
     assert run(src) == 9
 
 
+def test_multiline_list_pattern_clause(run):
+    src = """
+    winner(xs) =
+      [
+        x, x, x,
+        .._
+      ] -> x |
+      _ -> "none"
+
+    winner([7, 7, 7, 0, 1, 2])
+    """
+    assert run(src) == 7
+
+
 def test_list_spread_literal(run):
     assert run("[..[1,2]]") == [1, 2]
     assert run("[1, ..[2,3]]") == [1, 2, 3]


### PR DESCRIPTION
### Motivation

- List-pattern clauses that spanned multiple lines could hit a parse error (`Invalid pattern token '\n'`) when a newline occurred between `[`/items/commas and the next token. This broke real examples (e.g., the tic-tac-toe patterns) and needs a minimal parser fix.

### Description

- Make the parser ignore/skip `NEWLINE` tokens inside list patterns by calling `skip_newlines()` right after `LBRACK`, after each parsed list-pattern item, and after commas in list patterns in `src/genia/interpreter.py`.
- Add a regression test `test_multiline_list_pattern_clause` in `tests/test_lists_and_patterns.py` to lock the multiline list-pattern behavior.
- Update the language state and rules documents by editing `GENIA_STATE.md` and `GENIA_RULES.md` to record that multiline list-pattern formatting is accepted and that the parser ignores newlines inside list patterns.
- Update the book chapter `docs/book/02-pattern-matching.md` with minimal/edge/failure examples for multiline list patterns so documentation matches implemented behavior.
- Commit message: `Fix newline handling in list patterns` (changes staged and committed).

### Testing

- Attempted to run `pytest` for the modified test file (`uv run pytest tests/test_lists_and_patterns.py -q`) but the runner failed to install `pytest` due to network/PyPI fetch restrictions in the environment, so the test suite could not be executed end-to-end.
- Manually exercised the interpreter with a temporary file containing a multiline list-pattern clause and confirmed `python3 src/genia/interpreter.py /tmp/newline_pattern_test.genia` returned the expected result (`"x"`).
- Other interactive program runs (e.g., `examples/tic-tac-toe.genia`) behaved as before but hit EOF in the non-interactive test environment when the program requested user input, which is expected and unrelated to the change.
- The new parser change and docs updates are committed and a regression test was added to prevent regression when test execution is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cca4118f448329ab07ab93aa3ee18a)