### PR TITLE
Add Phase 1 Flow runtime: lazy single-use Flows with `take`/`head` and flow-aware transforms

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -97,6 +97,12 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
     - `entry_name`, `entry_bytes`, `set_entry_bytes`, `update_entry_bytes`, `entry_json`
   - strings: `byte_length`, `is_empty`, `concat`, `contains`, `starts_with`, `ends_with`, `find`, `split`, `split_whitespace`, `join`, `trim`, `trim_start`, `trim_end`, `lower`, `upper`
   - constants: `pi`, `e`, `true`, `false`, `nil`
+- flow runtime (phase 1):
+  - `stdin |> lines` creates a lazy single-use flow
+  - transforms: `lines`, `map`, `filter`, `take`, `head`
+  - sinks/materialization: `each`, `run`, `collect`
+  - consuming the same flow twice raises `RuntimeError("Flow has already been consumed")`
+  - `take`/`head` perform early upstream termination (normal completion)
 
 ## REPL commands
 
@@ -112,8 +118,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
 - general host interop / FFI
 - general member access and indexing syntax
 - a language-level scheduler (concurrency is host-thread based)
-- generalized flow semantics (lazy sequences, multi-output stages, backpressure, cancellation)
-- full Flow runtime system (stages/sinks/backpressure/cancellation/multi-port stages)
+- full Flow runtime system beyond phase 1 (async scheduling, multi-port stages, richer cancellation/backpressure controls)
 
 ## Conditionals in Genia
 

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -232,3 +232,17 @@ When changing syntax/semantics/runtime behavior, update together:
   - else use exact `main/0`
   - else do nothing
 - no partial matching/coercion is performed by the entrypoint selector
+
+## 19) Flow runtime invariants (phase 1)
+
+- pipeline operator semantics are unchanged (AST→Core IR call rewrite only)
+- flow behavior is runtime-level and value-based, with no parser/operator additions
+- `stdin` may be used as a source value in pipelines; `input()` remains interactive-only
+- phase-1 flow builtins:
+  - sources/transforms: `lines`, `map`, `filter`, `take`, `head`
+  - sinks/materialization: `each`, `run`, `collect`
+- flows are single-use:
+  - first consumption succeeds
+  - second consumption must raise `RuntimeError("Flow has already been consumed")`
+- `take(n, flow)` must stop upstream pulling immediately after producing `n` items
+- reaching EOF or a `take`/`head` limit is normal completion (not an error)

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -153,6 +153,26 @@ Case placement rules (enforced):
 - `argv` (returns raw trailing CLI args as a list of strings)
 - constants in global env: `pi`, `e`, `true`, `false`, `nil`
 
+### Flow runtime (Phase 1)
+
+- `stdin` is a stream source value when used in pipelines (`stdin |> lines`)
+  - `stdin()` still returns cached full stdin lines list for compatibility
+- flow transforms:
+  - `lines(flow_or_source)`
+  - `map(f, flow)` / `filter(pred, flow)` when second arg is a flow
+  - `take(n, flow)` when second arg is a flow
+  - `head(flow)` and `head(n, flow)` via stdlib aliases over `take`
+- flow sinks/materialization:
+  - `each(f, flow)` (tap-style stage)
+  - `collect(flow)` (materialize to list)
+  - `run(flow)` (consume to completion)
+
+Flow semantics:
+
+- lazy, pull-based, single-use
+- consuming a flow twice raises `RuntimeError("Flow has already been consumed")`
+- `take` performs early termination (stops upstream pulling as soon as limit is reached)
+
 ### CLI argument helpers (host-backed builtin layer)
 
 - `cli_parse(args) -> [opts, positionals]`
@@ -347,7 +367,7 @@ Core IR shape currently includes:
 - general host interop / FFI layer
 - general member access syntax
 - index syntax
-- generalized flow runtime semantics (lazy sequences, multi-output stages, backpressure, cancellation)
+- generalized flow runtime semantics beyond Phase 1 (multi-output stages, async scheduling, advanced backpressure/cancellation)
 - full Flow system (stages/sinks/backpressure/multi-port pipelines)
 - language-level scheduler/selective receive/timeouts (concurrency remains host-primitive based)
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ agent_get(counter)
 - stdlib prelude helpers include Markdown docstrings for learn-by-inspection via `help("name")`
 - constants: `pi`, `e`, `true`, `false`, `nil`
 - option builtins: `none`, `some`, `get?`, `unwrap_or`, `is_some?`, `is_none?`
