### PR TITLE
Generalize pipeline lowering docs/tests for callable RHS expressions

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -46,7 +46,8 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - literals: numbers, strings (single/double quotes + escapes, plus triple-quoted multiline strings), booleans, `nil`
 - variables and top-level assignment (`name = expr`)
 - unary/binary operators: `!`, unary `-`, `+ - * / %`, comparisons, equality, `&&`, `||`
-- pipeline operator (phase 1): `|>` with call-rewrite semantics (`x |> f` → `f(x)`, `x |> f(y)` → `f(y, x)`)
+- pipeline operator (phase 2): `|>` with call-rewrite semantics (`x |> f` → `f(x)`, `x |> f(y)` → `f(y, x)`, `x |> expr` → `expr(x)` when `expr` is valid in ordinary call-callee position)
+  - example: `record |> "name"` behaves like `"name"(record)`
   - lowering/desugaring happens in the AST→Core IR pass
 - function definitions with expression body, block body, or case body
 - optional named-function docstring metadata:

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -97,6 +97,8 @@ Pipeline rewrite invariant:
 
 - `x |> f` is equivalent to `f(x)`
 - `x |> f(y)` is equivalent to `f(y, x)` (append source value as final arg)
+- `x |> expr` is equivalent to `expr(x)` when `expr` is valid in ordinary call-callee position
+  - example: `record |> "name"` is equivalent to `"name"(record)`
 - chaining is left-associative
 - rewrite happens in lowering from parsed AST to Core IR; runtime does not treat pipeline as a separate IR/runtime primitive
 - this is expression-level call rewriting only (no stream runtime semantics)

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -36,10 +36,12 @@ This file describes what is **actually implemented now** in the Python runtime.
 - lambdas: `(x) -> x + 1`
 - varargs lambdas: `(..xs) -> xs`, `(a, ..rest) -> rest`
 
-Pipeline (Phase 1) rewrite model:
+Pipeline (Phase 2) rewrite model:
 
 - `x |> f` rewrites to `f(x)`
 - `x |> f(y)` rewrites to `f(y, x)` (left value appended as the last argument)
+- `x |> expr` rewrites to `expr(x)` when `expr` is valid in ordinary call-callee position
+  - example: `record |> "name"` rewrites to `"name"(record)`
 - left associative: `a |> f |> g` rewrites to `g(f(a))`
 - rewrite is performed in the AST→Core IR lowering pass (not by runtime special-casing)
 - no stream runtime semantics are added in this phase

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -160,6 +160,21 @@ Expected result:
 [nil, "?", "?"]
 ```
 
+Pipeline cross-reference (same callable semantics, pipeline lowering only):
+
+```genia
+person = { name: "Matthew" }
+person |> "name"
+```
+
+Expected result:
+
+```genia
+"Matthew"
+```
+
+This works because pipeline lowers to ordinary call form (`person |> "name"` -> `"name"(person)`), not because pipeline has separate lookup semantics.
+
 ### Failure case example
 
 ```genia

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -252,7 +252,7 @@ No documentation available.
 
 ---
 
-## Pipeline Operator (Phase 1)
+## Pipeline Operator (Phase 2)
 
 Genia now supports a minimal pipeline operator for left-to-right function composition:
 
@@ -262,33 +262,35 @@ Rewrite rules (implemented):
 
 * `x |> f` becomes `f(x)`
 * `x |> f(y)` becomes `f(y, x)` (the piped value is appended as the final argument)
+* `x |> expr` becomes `expr(x)` when `expr` is valid in ordinary call-callee position
+  * this includes callable data such as string projectors over maps (`record |> "name"` -> `"name"(record)`)
 * chaining is left-associative: `a |> f |> g` becomes `g(f(a))`
 * this rewrite happens in the AST→Core IR lowering pass
 
 ### Minimal example
 
 ```genia
-inc(x) = x + 1
-4 |> inc
+record = { name: "Matthew" }
+record |> "name"
 ```
 
 Result:
 
 ```genia
-5
+"Matthew"
 ```
 
 ### Edge case example
 
 ```genia
-pair(a, b) = [a, b]
-9 |> pair(1)
+record = { user: { name: "Matthew" } }
+record |> "user" |> "name"
 ```
 
 Result:
 
 ```genia
-[1, 9]
+"Matthew"
 ```
 
 Pipeline-friendly API design note:
