### PR TITLE
Harden module import caching and slash accessor coverage

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -61,6 +61,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - list literals with spread (`[..xs]`, `[1, ..xs, 2]`)
 - map literals (`{name: "m"}`, `{"name": "m"}`, `{}`)
 - module import forms: `import mod`, `import mod as alias`
+  - imports are cached by module name; repeated imports/aliases reuse the same module value
 - phase-1 slash named accessor: `mod/name`, `map/name` (bare identifier RHS only)
 - callable data (phase 1 subset):
   - map lookup calls: `m(key)`, `m(key, default)`

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -94,7 +94,9 @@ Required constraints:
 - imports bind only the module value in the current environment (no export splatting)
 - module values are runtime namespace values distinct from maps
 - module resolution is file-based only in this phase
+- module loads are cached by module name (`loaded_modules`); duplicate imports/aliases must reuse the same module value instance
 - top-level named assignments/functions from the module file are exported
+- missing module files must raise a deterministic `FileNotFoundError("Module not found: <name>")`
 
 ## 9) Operator model
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -32,6 +32,7 @@ This file describes what is **actually implemented now** in the Python runtime.
 - list literals: `[a, b, c]`
 - map literals: `{ key: value }` with identifier/string keys (`name: 1` sugar for `"name": 1`)
 - module import: `import mod`, `import mod as alias`
+  - imports are cached by module name in `loaded_modules` (repeat imports/aliases reuse the same module instance)
 - list spread in literals: `[..xs]`, `[1, ..xs, 2]`
 - call spread: `f(..xs)`
 - lambdas: `(x) -> x + 1`
@@ -71,6 +72,7 @@ Pipeline (Phase 2) rewrite model:
   - supported LHS runtime kinds: module values, map values
   - map missing key => `nil`
   - module missing export => clear error
+  - non-identifier RHS (for example `lhs/(1 + 2)`) raises a clear `TypeError`
   - this does not add general member/index access
 - callable data (phase 1):
   - maps are callable lookup values:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ import math as m
 
 - `import mod` binds a module value to `mod`
 - `import mod as alias` binds the same module value to `alias`
+- module imports are cached by module name (`loaded_modules`) so duplicate imports are not re-evaluated
 - module exports are accessed with narrow slash access (`mod/name`)
 - modules are immutable runtime namespace values (distinct from maps)
 

--- a/docs/book/03-functions.md
+++ b/docs/book/03-functions.md
@@ -33,8 +33,24 @@ Notes:
 
 - `import math` binds one module value named `math`.
 - `import math as m` binds that same module value as `m`.
+- repeated imports are cached by module name, so module files are evaluated once per root environment.
 - export access uses `module/name` (bare identifier RHS only).
 - module values are namespace-like and distinct from maps.
+
+Failure examples:
+
+```genia
+import no_such_module
+```
+
+- raises `FileNotFoundError("Module not found: no_such_module")`.
+
+```genia
+import math
+math/missing
+```
+
+- raises `NameError` for the missing export.
 
 ## Function Docstrings (Implemented)
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -1894,8 +1894,7 @@ class Env:
         for path in candidates:
             if path.is_file():
                 return path
-        joined = ", ".join(str(p) for p in candidates)
-        raise FileNotFoundError(f"Module not found: {module_name} (searched: {joined})")
+        raise FileNotFoundError(f"Module not found: {module_name}")
 
     def load_module(self, module_name: str, requester_filename: str | None = None) -> "ModuleValue":
         root = self.root()

--- a/tests/test_modules_phase1.py
+++ b/tests/test_modules_phase1.py
@@ -20,6 +20,19 @@ def test_import_module_with_alias_binds_same_module_value(run):
     assert run(src) == [True, 3]
 
 