+- flow runtime (Phase 1): `lines`, `map`/`filter` (flow-aware), `take`, `head`, `each`, `collect`, `run`
 
 ### CLI args / options (runtime layer)
 
@@ -308,7 +309,7 @@ rewrite_zip(in_path, out_path) =
 
 - general host interop / FFI
 - general member access / indexing syntax
-- generalized flow semantics (lazy sequences, multi-output stages, backpressure, cancellation)
+- full flow system beyond Phase 1 (async scheduling, multi-port stages, richer cancellation/backpressure controls)
 - full Flow system (stages/sinks/backpressure/multi-port pipelines)
 - language-level scheduler/event loop for simulations
 

--- a/docs/book/05-lists.md
+++ b/docs/book/05-lists.md
@@ -211,7 +211,7 @@ Expected behavior:
 
 - lazy sequences
 - iterator protocol
-- flow-aware list pipelines (backpressure/cancellation/multi-output stages)
+- advanced flow/list interop (multi-output stages, async backpressure/cancellation controls)
 - built-in map/filter syntax (helpers exist only as stdlib functions)
 
 ---

--- a/docs/book/11-flow.md
+++ b/docs/book/11-flow.md
@@ -1,0 +1,83 @@
+# Chapter 11: Flow (Phase 1)
+
+Genia now supports a minimal lazy Flow runtime model for stream-style pipelines.
+
+## Flow model
+
+A Flow is:
+
+- lazy
+- pull-based
+- source-bound
+- single-use (consumable)
+
+## Reusable stages
+
+Any function of shape `(flow) -> flow` can be reused as a stage.
+
+### Minimal example
+
+```genia
+clean(flow) =
+  flow |> lines |> map(trim) |> filter((x) -> x != "")
+
+stdin |> clean |> each(print) |> run
+```
+
+### Edge case example
+
+```genia
+stdin |> lines |> take(0) |> collect
+```
+
+Expected result:
+
+```genia
+[]
+```
+
+### Failure case example
+
+```genia
+x = stdin |> lines
+x |> run
+x |> run
+```
+
+Expected behavior:
+
+- second consume raises `RuntimeError: Flow has already been consumed`
+
+## `take` / `head`
+
+- `take(n, flow)` returns at most `n` items
+- `head(flow)` is an alias of `take(1, flow)`
+- `head(n, flow)` is an alias of `take(n, flow)`
+
+These stop upstream pulling as soon as the limit is reached.
+
+## `stdin` vs `input()`
+
+- `stdin` is stream input for flows
+- `input()` remains interactive prompt input
+
+## Implementation status
+
+### ✅ Implemented
+
+- lazy single-use flow values
+- `stdin |> lines` source binding
+- flow-aware `map`, `filter`, `take`
+- `head/1` and `head/2` aliases (stdlib)
+- `each`, `collect`, and `run`
+- early termination on `take`/`head`
+
+### ⚠️ Partial
+
+- cancellation/backpressure is limited to downstream early-stop via `take`/`head`
+
+### ❌ Not implemented
+
+- async stream scheduling
+- multi-source/multi-port flow stages
+- generalized push-based stream runtime

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -1959,6 +1959,29 @@ class GeniaFunctionGroup:
     def sorted_arities(self) -> list[int]:
         return sorted(self.functions)
 
+    def __call__(self, *args: Any) -> Any:
+        arity = len(args)
+        exact = self.get(arity)
+        if exact is not None:
+            return exact(*args)
+        vararg_matches = [
+            candidate
+            for candidate in self.values()
+            if isinstance(candidate, GeniaFunction)
+            and candidate.rest_param is not None
+            and arity >= candidate.arity
+        ]
+        if len(vararg_matches) == 1:
+            return vararg_matches[0](*args)
+        if len(vararg_matches) > 1:
+            candidates = ", ".join(
+                f"{self.name}/{candidate.arity}+"
+                for candidate in sorted(vararg_matches, key=lambda fn: fn.arity)
+            )
+            raise TypeError(f"Ambiguous function resolution: {self.name}/{arity}. Matching varargs: {candidates}")
+        available = ", ".join(f"{self.name}/{n}" for n in self.sorted_arities())
+        raise TypeError(f"No matching function: {self.name}/{arity}. Available: {available}")
+
 
 
 @dataclass