@@ -306,6 +308,16 @@ Expected behavior:
 
 * runtime `TypeError` because `2` is not callable.
 
+Another failure case:
+
+```genia
+"name"(42)
+```
+
+Expected behavior:
+
+* runtime `TypeError` because string projectors require a map-like runtime map target.
+
 ---
 
 ## Implementation Status
@@ -319,6 +331,7 @@ Expected behavior:
   * fallback to `main/0` when `main/1` is absent
   * trailing CLI args in `-c` mode are passed through to `argv()` (including bare positional values)
 * Pipeline operator `|>` with expression-level call rewriting
+* Bare callable pipeline RHS forms that lower to ordinary call syntax (for example, string projector pipelines such as `record |> "name"`)
 * Named-function docstring metadata (`f(...) = "doc" ...`)
 * `help(name)` output with:
   * signature header (`name/shape`)

--- a/tests/test_pipeline_operator.py
+++ b/tests/test_pipeline_operator.py
@@ -66,6 +66,46 @@ def test_pipeline_with_list_helpers(run):
     assert run(src) == [2, 3, 4]
 
 
+def test_pipeline_people_map_name_projector_call_form(run):
+    src = '''
+    people = [{name: "A"}, {name: "B"}]
+    people |> map("name")
+    '''
+    assert run(src) == ["A", "B"]
+
+
+def test_pipeline_with_string_projector_rhs(run):
+    src = '''
+    record = { name: "Matthew", age: 42 }
+    record |> "name"
+    '''
+    assert run(src) == "Matthew"
+
+
+def test_pipeline_with_missing_string_projector_key_returns_nil(run):
+    src = '''
+    record = { name: "Matthew", age: 42 }
+    record |> "missing"
+    '''
+    assert run(src) is None
+
+
+def test_pipeline_with_parenthesized_string_projector_rhs(run):
+    src = '''
+    record = { name: "Matthew" }
+    record |> ("name")
+    '''
+    assert run(src) == "Matthew"
+
+
+def test_pipeline_string_projector_chain(run):
+    src = '''
+    record = { user: { name: "Matthew" } }
+    record |> "user" |> "name"
+    '''
+    assert run(src) == "Matthew"
+
+
 def test_pipeline_with_case_expression_still_rejected_in_subexpression(run):
     src = """
     id(x) = x


### PR DESCRIPTION
### Motivation

- Make pipeline ergonomics consistent with callable-data phase 1 by allowing a bare callable expression on the RHS of `|>` to lower to an ordinary call. 
- Preserve the lowering-only model (no runtime special-casing) and reuse ordinary call semantics for callable RHS forms such as string projectors. 

### Description

- Added focused tests in `tests/test_pipeline_operator.py` to cover `record |> "name"`, missing-key behavior, parenthesized RHS, chained projector pipelines, and the compatibility case `people |> map("name")`. 
- Updated authoritative documentation to document Phase 2 lowering: `GENIA_STATE.md`, `GENIA_RULES.md`, and `GENIA_REPL_README.md` now state that `x |> expr` lowers to `expr(x)` when `expr` is valid as an ordinary call callee and include a string-projector example. 
- Updated learning book chapters `docs/book/03-functions.md` and `docs/book/01-core-data.md` with minimal, edge, and failure examples and a cross-reference showing pipeline projector use, keeping examples aligned with implemented behavior. 
- No runtime or parser syntax changes were introduced; the change is tests/docs only because the lowering path already supported the generalized callable-RHS shape. 

### Testing

- Ran the focused pipeline and callable-data tests with `pytest -q tests/test_pipeline_operator.py tests/test_callable_data.py` which passed. 
- Ran a broader subset with `pytest -q tests/test_pipeline_operator.py tests/test_callable_data.py tests/test_map_syntax.py tests/test_higher_order.py tests/test_varargs_apply.py` and the suite passed (`51 passed`). 
- All modified tests and existing callable-data pipeline behavior succeeded with no regressions observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d071bdcc1c8329b0c5489b9a1fdd77)