### PR TITLE
Fix callable-data defaults to apply only for missing keys; add tests and update docs

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -59,6 +59,9 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - lambda expressions, including varargs lambdas with `..rest`
 - list literals with spread (`[..xs]`, `[1, ..xs, 2]`)
 - map literals (`{name: "m"}`, `{"name": "m"}`, `{}`)
+- callable data (phase 1 subset):
+  - map lookup calls: `m(key)`, `m(key, default)`
+  - string projector calls over maps: `"key"(m)`, `"key"(m, default)`
 - function-call argument spread (`f(..xs)`)
 - pattern matching:
   - tuple patterns

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -66,11 +66,11 @@ Pipeline (Phase 1) rewrite model:
 - callable data (phase 1):
   - maps are callable lookup values:
     - `m(key)` returns stored value or `nil`
-    - `m(key, default)` returns stored value or `default` when key is missing
+    - `m(key, default)` returns stored value when key exists, otherwise `default`
     - arity other than 1 or 2 raises `TypeError`
   - strings are callable map projectors:
     - `"key"(m)` returns `map_get(m, "key")` behavior (`value` or `nil`)
-    - `"key"(m, default)` returns `value` or `default` when key is missing
+    - `"key"(m, default)` returns stored value when key exists, otherwise `default`
     - first argument must be a map; non-map targets raise `TypeError`
     - arity other than 1 or 2 raises `TypeError`
 

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -113,10 +113,10 @@ Expected behavior:
 - missing-key lookup returns `nil`
 - callable map lookup:
   - `m(key)` => value or `nil`
-  - `m(key, default)` => value or `default`
+  - `m(key, default)` => stored value when key exists, else `default`
 - callable string projectors for maps:
   - `"key"(m)` => value or `nil`
-  - `"key"(m, default)` => value or `default`
+  - `"key"(m, default)` => stored value when key exists, else `default`
 
 ### ⚠️ Partial
 
@@ -186,7 +186,7 @@ Expected behavior:
 
 - map callable lookup by key (`m(key)`) and key-with-default (`m(key, default)`)
 - string key projector lookup against maps (`"key"(m)` and `"key"(m, default)`)
-- missing-key result is `nil` (or provided default in arity-2 forms)
+- missing-key result is `nil` (or provided default in arity-2 forms); existing keys mapped to `nil` still return `nil`
 
 ### ⚠️ Partial
 

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -12,6 +12,7 @@ Ordinary call syntax also supports a small callable-data subset:
 
 - maps: `m(key)` / `m(key, default)`
 - string projectors over maps: `"key"(m)` / `"key"(m, default)`
+- in arity-2 forms, the second argument is used only when the key is missing
 
 No other callable-data forms are implemented in this phase.
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2253,10 +2253,10 @@ class Evaluator:
             if arg_count == 1:
                 return fn.get(args[0])
             if arg_count == 2:
-                value = fn.get(args[0])
-                if value is None:
-                    return args[1]
-                return value
+                key = args[0]
+                if fn.has(key):
+                    return fn.get(key)
+                return args[1]
             raise TypeError(f"map callable expected 1 or 2 args, got {arg_count}")
 
         if isinstance(fn, str):
@@ -2266,10 +2266,9 @@ class Evaluator:
             target = args[0]
             if not isinstance(target, GeniaMap):
                 raise TypeError("string projector expected a map as first argument")
-            value = target.get(fn)
-            if value is None and arg_count == 2:
+            if arg_count == 2 and not target.has(fn):
                 return args[1]
-            return value
+            return target.get(fn)
 
         if tail_position and not self.debug_mode:
             return TailCall(fn, tuple(args))

--- a/tests/test_callable_data.py
+++ b/tests/test_callable_data.py
@@ -9,12 +9,28 @@ def test_map_callable_lookup_and_default(run):
     assert run(src) == ["Matthew", None, "?"]
 
 
+def test_map_callable_default_only_for_missing_keys(run):
+    src = '''
+    person = { name: nil }
+    person("name", "?")
+    '''
+    assert run(src) is None
+
+
 def test_string_projector_lookup_and_default(run):
     src = '''
     person = { name: "Matthew", age: 42 }
     ["name"(person), "missing"(person), "missing"(person, "?")]
     '''
     assert run(src) == ["Matthew", None, "?"]
+
+
+def test_string_projector_default_only_for_missing_keys(run):
+    src = '''
+    person = { name: nil }
+    "name"(person, "?")
+    '''
+    assert run(src) is None
 
 
 def test_map_callable_wrong_arity_raises_clear_error(run):


### PR DESCRIPTION
### Motivation
- Fix a correctness bug where `m(key, default)` and `"key"(m, default)` returned the `default` when the key existed with a stored `nil` value.  
- Ensure callable-map and string-projector behavior is precise and aligns with the language invariants (presence vs. value).  
- Keep docs and tests synchronized with the runtime: book chapters and `GENIA_STATE.md` must describe only implemented behavior.

### Description
- Change runtime call dispatch so map-callable arity-2 uses `has(key)` to decide whether to return the stored value or the provided default (`src/genia/interpreter.py`).
- Change string-projector arity-2 to consult the target map's `has` before returning the default, and preserve `nil` values when the key exists (`src/genia/interpreter.py`).
- Add focused tests for `nil`-valued keys for both map-call (`person("name", "?")`) and string-projector (`"name"(person, "?")`) forms, plus existing callable-data coverage (`tests/test_callable_data.py`).
- Update authoritative docs to match exact runtime behavior: `GENIA_STATE.md`, `docs/book/01-core-data.md`, `docs/book/03-functions.md`, and `GENIA_REPL_README.md` to clarify that arity-2 defaults are used only when the key is missing.

### Testing
- Ran `pytest -q tests/test_callable_data.py tests/test_pipeline_operator.py tests/test_maps.py tests/test_lists_and_patterns.py` and all tests passed (`40 passed`).  
- The new callable-data tests exercise success cases, arity errors, wrong-target `TypeError`, and the `nil`-value edge cases and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd4a66edd483298de7a96468c56e48)