@@ -2150,6 +2173,23 @@ class GeniaZipEntry:
         return f"<zip-entry {self.name!r} {len(self.data.value)}>"
 
 
+class GeniaFlow:
+    def __init__(self, iterator_factory: Callable[[], Iterable[Any]], *, label: str = "flow"):
+        self._iterator_factory = iterator_factory
+        self._label = label
+        self._consumed = False
+
+    def consume(self) -> Iterable[Any]:
+        if self._consumed:
+            raise RuntimeError("Flow has already been consumed")
+        self._consumed = True
+        return self._iterator_factory()
+
+    def __repr__(self) -> str:
+        state = "consumed" if self._consumed else "ready"
+        return f"<flow {self._label} {state}>"
+
+
 def eval_with_tco(
     fn: Any,
     args: tuple[Any, ...],
@@ -2323,6 +2363,43 @@ class Evaluator:
     ) -> Any:
 
         if isinstance(fn, GeniaFunctionGroup):
+            if isinstance(callee_node, IrVar) and len(args) == 2 and isinstance(args[1], GeniaFlow):
+                if callee_node.name == "map":
+                    mapper = args[0]
+                    source = args[1]
+
+                    def iterator() -> Iterable[Any]:
+                        for item in source.consume():
+                            yield self.invoke_callable(mapper, [item], tail_position=False)
+
+                    return GeniaFlow(iterator, label="map")
+                if callee_node.name == "filter":
+                    predicate = args[0]
+                    source = args[1]
+
+                    def iterator() -> Iterable[Any]:
+                        for item in source.consume():
+                            if self.invoke_callable(predicate, [item], tail_position=False):
+                                yield item
+
+                    return GeniaFlow(iterator, label="filter")
+                if callee_node.name == "take":
+                    count = args[0]
+                    source = args[1]
+                    if not isinstance(count, int) or isinstance(count, bool):
+                        raise TypeError("take expected an integer count as first argument")
+
+                    def iterator() -> Iterable[Any]:
+                        if count <= 0:
+                            return
+                        remaining = count
+                        for item in source.consume():
+                            if remaining <= 0:
+                                break
+                            yield item
+                            remaining -= 1
+
+                    return GeniaFlow(iterator, label="take")
             arity = len(args)
 
             def resolve_target(functions: GeniaFunctionGroup, call_arity: int) -> Any | None:
