### PR TITLE
Add regression tests for Option `get?` error cases and pattern-matching usage

### DIFF
--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -76,6 +76,21 @@ def test_get_unsupported_target_type_error(run):
         run('get?("a", 42)')
 
 
+
+def test_get_some_non_map_target_type_error(run):
+    with pytest.raises(TypeError, match=r"get\? expected a map, some\(map\), or none target"):
+        run('get?("a", some(42))')
+
+
+def test_option_values_work_with_pattern_matching(run):
+    src = '\n'.join([
+        'status(opt) =',
+        '  none -> "missing" |',
+        '  x ? is_some?(x) -> unwrap_or("?", x)',
+        '[status(get?("name", {name: "Genia"})), status(none)]',
+    ])
+    assert run(src) == ["Genia", "missing"]
+
 def test_unwrap_or_requires_option(run):
     with pytest.raises(TypeError, match="unwrap_or expected an option value"):
         run('unwrap_or(0, 42)')


### PR DESCRIPTION
### Motivation
- Lock in two Option-related guarantees: `get?` must raise a deterministic `TypeError` for unsupported wrapped targets such as `some(non_map)`, and Option values must continue to work with the existing pattern-matching flow without introducing new syntax.

### Description
- Add `test_get_some_non_map_target_type_error` to assert `get?("a", some(42))` raises the same `TypeError` as other unsupported targets.
- Add `test_option_values_work_with_pattern_matching` that defines `status(opt)` and verifies both `status(get?("name", {name: "Genia"}))` and `status(none)` behave as expected using a literal `none` match and guard-based `some(...)` handling with `is_some?` + `unwrap_or`.
- Replace a regex match with a raw string literal in the test to silence a `SyntaxWarning` for the escape sequence.

### Testing
- Ran `pytest -q tests/test_option.py` and the suite passed (`16 passed` after these changes).
- Ran `pytest -q tests/test_option.py tests/test_callable_data.py` and the combined run passed (`26 passed`, no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d141be15f48329bd9e78b2a30e0016)