### PR TITLE
Align map literal/pattern truth across tests and docs

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -92,6 +92,7 @@ Map pattern semantics:
   - explicit: `{ name: n }`, `{ "name": n }`
   - shorthand binding: `{ name }` (identifier keys only; sugar for `{ name: name }`)
   - mixed forms are supported (`{ name, age: years }`)
+- trailing commas are accepted (`{ name, age: years, }`)
 - patterns are partial by default:
   - `{ name }` matches any map containing key `"name"`
   - multiple entries require all listed keys to be present

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Supported pattern forms:
 - tuple patterns (`(a, b)`)
 - list patterns (`[x, ..rest]`)
 - map patterns (`{name}`, `{name: n}`, `{"name": n}`; partial by default)
+- map pattern shorthand is identifier-only (`{"name"}` shorthand is invalid; use `{"name": n}`)
 - guards (`pattern ? condition -> result`)
 - duplicate bindings (`[x, x]` only matches equal values)
 

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -345,7 +345,7 @@ Expected behavior (demo grid wrapping):
 - The demo is text-mode only (no graphics).
 - The first version is single-ant only.
 - Simulation timing is blocking (`sleep`) and host-dependent.
-- There is still no native map syntax (no map literals, no map patterns).
+- Native map syntax is available for authoring state (`{}`, `{ key: value }`, map patterns like `{name}`).
 - There is still no scheduler/event loop or language-level simulation framework.
 
 ### Implementation status for the ants demo

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -108,7 +108,7 @@ greet(person) =
 
 ```genia
 describe(person) =
-  ({ name, age: years, city }) -> [name, years, city]
+  ({ "name": name, age: years, city, }) -> [name, years, city]
 ```
 
 Map patterns are partial by default: extra keys are allowed.  

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2,15 +2,6 @@
 """
 Minimal Genia REPL / interpreter prototype.
 
-Need to implement soon:
-And I would say this requires:
-
-- list values
-- list patterns
-- wildcard _
-- rest pattern ..
-- recursion
-
 Implemented subset:
 - numbers, booleans, nil, strings
 - arithmetic: + - * / %
@@ -24,13 +15,6 @@ Implemented subset:
 - guards: pattern ? condition -> result
 - blocks with newline or ; expression separators
 - builtins: log(...), print(...), input(prompt), help()
-
-Not yet implemented:
-- lambdas
-- lists/maps/destructuring beyond tuple-parameter patterns
-- pipelines
-- member access / indexing
-- modules
 """
 from __future__ import annotations
 

--- a/tests/test_map_syntax.py
+++ b/tests/test_map_syntax.py
@@ -48,6 +48,15 @@ def test_map_patterns_explicit_binding(run):
     assert run(src) == "Hello Matthew"
 
 
+def test_map_patterns_explicit_string_key_binding(run):
+    src = '''
+    greet(person) =
+      ({ "name": n }) -> "Hello " + n
+    greet({ name: "Matthew", age: 42 })
+    '''
+    assert run(src) == "Hello Matthew"
+
+
 def test_map_patterns_shorthand_binding(run):
     src = '''
     greet(person) =
@@ -114,6 +123,15 @@ def test_map_patterns_work_in_case_expressions(run):
     }
 
     classify({ type: "user", name: "Ada", extra: true })
+    '''
+    assert run(src) == "user:Ada"
+
+
+def test_map_patterns_allow_trailing_comma(run):
+    src = '''
+    classify(x) =
+      ({ type: "user", name, }) -> "user:" + name
+    classify({ type: "user", name: "Ada" })
     '''
     assert run(src) == "user:Ada"
 


### PR DESCRIPTION
### Motivation
- Tighten and align the repository truth for map literals and map patterns so code, tests, and docs consistently describe the implemented behavior. 
- Remove stale interpreter commentary that claimed map/list destructuring or related features were missing and could cause confusion. 

### Description
- Added focused syntax tests to `tests/test_map_syntax.py` for explicit string-key map pattern binding (`{"name": n}`) and trailing-comma acceptance in map patterns. 
- Removed stale top-level commentary in `src/genia/interpreter.py` that asserted maps/destructuring were not implemented. 
- Updated documentation to reflect actual behavior by editing `GENIA_STATE.md`, `README.md`, `docs/book/01-core-data.md`, and `docs/book/02-pattern-matching.md` to mention identifier-key sugar, string-key map literals, partial-by-default map patterns, shorthand identifier-only constraint, and trailing-comma acceptance. 
- No runtime semantics were added or changed; this is a cleanup and validation pass that strengthens tests and corrects docs to match the existing implementation. 

### Testing
- Ran `pytest -q tests/test_map_syntax.py tests/test_maps.py` and observed all tests in those files passed (`27 passed`). 
- The changes were verified to not alter runtime behavior, and the new tests confirm explicit string-key pattern binding and trailing commas in map patterns are accepted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd383ee7a0832981e06435382fbe75)