### PR TITLE
Add minimal map literal and map pattern syntax

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -58,10 +58,12 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - official docstring style/templates live in `docs/book/03-functions.md`
 - lambda expressions, including varargs lambdas with `..rest`
 - list literals with spread (`[..xs]`, `[1, ..xs, 2]`)
+- map literals (`{name: "m"}`, `{"name": "m"}`, `{}`)
 - function-call argument spread (`f(..xs)`)
 - pattern matching:
   - tuple patterns
   - list patterns
+  - map patterns (`{name}`, `{name: n}`, `{"name": n}`)
   - glob string patterns (`glob"..."`) with whole-string matching only
   - wildcard `_`
   - rest pattern `..rest` / `.._`
@@ -97,7 +99,6 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 
 ## Not implemented (current)
 
-- map/dict literals and map patterns
 - regex patterns / extglob operators
 - `$1` / `$2` / `ARGV`-style special CLI syntax
 - general host interop / FFI

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -47,10 +47,12 @@ Supported patterns:
 - wildcard `_`
 - tuple pattern
 - list pattern with optional rest
+- map pattern (string-keyed entries; partial-by-default)
 
 Required constraints:
 
 - list rest pattern (`..name` / `.._`) is valid only in final list-pattern position
+- map pattern shorthand is valid only for identifier keys (`{name}`), not string keys (`{"name"}` requires `:`)
 - parser ignores newlines between list-pattern delimiters and items
 - duplicate names in a pattern require equality at match time
 - glob patterns match only string values and must match the entire string
@@ -108,9 +110,9 @@ No additional member/index/flow operators should be introduced without explicitl
 - one handler invocation at a time per process
 - concurrency remains host-backed (threads), not language-scheduled
 
-## 11) Host-backed persistent map bridge invariants
+## 11) Host-backed persistent map invariants
 
-- persistent map support is runtime/builtin only (no syntax added)
+- persistent map runtime is shared by both map builtins and map literal/pattern syntax
 - required builtins: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
 - map values are opaque runtime wrappers, not exposed host objects
 - `map_put` / `map_remove` must return new map values (no mutation of prior values)

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -30,6 +30,7 @@ This file describes what is **actually implemented now** in the Python runtime.
 - pipeline operator: `|>`
 - block expressions: `{ ... }`
 - list literals: `[a, b, c]`
+- map literals: `{ key: value }` with identifier/string keys (`name: 1` sugar for `"name": 1`)
 - list spread in literals: `[..xs]`, `[1, ..xs, 2]`
 - call spread: `f(..xs)`
 - lambdas: `(x) -> x + 1`
@@ -80,9 +81,22 @@ Implemented pattern types:
 - wildcard `_`
 - tuple patterns
 - list patterns
+- map patterns (partial-by-default key matching)
 - rest pattern `..name` / `.._` (list patterns only; final position only)
 - duplicate binding semantics (same name must match equal value)
 - multiline list pattern formatting is accepted (newlines inside `[...]` pattern shapes)
+
+Map pattern semantics:
+
+- key forms:
+  - explicit: `{ name: n }`, `{ "name": n }`
+  - shorthand binding: `{ name }` (identifier keys only; sugar for `{ name: name }`)
+  - mixed forms are supported (`{ name, age: years }`)
+- patterns are partial by default:
+  - `{ name }` matches any map containing key `"name"`
+  - multiple entries require all listed keys to be present
+- missing keys fail the match
+- duplicate binding names follow normal duplicate-binding equality semantics
 
 Glob pattern semantics (Phase 1):
 
@@ -265,8 +279,8 @@ Implemented optimizations:
 Core IR shape currently includes:
 
 - program items: expression statement, assignment, named function definition
-- expressions: literal, variable, call, unary, binary, lambda, block, list, spread, case
-- patterns: wildcard, variable, literal, tuple, list, final rest
+- expressions: literal, variable, call, unary, binary, lambda, block, list, map, spread, case
+- patterns: wildcard, variable, literal, tuple, list, map, final rest
 - function docstrings are carried as metadata on named-function definitions (not runtime expressions)
 
 ## 8) Debug/runtime tooling
@@ -282,7 +296,6 @@ Core IR shape currently includes:
 
 ## 9) Explicitly not implemented (current)
 
