### PR TITLE
Add minimal Option primitive (`none` / `some`) and `get?`/`unwrap_or` builtins

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -43,7 +43,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 ## Implemented today
 
 - parser keeps a surface AST and lowers it into a minimal Core IR before evaluation
-- literals: numbers, strings (single/double quotes + escapes, plus triple-quoted multiline strings), booleans, `nil`
+- literals: numbers, strings (single/double quotes + escapes, plus triple-quoted multiline strings), booleans, `nil`, `none`
 - variables and top-level assignment (`name = expr`)
 - unary/binary operators: `!`, unary `-`, `+ - * / %`, comparisons, equality, `&&`, `||`
 - pipeline operator (phase 2): `|>` with call-rewrite semantics (`x |> f` → `f(x)`, `x |> f(y)` → `f(y, x)`, `x |> expr` → `expr(x)` when `expr` is valid in ordinary call-callee position)
@@ -87,6 +87,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - refs: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
   - concurrency: `spawn`, `send`, `process_alive?`
   - phase-1 persistent associative maps: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`
+  - phase-1 primitive option model: `none`, `some`, `get?`, `unwrap_or`, `is_some?`, `is_none?`
   - simulation primitives (phase 2): `rand`, `rand_int`, `sleep`
   - bytes/json/zip bridge builtins (phase 1):
     - `utf8_encode`, `utf8_decode`

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -152,6 +152,20 @@ No additional member/index/flow operators should be introduced without explicitl
 - string projector with non-map target raises clear `TypeError`
 - this does not add parser syntax, call operators, or user-defined callable-data protocols
 
+## 11.2) Option invariants (phase 1)
+
+- primitive option values are `none` and `some(value)` (where `none` is distinct from `nil`)
+- `get?(key, target)` is defined exactly as:
+  - `get?(key, none) -> none`
+  - `get?(key, some(map)) -> get?(key, map)`
+  - `get?(key, map) -> some(value)` when key exists
+  - `get?(key, map) -> none` when key is missing
+- key presence, not value truthiness, determines `some(...)` vs `none`
+  - key mapped to `nil` still returns `some(nil)`
+- `unwrap_or(default, opt)` accepts option values only
+- `is_some?(opt)` and `is_none?(opt)` report option shape
+- pipeline behavior is unchanged and relies on existing rewrite rules (`record |> get?("name")` rewrites to `get?("name", record)`)
+
 ## 12) Error behavior
 
 - unmatched function/case dispatch should raise deterministic runtime errors

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -22,7 +22,7 @@ This file describes what is **actually implemented now** in the Python runtime.
 
 ## 2) Implemented syntax and expression forms
 
-- literals: number, string (single/double quoted + triple-quoted multiline), boolean, `nil`
+- literals: number, string (single/double quoted + triple-quoted multiline), boolean, `nil`, `none`
 - variables
 - function calls
 - unary operators: `-`, `!`
@@ -227,6 +227,31 @@ Behavior:
 - list keys are supported by stable structural key-freezing in runtime
 - tuple keys are supported by the same runtime key-freezing strategy (runtime-level interop values)
 - invalid map arguments and unsupported key types raise clear `TypeError`
+
+### Primitive Option model (Phase 1, runtime-backed)
+
+- option values:
+  - `none` (distinct from `nil`)
+  - `some(value)`
+- option/query builtins:
+  - `get?(key, target)`
+  - `unwrap_or(default, opt)`
+  - `is_some?(opt)`
+  - `is_none?(opt)`
+
+`get?` semantics:
+
+- `get?(key, none) -> none`
+- `get?(key, some(map)) -> get?(key, map)`
+- `get?(key, map) -> some(value)` when key exists (including `value = nil`)
+- `get?(key, map) -> none` when key is missing
+- unsupported target types raise clear `TypeError`
+
+Compatibility note:
+
+- existing callable-data map/string-projector behavior is unchanged:
+  - `m(key)`, `m(key, default)`
+  - `"key"(m)`, `"key"(m, default)`
 
 ### String builtins
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ pytest -q
 - String (UTF-8 safe helpers available through builtins)
 - Boolean (`true`, `false`)
 - Nil (`nil`)
+- Option none literal (`none`) and option wrappers (`some(value)`)
 - List
 - Function
 - Host-backed reference (`ref`)
@@ -207,6 +208,7 @@ agent_get(counter)
 - `help(name)` prints named function metadata (`name/shape`, source if available, rendered docstring, or undocumented fallback)
 - stdlib prelude helpers include Markdown docstrings for learn-by-inspection via `help("name")`
 - constants: `pi`, `e`, `true`, `false`, `nil`
+- option builtins: `none`, `some`, `get?`, `unwrap_or`, `is_some?`, `is_none?`
 
 ### CLI args / options (runtime layer)
 

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -520,3 +520,71 @@ Expected behavior (demo grid wrapping):
 - actor/scheduler-based simulation runtime
 - native language abstractions for agents, ticks, or worlds
 - native map syntax for simulation state authoring
+
+---
+
+## Primitive Option values (phase 1)
+
+Genia now has a minimal Option model that is separate from `nil`.
+
+- `none`
+- `some(value)`
+
+And minimal helpers:
+
+- `get?(key, target)`
+- `unwrap_or(default, opt)`
+- `is_some?(opt)`
+- `is_none?(opt)`
+
+### Minimal example
+
+```genia
+person = { name: "Genia" }
+person |> get?("name") |> unwrap_or("unknown")
+```
+
+Expected result:
+
+```genia
+"Genia"
+```
+
+### Edge case example
+
+```genia
+[get?("a", {a:nil}), get?("b", {a:nil})]
+```
+
+Expected behavior:
+
+- first result is `some(nil)` (key exists)
+- second result is `none` (key missing)
+
+### Failure case example
+
+```genia
+get?("name", 42)
+```
+
+Expected behavior:
+
+- raises `TypeError` (`get?` supports map targets, `some(map)`, and `none`)
+
+### Implementation status
+
+### ✅ Implemented
+
+- primitive option values: `none`, `some(value)`
+- `get?` lookup semantics with key-presence distinction (`some(nil)` vs `none`)
+- `unwrap_or(default, opt)` for defaulting on `none`
+- `is_some?` / `is_none?` predicates
+- pipeline-friendly lookup (`record |> get?("name")`)
+
+### ⚠️ Partial
+
+- pattern matching can match `none` directly, but there is no constructor-pattern syntax for destructuring `some(x)`
+
+### ❌ Not implemented
+
+- dedicated option-pattern constructor syntax (e.g., `some(x)` pattern destructuring)

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -318,6 +318,58 @@ Write `last` using pattern matching and recursion.
 
 ---
 
+## Pattern matching with Option values (phase 1)
+
+Option values can be matched in today’s pattern system with current minimal support.
+
+### Minimal example
+
+```genia
+fallback(opt) =
+  none -> "missing" |
+  _ -> "present"
+```
+
+`none` is a literal pattern and matches only the Option none value.
+
+### Edge case example
+
+```genia
+name_or(default, record) =
+  record |> get?("name") ? is_some?(record |> get?("name")) -> unwrap_or(default, record |> get?("name")) |
+  _ -> default
+```
+
+Current style for `some(...)` is guard-based (`is_some?`) plus `unwrap_or` because constructor-pattern destructuring is not implemented.
+
+### Failure case example
+
+```genia
+bad(opt) =
+  some(x) -> x
+```
+
+Expected behavior:
+
+- pattern parse/runtime mismatch (constructor-pattern syntax is not part of current pattern grammar)
+
+### Implementation status
+
+### ✅ Implemented
+
+- literal matching on `none`
+- guard-friendly Option checks (`is_some?`, `is_none?`) in existing case/function matching flow
+
+### ⚠️ Partial
+
+- destructuring `some(value)` requires helper calls (no direct constructor pattern)
+
+### ❌ Not implemented
+
+- `some(x)` pattern syntax
+
+---
+
 ## Implementation Status
 
 ### ✅ Implemented

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -515,6 +515,11 @@ class Nil(Node):
 
 
 @dataclass
+class NoneOption(Node):
+    span: SourceSpan | None = None
+
+
+@dataclass
 class Var(Node):
     name: str
     span: SourceSpan | None = None
@@ -888,6 +893,8 @@ def lower_node(node: Node) -> IrNode:
         return IrLiteral(node.value, span=node.span)
     if isinstance(node, Nil):
         return IrLiteral(None, span=node.span)
+    if isinstance(node, NoneOption):
+        return IrLiteral(OPTION_NONE, span=node.span)
     if isinstance(node, Var):
         return IrVar(node.name, span=node.span)
     if isinstance(node, Unary):
@@ -950,6 +957,8 @@ def lower_pattern(pattern: Node) -> IrPattern:
         return IrPatLiteral(pattern.value)
     if isinstance(pattern, Nil):
         return IrPatLiteral(None)
+    if isinstance(pattern, NoneOption):
+        return IrPatLiteral(OPTION_NONE)
     if isinstance(pattern, WildcardPattern):
         return IrPatWildcard()
     if isinstance(pattern, RestPattern):
@@ -1134,7 +1143,7 @@ PRECEDENCE = {
     "PERCENT": 60,
 }
 
-RESERVED_LITERAL_IDENTIFIERS = frozenset({"true", "false", "nil"})
+RESERVED_LITERAL_IDENTIFIERS = frozenset({"true", "false", "nil", "none"})
 
 
 class Parser:
@@ -1547,6 +1556,8 @@ class Parser:
                 return Boolean(False, span=self.span_for_tokens(tok, tok))
             if tok.text == "nil":
                 return Nil(span=self.span_for_tokens(tok, tok))
+            if tok.text == "none":
+                return NoneOption(span=self.span_for_tokens(tok, tok))
             if tok.text == "_":
                 return WildcardPattern(span=self.span_for_tokens(tok, tok))
             return Var(tok.text, span=self.span_for_tokens(tok, tok))
@@ -1605,6 +1616,8 @@ class Parser:
                 return Boolean(False, span=self.span_for_tokens(tok, tok))
             if tok.text == "nil":
                 return Nil(span=self.span_for_tokens(tok, tok))
+            if tok.text == "none":
+                return NoneOption(span=self.span_for_tokens(tok, tok))
             return Var(tok.text, span=self.span_for_tokens(tok, tok))
         if tok.kind in ("MINUS", "BANG"):
             self.i += 1
@@ -2065,6 +2078,22 @@ class GeniaMap:
 
     def __repr__(self) -> str:
         return f"<map {len(self._entries)}>"
+
+
+class GeniaOptionNone:
+    def __repr__(self) -> str:
+        return "none"
+
+
+OPTION_NONE = GeniaOptionNone()
+
+
+@dataclass(frozen=True)
+class GeniaOptionSome:
+    value: Any
+
+    def __repr__(self) -> str:
+        return f"some({self.value!r})"
 
 
 @dataclass(frozen=True)
@@ -2908,6 +2937,14 @@ Persistent map builtins (phase 1, host-backed opaque wrapper):
   map_remove(map, key)
   map_count(map)
 
+Option builtins (phase 1):
+  none
+  some(value)
+  get?(key, target)
+  unwrap_or(default, option)
+  is_some?(option)
+  is_none?(option)
+
 Simulation primitives (host-backed builtins):
   rand()                float in [0, 1)
   rand_int(n)           integer in [0, n), n must be a positive integer
@@ -3156,6 +3193,33 @@ Bytes / JSON / ZIP builtins (host-backed runtime bridge):
         genia_map = _ensure_map(map_value, "map_count")
         return genia_map.count()
 
+    def some_fn(value: Any) -> GeniaOptionSome:
+        return GeniaOptionSome(value)
+
+    def is_some_fn(value: Any) -> bool:
+        return isinstance(value, GeniaOptionSome)
+
+    def is_none_fn(value: Any) -> bool:
+        return value is OPTION_NONE
+
+    def unwrap_or_fn(default: Any, opt: Any) -> Any:
+        if isinstance(opt, GeniaOptionSome):
+            return opt.value
+        if opt is OPTION_NONE:
+            return default
+        raise TypeError("unwrap_or expected an option value")
+
+    def get_option_fn(key: Any, target: Any) -> Any:
+        if target is OPTION_NONE:
+            return OPTION_NONE
+        if isinstance(target, GeniaOptionSome):
+            return get_option_fn(key, target.value)
+        if isinstance(target, GeniaMap):
+            if target.has(key):
+                return GeniaOptionSome(target.get(key))
+            return OPTION_NONE
+        raise TypeError("get? expected a map, some(map), or none target")
+
     def rand_fn(*args: Any) -> float:
         if len(args) != 0:
             raise TypeError(f"rand expected 0 args, got {len(args)}")
@@ -3272,6 +3336,12 @@ Bytes / JSON / ZIP builtins (host-backed runtime bridge):
     env.set("true", True)
     env.set("false", False)
     env.set("nil", None)
+    env.set("none", OPTION_NONE)
+    env.set("some", some_fn)
+    env.set("get?", get_option_fn)
+    env.set("unwrap_or", unwrap_or_fn)
+    env.set("is_some?", is_some_fn)
+    env.set("is_none?", is_none_fn)
     env.set("ref", ref_fn)
     env.set("ref_get", ref_get_fn)
     env.set("ref_set", ref_set_fn)

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,0 +1,66 @@
+import pytest
+
+
+def test_some_value(run):
+    result = run("some(2)")
+    assert run("is_some?(some(2))") is True
+    assert run("unwrap_or(0, some(2))") == 2
+    assert "some(2" in repr(result)
+
+
+def test_none_value(run):
+    assert run("none") == run("none")
+    assert run("is_none?(none)") is True
+
+
+def test_get_present_key_returns_some(run):
+    assert run('is_some?(get?("a", {a: 1}))') is True
+    assert run('unwrap_or(0, get?("a", {a: 1}))') == 1
+
+
+def test_get_missing_key_returns_none(run):
+    assert run('is_none?(get?("b", {a: 1}))') is True
+    assert run('unwrap_or(9, get?("b", {a: 1}))') == 9
+
+
+def test_get_nested_pipeline_success(run):
+    src = '\n'.join([
+        'record = some({ profile: { name: "Genia" } })',
+        'record |> get?("profile") |> get?("name") |> unwrap_or("?")',
+    ])
+    assert run(src) == "Genia"
+
+
+def test_get_nested_pipeline_missing(run):
+    src = '\n'.join([
+        'record = some({ profile: {} })',
+        'record |> get?("profile") |> get?("name") |> unwrap_or("?")',
+    ])
+    assert run(src) == "?"
+
+
+def test_get_preserves_present_nil_vs_missing(run):
+    src = '[is_some?(get?("a", {a:nil})), is_none?(get?("b", {a:nil})), unwrap_or("d", get?("a", {a:nil}))]'
+    assert run(src) == [True, True, None]
+
+
+def test_unwrap_or_some_and_none(run):
+    assert run('unwrap_or(5, some(2))') == 2
+    assert run('unwrap_or(5, none)') == 5
+
+
+def test_option_predicates(run):
+    assert run('is_some?(some(1))') is True
+    assert run('is_some?(none)') is False
+    assert run('is_none?(none)') is True
+    assert run('is_none?(some(1))') is False
+
+
+def test_get_unsupported_target_type_error(run):
+    with pytest.raises(TypeError, match="get\\? expected a map, some\\(map\\), or none target"):
+        run('get?("a", 42)')
+
+
+def test_unwrap_or_requires_option(run):
+    with pytest.raises(TypeError, match="unwrap_or expected an option value"):
+        run('unwrap_or(0, 42)')


### PR DESCRIPTION
### Motivation
- Introduce a minimal Option model to clearly distinguish missing values from `nil` and enable safe nested lookups without changing existing map callable semantics. 

### Description
- Add a `none` literal and a `some(value)` runtime wrapper with parser/lowering support via a new `NoneOption` AST node and `OPTION_NONE` / `GeniaOptionSome` runtime types. 
- Implement builtins `some`, `get?`, `unwrap_or`, `is_some?`, and `is_none?` and wire them into the global environment as `env.set(...)`. 
- Implement `get?` semantics so `get?(key, none) -> none`, `get?(key, some(map)) -> get?(key, map)`, `get?(key, map) -> some(value)` when key exists (including `nil`), and `get?(key, map) -> none` when missing, while preserving existing `m(key)` and `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d13adb4b308329a307687c02e9f93c)