### PR TITLE
Add phase-1 callable maps and string projectors

### DIFF
--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -118,6 +118,16 @@ No additional member/index/flow operators should be introduced without explicitl
 - `map_put` / `map_remove` must return new map values (no mutation of prior values)
 - unsupported map input types and unsupported key types must raise clear `TypeError`
 
+## 11.1) Callable-data invariants (phase 1)
+
+- ordinary call syntax may target map values and string values in these exact forms only:
+  - `m(key)` / `m(key, default)` where `m` is a map value
+  - `"key"(m)` / `"key"(m, default)` where first arg is a map value
+- map-call and string-projector-call arity is restricted to 1 or 2; other arities raise clear `TypeError`
+- missing map keys return `nil` unless an explicit default is provided in arity-2 form
+- string projector with non-map target raises clear `TypeError`
+- this does not add parser syntax, call operators, or user-defined callable-data protocols
+
 ## 12) Error behavior
 
 - unmatched function/case dispatch should raise deterministic runtime errors

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -63,6 +63,16 @@ Pipeline (Phase 1) rewrite model:
 - resolution behavior:
   - exact fixed arity beats varargs
   - if multiple varargs candidates match and neither is more specific, runtime raises `TypeError("Ambiguous function resolution")`
+- callable data (phase 1):
+  - maps are callable lookup values:
+    - `m(key)` returns stored value or `nil`
+    - `m(key, default)` returns stored value or `default` when key is missing
+    - arity other than 1 or 2 raises `TypeError`
+  - strings are callable map projectors:
+    - `"key"(m)` returns `map_get(m, "key")` behavior (`value` or `nil`)
+    - `"key"(m, default)` returns `value` or `default` when key is missing
+    - first argument must be a map; non-map targets raise `TypeError`
+    - arity other than 1 or 2 raises `TypeError`
 
 ## 4) Case expressions and pattern matching
 

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -111,6 +111,12 @@ Expected behavior:
 - map builtins (`map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`)
 - persistent behavior for `map_put` and `map_remove`
 - missing-key lookup returns `nil`
+- callable map lookup:
+  - `m(key)` => value or `nil`
+  - `m(key, default)` => value or `default`
+- callable string projectors for maps:
+  - `"key"(m)` => value or `nil`
+  - `"key"(m, default)` => value or `default`
 
 ### ⚠️ Partial
 
@@ -119,7 +125,76 @@ Expected behavior:
 ### ❌ Not implemented
 
 - member/index syntax for maps
+- callable data beyond maps and string projectors (no list-call, no string indexing, no callable protocol)
 - general host interop / FFI
+
+---
+
+## Callable data (phase 1, map-centric)
+
+Only two callable-data forms are implemented in this phase.
+
+### Minimal example
+
+```genia
+person = { name: "Matthew", age: 42 }
+[person("name"), "age"(person)]
+```
+
+Expected result:
+
+```genia
+["Matthew", 42]
+```
+
+### Edge case example
+
+```genia
+person = { name: "Matthew" }
+[person("missing"), person("missing", "?"), "missing"(person, "?")]
+```
+
+Expected result:
+
+```genia
+[nil, "?", "?"]
+```
+
+### Failure case example
+
+```genia
+"name"(42)
+```
+
+Expected behavior:
+
+- raises `TypeError` because string projector targets must be maps.
+
+Another failure case:
+
+```genia
+{}()
+```
+
+Expected behavior:
+
+- raises `TypeError` because callable maps support only arity 1 or 2.
+
+### Implementation status
+
+### ✅ Implemented
+
+- map callable lookup by key (`m(key)`) and key-with-default (`m(key, default)`)
+- string key projector lookup against maps (`"key"(m)` and `"key"(m, default)`)
+- missing-key result is `nil` (or provided default in arity-2 forms)
+
+### ⚠️ Partial
+
+- callable-data support is intentionally narrow to canonical map lookup and string projection only
+
+### ❌ Not implemented
+
+- any other callable-data behavior (lists, nested path lookup, mutation-by-call, user-defined callable protocols)
 
 ---
 

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -8,6 +8,13 @@ inc(x) = x + 1
 
 Named functions are values and dispatch by name + arity shape.
 
+Ordinary call syntax also supports a small callable-data subset:
+
+- maps: `m(key)` / `m(key, default)`
+- string projectors over maps: `"key"(m)` / `"key"(m, default)`
+
+No other callable-data forms are implemented in this phase.
+
 ---
 
 ## Function Docstrings (Implemented)

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2248,6 +2248,29 @@ class Evaluator:
                 return TailCall(target, tuple(args))
             return target(*args)
 
+        if isinstance(fn, GeniaMap):
+            arg_count = len(args)
+            if arg_count == 1:
+                return fn.get(args[0])
+            if arg_count == 2:
+                value = fn.get(args[0])
+                if value is None:
+                    return args[1]
+                return value
+            raise TypeError(f"map callable expected 1 or 2 args, got {arg_count}")
+
+        if isinstance(fn, str):
+            arg_count = len(args)
+            if arg_count not in (1, 2):
+                raise TypeError(f"string projector expected 1 or 2 args, got {arg_count}")
+            target = args[0]
+            if not isinstance(target, GeniaMap):
+                raise TypeError("string projector expected a map as first argument")
+            value = target.get(fn)
+            if value is None and arg_count == 2:
+                return args[1]
+            return value
+
         if tail_position and not self.debug_mode:
             return TailCall(fn, tuple(args))
         return fn(*args)

--- a/tests/test_callable_data.py
+++ b/tests/test_callable_data.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+def test_map_callable_lookup_and_default(run):
+    src = '''
+    person = { name: "Matthew", age: 42 }
+    [person("name"), person("missing"), person("missing", "?")]
+    '''
+    assert run(src) == ["Matthew", None, "?"]
+
+
+def test_string_projector_lookup_and_default(run):
+    src = '''
+    person = { name: "Matthew", age: 42 }
+    ["name"(person), "missing"(person), "missing"(person, "?")]
+    '''
+    assert run(src) == ["Matthew", None, "?"]
+
+
+def test_map_callable_wrong_arity_raises_clear_error(run):
+    with pytest.raises(TypeError, match="map callable expected 1 or 2 args, got 0"):
+        run("{}()")
+
+    with pytest.raises(TypeError, match="map callable expected 1 or 2 args, got 3"):
+        run('{}("a", "b", "c")')
+
+
+def test_string_projector_wrong_arity_raises_clear_error(run):
+    with pytest.raises(TypeError, match="string projector expected 1 or 2 args, got 0"):
+        run('"name"()')
+
+    with pytest.raises(TypeError, match="string projector expected 1 or 2 args, got 3"):
+        run('"name"({}, "x", "y")')
+
+
+def test_string_projector_requires_map_target(run):
+    with pytest.raises(TypeError, match="string projector expected a map as first argument"):
+        run('"name"(42)')
+
+
+def test_ordinary_non_callable_values_still_fail_normally(run):
+    with pytest.raises(TypeError):
+        run("1(2)")
+
+
+def test_ordinary_function_calls_still_work(run):
+    src = """
+    inc(x) = x + 1
+    inc(4)
+    """
+    assert run(src) == 5


### PR DESCRIPTION
### Motivation

- Provide a minimal, predictable way to query maps with ordinary call syntax so `m(key)` / `m(key, default)` and string projectors `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd45f16e008329959b2f4a09624147)