-- map literals / map patterns
 - general host interop / FFI layer
 - module/import syntax
 - member access syntax

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Supported pattern forms:
 - wildcard `_`
 - tuple patterns (`(a, b)`)
 - list patterns (`[x, ..rest]`)
+- map patterns (`{name}`, `{name: n}`, `{"name": n}`; partial by default)
 - guards (`pattern ? condition -> result`)
 - duplicate bindings (`[x, x]` only matches equal values)
 
@@ -130,6 +131,18 @@ add(..[20, 22])
 
 - list literal spread is implemented
 - function call argument spread is implemented
+
+### Map literals
+
+```genia
+person = { name: "Matthew", age: 42 }
+point = { "x": 10, "y": 20 }
+empty = {}
+```
+
+- identifier keys in literals are sugar for string keys
+- trailing commas are supported
+- duplicate keys are deterministic last-one-wins
 
 ### Pipeline operator (Phase 1)
 
@@ -260,7 +273,6 @@ rewrite_zip(in_path, out_path) =
 
 ## Not implemented yet
 
-- map literals/patterns
 - general host interop / FFI
 - module/import syntax
 - member access / indexing syntax

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -22,7 +22,7 @@ This chapter covers the current Phase-1 host-backed core-data bridges (maps, byt
 
 ## Phase 1 map bridge (what it is)
 
-Genia does **not** have map literals or map patterns yet.
+Genia now has minimal map literals and map patterns, and still exposes the runtime/builtin bridge APIs directly.
 
 Instead, Genia now exposes a minimal runtime/builtin bridge:
 
@@ -33,7 +33,15 @@ Instead, Genia now exposes a minimal runtime/builtin bridge:
 - `map_remove(m, key)`
 - `map_count(m)`
 
-Implementation note: this is a **Phase 1 host-backed opaque map bridge**, not full native map syntax.
+Implementation note: map values remain the same **Phase 1 host-backed opaque map runtime value** under both builtin and literal syntax.
+
+Literal forms implemented:
+
+- `{}` (empty map)
+- `{ name: "Matthew" }` (identifier key sugar for string key)
+- `{ "name": "Matthew" }` (explicit string key)
+- trailing commas are accepted
+- duplicate keys are deterministic last-one-wins
 
 ---
 
@@ -110,8 +118,6 @@ Expected behavior:
 
 ### ❌ Not implemented
 
-- map literals
-- map pattern matching
 - member/index syntax for maps
 - general host interop / FFI
 

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -91,6 +91,40 @@ No conditionals needed.
 
 ---
 
+## Map patterns (implemented)
+
+Map patterns match required keys in persistent map values.
+
+### Minimal example
+
+```genia
+greet(person) =
+  ({ name }) -> "Hello " + name
+```
+
+`{ name }` is shorthand for `{ name: name }`.
+
+### Edge case example
+
+```genia
+describe(person) =
+  ({ name, age: years, city }) -> [name, years, city]
+```
+
+Map patterns are partial by default: extra keys are allowed.  
+All listed keys must be present.
+
+### Failure case example
+
+```genia
+bad(person) =
+  ({ "name" }) -> person
+```
+
+Expected behavior: syntax error (shorthand is only allowed for identifier keys; string keys must use `:`).
+
+---
+
 ## Multiline list patterns (implemented)
 
 List pattern shapes can span lines inside `[...]`.
@@ -291,6 +325,7 @@ Write `last` using pattern matching and recursion.
 * Basic pattern matching
 * Ordered evaluation
 * List destructuring (`[x, ..rest]`)
+* Map destructuring (`{name}`, `{name: n}`, mixed forms)
 * Variable binding
 * Pattern guards (`pattern ? guard -> result`)
 * Glob string patterns (`glob"..."`) with whole-string matching only

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -80,8 +80,8 @@ BASE_DIR = Path(__file__).resolve().parents[2] if "__file__" in globals() else P
 # - Clojure-style symbol punctuation that we allow in names is listed below.
 # - `name?` and `name!` are ordinary identifiers (no special lexer semantics).
 # - `/` is reserved for division and is not allowed inside identifier names.
-ALWAYS_OPERATOR_DELIMITERS = frozenset({"+", "*", "/", "%", "=", "<", ">", "|", ",", ";", "(", ")", "{", "}", "[", "]"})
-ALLOWED_SYMBOL_PUNCTUATION = frozenset({"_", "?", "!", ".", ":", "$", "-"})
+ALWAYS_OPERATOR_DELIMITERS = frozenset({"+", "*", "/", "%", "=", "<", ">", "|", ",", ";", ":", "(", ")", "{", "}", "[", "]"})
+ALLOWED_SYMBOL_PUNCTUATION = frozenset({"_", "?", "!", ".", "$", "-"})
 IDENT_START_RE = re.compile(r"[A-Za-z_$]")
 IDENT_BODY_RE = re.compile(r"[A-Za-z0-9]")
 
@@ -115,6 +115,7 @@ TOKEN_SPEC = [
     ("RBRACK", r"\]"),
     ("DOTDOT", r"\.\."),
     ("COMMA", r","),
+    ("COLON", r":"),
     ("SEMI", r";"),
     ("COMMENT", r"#[^\n]*"),
     ("NEWLINE", r"\n"),
@@ -150,6 +151,7 @@ PUNCTUATION_TOKENS = [
     ("LBRACK", "["),
     ("RBRACK", "]"),
     ("COMMA", ","),
+    ("COLON", ":"),
     ("SEMI", ";"),
 ]
 def _is_identifier_start(ch: str) -> bool:
@@ -575,6 +577,12 @@ class ListLiteral(Node):
 
 
 @dataclass
+class MapLiteral(Node):
+    items: list[tuple[str, Node]]
+    span: SourceSpan | None = None
+
+
+@dataclass
 class Spread(Node):
     expr: Node
     span: SourceSpan | None = None
@@ -606,6 +614,12 @@ class RestPattern(Node):
 @dataclass
 class TuplePattern(Node):
     items: list[Node]
+    span: SourceSpan | None = None
+
+
+@dataclass
+class MapPattern(Node):
+    items: list[tuple[str, Node]]
     span: SourceSpan | None = None
 
 
@@ -725,6 +739,14 @@ class IrList(IrNode):
 
 
 @dataclass
+class IrMap(IrNode):
+    """Map literal with lowered values and normalized string keys."""
+
+    items: list[tuple[str, IrNode]]
+    span: SourceSpan | None = None
+
+
+@dataclass
 class IrSpread(IrNode):
     """List spread element in expression contexts (list literals and call args)."""
 
@@ -776,6 +798,13 @@ class IrPatList(IrPattern):
     """List structural pattern with optional rest."""
 
     items: list[IrPattern]
+
+
+@dataclass
+class IrPatMap(IrPattern):
+    """Map pattern that requires listed string keys to exist."""
+
+    items: list[tuple[str, IrPattern]]
 
 
 @dataclass
@@ -879,6 +908,8 @@ def lower_node(node: Node) -> IrNode:
         return IrBlock([lower_node(expr) for expr in node.exprs], span=node.span)
     if isinstance(node, ListLiteral):
         return IrList([lower_node(item) for item in node.items], span=node.span)
+    if isinstance(node, MapLiteral):
+        return IrMap([(key, lower_node(value)) for key, value in node.items], span=node.span)
     if isinstance(node, Spread):
         return IrSpread(lower_node(node.expr), span=node.span)
     if isinstance(node, CaseExpr):
@@ -929,6 +960,8 @@ def lower_pattern(pattern: Node) -> IrPattern:
         return IrPatTuple([lower_pattern(item) for item in pattern.items])
     if isinstance(pattern, ListPattern):
         return IrPatList([lower_pattern(item) for item in pattern.items])
+    if isinstance(pattern, MapPattern):
+        return IrPatMap([(key, lower_pattern(value)) for key, value in pattern.items])
     if isinstance(pattern, GlobPattern):
         return IrPatGlob(compile_glob_pattern(pattern.pattern))
     raise RuntimeError(f"Unknown pattern during lowering: {pattern!r}")
@@ -1413,9 +1446,9 @@ class Parser:
                 j += 1
             if self.tokens[j].kind in {"ARROW", "QMARK"}:
                 return True
-        if self.at("LPAREN", "LBRACK"):
+        if self.at("LPAREN", "LBRACK", "LBRACE"):
             open_kind = self.peek().kind
-            close_kind = "RPAREN" if open_kind == "LPAREN" else "RBRACK"
+            close_kind = {"LPAREN": "RPAREN", "LBRACK": "RBRACK", "LBRACE": "RBRACE"}[open_kind]
             depth = 0
             j = self.i
             while True:
@@ -1515,6 +1548,8 @@ class Parser:
                     self.skip_newlines()
             end = self.eat("RBRACK")
             return ListPattern(items, span=self.span_for_tokens(start, end))
+        if tok.kind == "LBRACE":
+            return self.parse_map_pattern()
         raise SyntaxError(f"Invalid pattern token {tok.text!r} ({tok.kind}) at {tok.pos}")
 
     def parse_expr(self, min_prec: int = 0) -> Node:
@@ -1582,8 +1617,16 @@ class Parser:
         if tok.kind == "LBRACK":
             return self.parse_list_literal()
         if tok.kind == "LBRACE":
-            return self.parse_block(allow_final_case=False)
+            return self.parse_brace_expr()
         raise SyntaxError(f"Unexpected token {tok.text!r} ({tok.kind}) at {tok.pos}")
+
+    def parse_brace_expr(self) -> Node:
+        save = self.i
+        try:
+            return self.parse_map_literal()
+        except SyntaxError:
+            self.i = save
+            return self.parse_block(allow_final_case=False)
 
     def parse_list_literal(self) -> ListLiteral:
         start = self.eat("LBRACK")
@@ -1608,6 +1651,74 @@ class Parser:
         self.skip_newlines()
         end = self.eat("RBRACK")
         return ListLiteral(items, span=self.span_for_tokens(start, end))
+
+    def parse_map_literal_key(self) -> str:
+        if self.at("IDENT"):
+            return self.eat("IDENT").text
+        if self.at("STRING"):
+            return parse_string_literal(self.eat("STRING").text)
+        tok = self.peek()
+        raise SyntaxError(f"Invalid map key token {tok.text!r} ({tok.kind}) at {tok.pos}")
+
+    def parse_map_literal(self) -> MapLiteral:
+        start = self.eat("LBRACE")
+        self.skip_newlines()
+        items: list[tuple[str, Node]] = []
+        if not self.at("RBRACE"):
+            while True:
+                key = self.parse_map_literal_key()
+                self.skip_newlines()
+                self.eat("COLON")
+                self.skip_newlines()
+                value = self.parse_expr()
+                items.append((key, value))
+                self.skip_separators()
+                if not self.maybe("COMMA"):
+                    break
+                self.skip_newlines()
+                if self.at("RBRACE"):
+                    break
+                self.skip_newlines()
+        self.skip_newlines()
+        end = self.eat("RBRACE")
+        return MapLiteral(items, span=self.span_for_tokens(start, end))
+
+    def parse_map_pattern(self) -> MapPattern:
+        start = self.eat("LBRACE")
+        self.skip_newlines()
+        items: list[tuple[str, Node]] = []
+        if not self.at("RBRACE"):
+            while True:
+                if self.at("IDENT"):
+                    key_tok = self.eat("IDENT")
+                    key = key_tok.text
+                    if self.maybe("COLON"):
+                        self.skip_newlines()
+                        value_pattern = self.parse_pattern_atom()
+                    else:
+                        value_pattern = Var(key, span=self.span_for_tokens(key_tok, key_tok))
+                    items.append((key, value_pattern))
+                elif self.at("STRING"):
+                    key_tok = self.eat("STRING")
+                    key = parse_string_literal(key_tok.text)
+                    if not self.maybe("COLON"):
+                        raise SyntaxError(f"Map pattern shorthand is only allowed for identifier keys at {key_tok.pos}")
+                    self.skip_newlines()
+                    value_pattern = self.parse_pattern_atom()
+                    items.append((key, value_pattern))
+                else:
+                    bad = self.peek()
+                    raise SyntaxError(f"Invalid map pattern key token {bad.text!r} ({bad.kind}) at {bad.pos}")
+
+                self.skip_newlines()
+                if not self.maybe("COMMA"):
+                    break
+                self.skip_newlines()
+                if self.at("RBRACE"):
+                    break
+                self.skip_newlines()
+        end = self.eat("RBRACE")
+        return MapPattern(items, span=self.span_for_tokens(start, end))
 
     def finish_call(self, fn: Node) -> Node:
         self.eat("LPAREN")
@@ -2238,6 +2349,22 @@ class Evaluator:
                     return None
                 env[k] = v
             return env
+        if isinstance(pattern, IrPatMap):
+            if not isinstance(arg, GeniaMap):
+                return None
+            env: dict[str, Any] = {}
+            for key, value_pattern in pattern.items:
+                if not arg.has(key):
+                    return None
+                value = arg.get(key)
+                sub = self.match_pattern_atom(value_pattern, value)
+                if sub is None:
+                    return None
+                for k, v in sub.items():
+                    if k in env and env[k] != v:
+                        return None
+                    env[k] = v
+            return env
         raise RuntimeError(f"Unsupported pattern: {pattern!r}")
 
     def eval(self, node: IrNode) -> Any:
@@ -2263,6 +2390,11 @@ class Evaluator:
                     result.extend(value)
                 else:
                     result.append(self.eval(item))
+            return result
+        if isinstance(node, IrMap):
+            result = GeniaMap()
+            for key, value_node in node.items:
+                result = result.put(key, self.eval(value_node))
             return result
         if isinstance(node, IrVar):
             return self.env.get(node.name)

--- a/tests/test_map_syntax.py
+++ b/tests/test_map_syntax.py
@@ -1,0 +1,154 @@
+import pytest
+
+from genia.interpreter import (
+    IrExprStmt,
+    IrFuncDef,
+    IrMap,
+    IrPatBind,
+    IrPatMap,
+    IrPatTuple,
+    Parser,
+    make_global_env,
+    lex,
+    lower_program,
+    run_source,
+)
+
+
+def test_map_literal_basics_and_identifier_key_sugar(run):
+    src = '''
+    person = { name: "Matthew", age: 42 }
+    [map_get(person, "name"), map_get(person, "age")]
+    '''
+    assert run(src) == ["Matthew", 42]
+
+
+def test_empty_map_literal(run):
+    assert run("map_count({})") == 0
+
+
+def test_map_literal_trailing_comma(run):
+    assert run('map_get({ name: "m", }, "name")') == "m"
+
+
+def test_map_literal_string_keys(run):
+    assert run('map_get({ "x": 10, "y": 20 }, "y")') == 20
+
+
+def test_map_literal_duplicate_keys_last_one_wins(run):
+    assert run('map_get({ name: "first", name: "second" }, "name")') == "second"
+
+
+def test_map_patterns_explicit_binding(run):
+    src = '''
+    greet(person) =
+      ({ name: n }) -> "Hello " + n
+    greet({ name: "Matthew", age: 42 })
+    '''
+    assert run(src) == "Hello Matthew"
+
+
+def test_map_patterns_shorthand_binding(run):
+    src = '''
+    greet(person) =
+      ({ name }) -> "Hello " + name
+    greet({ name: "Matthew", age: 42 })
+    '''
+    assert run(src) == "Hello Matthew"
+
+
+def test_map_patterns_mixed_shorthand_and_explicit(run):
+    src = '''
+    describe(person) =
+      ({ name, age: years, city }) -> [name, years, city]
+    describe({ name: "M", age: 42, city: "SF" })
+    '''
+    assert run(src) == ["M", 42, "SF"]
+
+
+def test_map_patterns_partial_matching_semantics(run):
+    src = '''
+    classify(x) =
+      ({ type: "user", name }) -> "user:" + name |
+      ({ type: "system" }) -> "system"
+    classify({ type: "system", extra: 1 })
+    '''
+    assert run(src) == "system"
+
+
+def test_map_patterns_missing_key_mismatch(run):
+    src = '''
+    classify(x) =
+      ({ name }) -> name
+    classify({ age: 42 })
+    '''
+    with pytest.raises(RuntimeError, match="No matching case"):
+        run(src)
+
+
+def test_map_patterns_duplicate_binding_equality_semantics(run):
+    src = '''
+    same(x) =
+      ({ left: n, right: n }) -> true |
+      (_) -> false
+    [same({ left: 1, right: 1 }), same({ left: 1, right: 2 })]
+    '''
+    assert run(src) == [True, False]
+
+
+def test_map_patterns_work_in_function_clauses(run):
+    src = '''
+    tag(item) =
+      ({ type: "user", name }) -> "u:" + name |
+      ({ type: "system" }) -> "s"
+    tag({ type: "user", name: "a", age: 1 })
+    '''
+    assert run(src) == "u:a"
+
+
+def test_map_patterns_work_in_case_expressions(run):
+    src = '''
+    classify(x) {
+      { type: "user", name } -> "user:" + name |
+      { type: "system" } -> "system"
+    }
+
+    classify({ type: "user", name: "Ada", extra: true })
+    '''
+    assert run(src) == "user:Ada"
+
+
+def test_invalid_map_pattern_string_key_shorthand_is_rejected(run):
+    src = '''
+    f(x) =
+      ({ "name" }) -> x
+    '''
+    with pytest.raises(SyntaxError, match="shorthand is only allowed for identifier keys"):
+        run(src)
+
+
+def test_ir_contains_map_literal_and_map_pattern_nodes():
+    src = '''
+    classify(x) =
+      ({ name }) -> name
+    { name: "m" }
+    '''
+    ir_nodes = lower_program(Parser(lex(src)).parse_program())
+
+    fn = ir_nodes[0]
+    assert isinstance(fn, IrFuncDef)
+    assert isinstance(fn.body.clauses[0].pattern, IrPatTuple)
+    pat = fn.body.clauses[0].pattern.items[0]
+    assert isinstance(pat, IrPatMap)
+    assert isinstance(pat.items[0][1], IrPatBind)
+
+    expr_stmt = ir_nodes[1]
+    assert isinstance(expr_stmt, IrExprStmt)
+    assert isinstance(expr_stmt.expr, IrMap)
+
+
+def test_map_literal_identifier_and_string_keys_same_result():
+    env = make_global_env([])
+    left = run_source('map_get({ name: "Matthew" }, "name")', env)
+    right = run_source('map_get({ "name": "Matthew" }, "name")', env)
+    assert left == right == "Matthew"


### PR DESCRIPTION
### Motivation

- Expose a minimal, idiomatic literal syntax for the existing persistent runtime maps to make everyday usage and examples simpler without changing the runtime map implementation. 
- Provide pattern-matching-first destructuring for maps so map-based dispatch integrates with Genia’s core pattern-match branching model. 
- Keep changes minimal and consistent with the existing AST → tiny Core IR → evaluator pipeline and the project’s immutability / pattern-first philosophy.

### Description

- Lexer and parser: added `COLON` token, `MapLiteral` and `MapPattern` AST nodes, `parse_map_literal`, `parse_map_pattern`, and a `parse_brace_expr` dispatcher to disambiguate `{ ... }` as either a map literal or a block. 
- IR and lowering: added `IrMap` and `IrPatMap` nodes and lowered `MapLiteral`/`MapPattern` into those IR nodes in `lower_node` / `lower_pattern`. 
- Evaluation / matching: map literals now evaluate to the existing `GeniaMap` runtime by iterative `put`, and `IrPatMap` participates in pattern matching with partial-by-default semantics (listed keys required, extras allowed); shorthand `{name}` lowers to `{ "name": name }` in patterns only. 
- Errors & constraints: shorthand destructuring is restricted to identifier keys (string-key shorthand is a syntax error), duplicate literal keys are deterministic (last-one-wins via sequential `put`), and no new conditional or map rest/spread features were added. 
- Files changed: `src/genia/interpreter.py`, `tests/test_map_syntax.py` (new), `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, `docs/book/01-core-data.md`, and `docs/book/02-pattern-matching.md` (documentation synchronized with implementation).

### Testing

- Added `tests/test_map_syntax.py` covering: map literal basics, empty map, trailing commas, identifier vs string keys, duplicate-key last-one-wins, explicit/shorthand/mixed map patterns, partial-match semantics, missing-key mismatch, duplicate-binding equality behavior, function-clause and case-expression usage, IR lowering, and invalid-shorthand syntax.
- Ran targeted tests during development and then the full test suite with `pytest -q`, and all tests passed: `294 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd20cdad6c8329bb339ed27e8d02ad)