+def test_duplicate_imports_reuse_loaded_module_instance():
+    env = make_global_env([])
+    run_source("import math\nimport math", env)
+    assert env.values["math"] is env.loaded_modules["math"]
+
+
+def test_multiple_aliases_reference_same_loaded_module_instance():
+    env = make_global_env([])
+    run_source("import math as m1\nimport math as m2", env)
+    assert env.values["m1"] is env.values["m2"]
+    assert env.values["m1"] is env.loaded_modules["math"]
+
+
 def test_module_missing_export_raises_clear_error(run):
     with pytest.raises(NameError, match="Module math has no export named missing"):
         run(
@@ -82,3 +95,62 @@ def test_file_based_module_resolution_relative_to_source(tmp_path):
         filename=str((tmp_path / "main.genia").resolve()),
     )
     assert result == [3, 3]
+
+
+def test_duplicate_import_does_not_re_evaluate_module(tmp_path):
+    module_file = tmp_path / "counter_mod.genia"
+    module_file.write_text(
+        """
+        _ = ref_update(counter, (n) -> n + 1)
+        value = 42
+        """,
+        encoding="utf-8",
+    )
+    env = make_global_env([])
+    counter = env.get("ref")(0)
+    env.set("counter", counter)
+    result = run_source(
+        """
+        import counter_mod
+        import counter_mod as c
+        [counter_mod/value, c/value]
+        """,
+        env,
+        filename=str((tmp_path / "main.genia").resolve()),
+    )
+    assert result == [42, 42]
+    assert env.get("ref_get")(counter) == 1
+
+
+def test_import_missing_module_raises_clear_error(run):
+    with pytest.raises(FileNotFoundError, match="^Module not found: definitely_not_a_real_module$"):
+        run("import definitely_not_a_real_module")
+
+
+def test_import_module_with_syntax_error_surfaces_cleanly(tmp_path):
+    module_file = tmp_path / "bad_syntax.genia"
+    module_file.write_text("broken = (", encoding="utf-8")
+    env = make_global_env([])
+    with pytest.raises(SyntaxError):
+        run_source(
+            "import bad_syntax",
+            env,
+            filename=str((tmp_path / "main.genia").resolve()),
+        )
+
+
+def test_import_module_runtime_failure_is_propagated(tmp_path):
+    module_file = tmp_path / "bad_eval.genia"
+    module_file.write_text("boom = missing_name", encoding="utf-8")
+    env = make_global_env([])
+    with pytest.raises(NameError, match="Undefined name: missing_name"):
+        run_source(
+            "import bad_eval",
+            env,
+            filename=str((tmp_path / "main.genia").resolve()),
+        )
+
+
+def test_named_accessor_invalid_rhs_expression_fails_clearly(run):
+    with pytest.raises(TypeError, match="requires a bare identifier"):
+        run("{name: \"Alice\"}/(1 + 2)")


### PR DESCRIPTION
### Motivation

- Lock down Phase 1 module import behavior so imports are deterministic, identity-preserving, and produce short, predictable errors when module files are missing. 
- Ensure `import x` vs `import x as y` surface the same module instance and that repeated imports do not re-evaluate module source. 
- Clarify and enforce narrow `/` accessor semantics and error boundaries for invalid RHS forms. 

### Description

- Made missing-module errors concise and deterministic by raising `FileNotFoundError("Module not found: <name>")` from `Env.resolve_module_path` and preserved the existing `loaded_modules` cache semantics in `Env.load_module`. 
- Added comprehensive tests in `tests/test_modules_phase1.py` covering basic import, alias identity, duplicate-import caching, duplicate-import non-re-evaluation (via a `ref` side-effect), missing-module file error, syntax error propagation from imported module, runtime error propagation from imported module, and invalid `/` RHS expression errors. 
- Updated authoritative docs to reflect the stable behavior: `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and `docs/book/03-functions.md` now document import caching and the narrow slash accessor error semantics. 

### Testing

- Ran the focused test selection with `pytest -q tests/test_modules_phase1.py tests/test_pipeline_operator.py tests/test_lists_and_patterns.py` and the run passed (`43 passed`).
- Ran the full test suite with `pytest -q` and observed all tests passing (`341 passed`).
- No failing automated tests were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d140b33ba08329bbbd96bab37edfcc)