@@ -2805,8 +2882,122 @@ def make_global_env(
                 stdin_cache = sys.stdin.read().splitlines()
         return stdin_cache
 
+    setattr(stdin_fn, "_genia_stdin_source", True)
+
     def argv_fn() -> list[str]:
         return list(argv_cache)
+
+    def _ensure_flow(value: Any, name: str) -> GeniaFlow:
+        if not isinstance(value, GeniaFlow):
+            raise TypeError(f"{name} expected a flow")
+        return value
+
+    def _ensure_callable(value: Any, name: str) -> Callable[..., Any]:
+        if not callable(value):
+            raise TypeError(f"{name} expected a function")
+        return value
+
+    def lines_fn(source: Any) -> GeniaFlow:
+        if isinstance(source, GeniaFlow):
+            upstream = _ensure_flow(source, "lines")
+
+            def iterator() -> Iterable[Any]:
+                for item in upstream.consume():
+                    if not isinstance(item, str):
+                        raise TypeError("lines expected string input items")
+                    yield item
+
+            return GeniaFlow(iterator, label="lines")
+
+        if callable(source):
+            raw_lines = source()
+        else:
+            raw_lines = source
+
+        if not isinstance(raw_lines, list):
+            raise TypeError("lines expected stdin source, flow, or list of strings")
+        if not all(isinstance(item, str) for item in raw_lines):
+            raise TypeError("lines expected a list of strings")
+
+        def iterator() -> Iterable[str]:
+            for item in raw_lines:
+                yield item
+
+        return GeniaFlow(iterator, label="lines")
+
+    def map_flow_fn(fn_value: Any, source: Any) -> Any:
+        mapper = _ensure_callable(fn_value, "map")
+        if isinstance(source, GeniaFlow):
+            upstream = source
+
+            def iterator() -> Iterable[Any]:
+                for item in upstream.consume():
+                    yield mapper(item)
+
+            return GeniaFlow(iterator, label="map")
+        if not isinstance(source, list):
+            raise TypeError("map expected a flow or list")
+        return [mapper(item) for item in source]
+
+    def filter_flow_fn(predicate_value: Any, source: Any) -> Any:
+        predicate = _ensure_callable(predicate_value, "filter")
+        if isinstance(source, GeniaFlow):
+            upstream = source
+
+            def iterator() -> Iterable[Any]:
+                for item in upstream.consume():
+                    if predicate(item):
+                        yield item
+
+            return GeniaFlow(iterator, label="filter")
+        if not isinstance(source, list):
+            raise TypeError("filter expected a flow or list")
+        return [item for item in source if predicate(item)]
+
+    def take_fn(n: Any, source: Any) -> GeniaFlow:
+        if not isinstance(n, int) or isinstance(n, bool):
+            raise TypeError("take expected an integer count as first argument")
+        upstream = _ensure_flow(source, "take")
+
+        def iterator() -> Iterable[Any]:
+            if n <= 0:
+                return
+            remaining = n
+            for item in upstream.consume():
+                if remaining <= 0:
+                    break
+                yield item
+                remaining -= 1
+
+        return GeniaFlow(iterator, label="take")
+
+    def head_fn(*args: Any) -> GeniaFlow:
+        if len(args) == 1:
+            return take_fn(1, args[0])
+        if len(args) == 2:
+            return take_fn(args[0], args[1])
+        raise TypeError(f"head expected 1 or 2 args, got {len(args)}")
+
+    def each_fn(fn_value: Any, source: Any) -> GeniaFlow:
+        effect = _ensure_callable(fn_value, "each")
+        upstream = _ensure_flow(source, "each")
+
+        def iterator() -> Iterable[Any]:
+            for item in upstream.consume():
+                effect(item)
+                yield item
+
+        return GeniaFlow(iterator, label="each")
+
+    def collect_fn(source: Any) -> list[Any]:
+        flow = _ensure_flow(source, "collect")
+        return list(flow.consume())
+
+    def run_fn(source: Any) -> None:
+        flow = _ensure_flow(source, "run")
+        for _ in flow.consume():
+            pass
+        return None
 
     def _emit_help(text: str) -> None:
         output = text + "\n"
@@ -3328,6 +3519,10 @@ Bytes / JSON / ZIP builtins (host-backed runtime bridge):
     env.set("print", print_fn)
     env.set("input", input_fn)
     env.set("stdin", stdin_fn)
+    env.set("lines", lines_fn)
+    env.set("each", each_fn)
+    env.set("run", run_fn)
+    env.set("collect", collect_fn)
     env.set("argv", argv_fn)
     env.set("help", help_fn)
     env.set("pi", math.pi)
@@ -3404,6 +3599,8 @@ Bytes / JSON / ZIP builtins (host-backed runtime bridge):
     env.register_autoload("any?", 2, "std/prelude/list.genia")
     env.register_autoload("nth", 2, "std/prelude/list.genia")
     env.register_autoload("take", 2, "std/prelude/list.genia")
+    env.register_autoload("head", 1, "std/prelude/list.genia")
+    env.register_autoload("head", 2, "std/prelude/list.genia")
     env.register_autoload("drop", 2, "std/prelude/list.genia")
     env.register_autoload("range", 1, "std/prelude/list.genia")
     env.register_autoload("range", 2, "std/prelude/list.genia")

--- a/std/prelude/list.genia
+++ b/std/prelude/list.genia
@@ -216,6 +216,17 @@ take_impl(n, xs) =
   (0, _) -> [] |
   (n, [x, ..rest]) -> [x] + take_impl(n - 1, rest)
 
+head(xs) = """
+# head
+
+Convenience alias for `take`.
+""" take(1, xs)
+head(n, xs) = """
+# head
+
+Convenience alias for `take`.
+""" take(n, xs)
+
 drop(n, xs) = """
 # drop
 

--- a/tests/test_flow_phase1.py
+++ b/tests/test_flow_phase1.py
@@ -1,0 +1,69 @@
+import pytest
+
+from genia import make_global_env, run_source
+from genia.interpreter import GeniaFlow
+
+
+def test_flow_reusable_stage_and_run(capsys):
+    src = """
+    clean(flow) =
+      flow |> lines |> map(trim) |> filter((x) -> x != "")
+
+    stdin |> clean |> each(print) |> run
+    """
+    env = make_global_env(stdin_data=["  a  ", "", " b "])
+    result = run_source(src, env)
+    captured = capsys.readouterr().out
+
+    assert result is None
+    assert captured == "a\nb\n"
+
+
+def test_flow_is_single_use():
+    src = """
+    x = stdin |> lines
+    x |> each(print) |> run
+    x |> each(print) |> run
+    """
+    env = make_global_env(stdin_data=["a", "b"])
+    with pytest.raises(RuntimeError, match="Flow has already been consumed"):
+        run_source(src, env)
+
+
+def test_collect_materializes_reusable_data():
+    src = """
+    xs = stdin |> lines |> collect
+    [xs, xs]
+    """
+    env = make_global_env(stdin_data=["a", "b"])
+    assert run_source(src, env) == [["a", "b"], ["a", "b"]]
+
+
+def test_take_and_head_aliases():
+    env = make_global_env(stdin_data=["a", "b", "c", "d"])
+    assert run_source("stdin |> lines |> take(2) |> collect", env) == ["a", "b"]
+
+    env = make_global_env(stdin_data=["a", "b", "c", "d"])
+    assert run_source("stdin |> lines |> head |> collect", env) == ["a"]
+
+    env = make_global_env(stdin_data=["a", "b", "c", "d"])
+    assert run_source("stdin |> lines |> head(3) |> collect", env) == ["a", "b", "c"]
+
+
+def test_take_zero_does_not_pull_upstream():
+    env = make_global_env()
+    state = {"pulled": 0}
+
+    def ticks():
+        def iterator():
+            i = 0
+            while True:
+                state["pulled"] += 1
+                yield i
+                i += 1
+
+        return GeniaFlow(iterator, label="ticks")
+
+    env.set("ticks", ticks)
+    assert run_source("ticks() |> take(0) |> collect", env) == []
+    assert state["pulled"] == 0


### PR DESCRIPTION
### Motivation

- Introduce a minimal, runtime-only Flow model so pipelines can be lazy, pull-based, and consumable while preserving existing `|>` rewrite semantics. 
- Provide early-termination control (`take`/`head`) to avoid over-reading `stdin` and enable Unix-style pipeline composition. 
- Support reusable stage functions of shape `(flow) -> flow` without adding parser syntax or new operators. 

### Description

- Added a runtime `GeniaFlow` type (`src/genia/interpreter.py`) that is lazy, single-use, and raises `RuntimeError("Flow has already been consumed")` on second consumption. 
- Implemented flow helpers and materializers: `lines`, `each`, `collect`, and `run` and registered them in the global environment. 
- Made `map`, `filter`, and `take` flow-aware by detecting when the second argument is a `GeniaFlow` and returning a new `GeniaFlow` that pulls from upstream; `take` short-circuits upstream pulling as soon as the limit is reached. 
- Added `head/1` and `head/2` aliases in `std/prelude/list.genia` that delegate to `take`, and registered autoload entries for them. 
- Small runtime integration: allow `GeniaFunctionGroup` to be invoked from Python-call sites and preserve existing list-based behavior when non-flow inputs are used. 
- Updated authoritative state and docs to match implementation by editing `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, adding `docs/book/11-flow.md`, and adjusting `docs/book/05-lists.md`. 
- Added tests `tests/test_flow_phase1.py` that cover reusable stages, single-use enforcement, `collect` materialization reuse, `take`/`head` semantics, and early-termination safety for generator-backed flows. 

### Testing

- Ran `pytest -q tests/test_flow_phase1.py` and the flow-specific tests passed. 
- Ran full test suite with `pytest -q` and all tests passed (`348 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d146ac95f48329bc12eb63ff0a89c5)