### PR TITLE
Add option constructor pattern matching for `some(...)`

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -72,6 +72,7 @@ python3 -m genia.interpreter --debug-stdio path/to/file.genia
   - list patterns
   - map patterns (`{name}`, `{name: n}`, `{"name": n}`)
   - glob string patterns (`glob"..."`) with whole-string matching only
+  - option constructor patterns (`some(pattern)`) and literal `none`
   - wildcard `_`
   - rest pattern `..rest` / `.._`
   - duplicate-binding equality semantics (`[x, x]`)

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -43,6 +43,7 @@ Supported patterns:
 
 - literal
 - glob string pattern (`glob"..."`)
+- option constructor pattern (`some(pattern)`)
 - variable binding
 - wildcard `_`
 - tuple pattern
@@ -164,6 +165,7 @@ No additional member/index/flow operators should be introduced without explicitl
   - `get?(key, map) -> none` when key is missing
 - key presence, not value truthiness, determines `some(...)` vs `none`
   - key mapped to `nil` still returns `some(nil)`
+- pattern matching supports constructor destructuring for `some(...)` with exactly one inner pattern
 - `unwrap_or(default, opt)` accepts option values only
 - `is_some?(opt)` and `is_none?(opt)` report option shape
 - pipeline behavior is unchanged and relies on existing rewrite rules (`record |> get?("name")` rewrites to `get?("name", record)`)

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -98,6 +98,7 @@ Implemented pattern types:
 
 - literal patterns
 - glob string patterns (`glob"..."`) for whole-string matching
+- option constructor patterns (`some(pattern)`)
 - variable binding
 - wildcard `_`
 - tuple patterns
@@ -274,6 +275,12 @@ Compatibility note:
 - existing callable-data map/string-projector behavior is unchanged:
   - `m(key)`, `m(key, default)`
   - `"key"(m)`, `"key"(m, default)`
+
+Pattern matching note:
+
+- `none` matches as a literal pattern
+- `some(pattern)` destructures option values in function clauses and case arms
+- `some(...)` pattern form requires exactly one inner pattern
 
 ### String builtins
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ pytest -q
 - Boolean (`true`, `false`)
 - Nil (`nil`)
 - Option none literal (`none`) and option wrappers (`some(value)`)
+- Option-aware pattern matching (`none`, `some(pattern)`)
 - List
 - Function
 - Host-backed reference (`ref`)

--- a/docs/book/01-core-data.md
+++ b/docs/book/01-core-data.md
@@ -584,8 +584,8 @@ Expected behavior:
 
 ### ⚠️ Partial
 
-- pattern matching can match `none` directly, but there is no constructor-pattern syntax for destructuring `some(x)`
+- `some(pattern)` supports exactly one inner pattern (multi-item constructor patterns are rejected)
 
 ### ❌ Not implemented
 
-- dedicated option-pattern constructor syntax (e.g., `some(x)` pattern destructuring)
+- multi-argument option constructor pattern forms (e.g., `some(a, b)`)

--- a/docs/book/02-pattern-matching.md
+++ b/docs/book/02-pattern-matching.md
@@ -320,14 +320,14 @@ Write `last` using pattern matching and recursion.
 
 ## Pattern matching with Option values (phase 1)
 
-Option values can be matched in today’s pattern system with current minimal support.
+Option values can be matched directly with literal and constructor patterns.
 
 ### Minimal example
 
 ```genia
 fallback(opt) =
   none -> "missing" |
-  _ -> "present"
+  some(_) -> "present"
 ```
 
 `none` is a literal pattern and matches only the Option none value.
@@ -336,37 +336,39 @@ fallback(opt) =
 
 ```genia
 name_or(default, record) =
-  record |> get?("name") ? is_some?(record |> get?("name")) -> unwrap_or(default, record |> get?("name")) |
-  _ -> default
+  get?("name", record) ->
+    none -> default |
+    some(name) -> name
 ```
 
-Current style for `some(...)` is guard-based (`is_some?`) plus `unwrap_or` because constructor-pattern destructuring is not implemented.
+Constructor-pattern matching composes with existing map/list patterns.
 
 ### Failure case example
 
 ```genia
 bad(opt) =
-  some(x) -> x
+  some(a, b) -> a
 ```
 
 Expected behavior:
 
-- pattern parse/runtime mismatch (constructor-pattern syntax is not part of current pattern grammar)
+- syntax error (`some(...)` pattern expects exactly one inner pattern)
 
 ### Implementation status
 
 ### ✅ Implemented
 
 - literal matching on `none`
-- guard-friendly Option checks (`is_some?`, `is_none?`) in existing case/function matching flow
+- constructor matching on `some(pattern)`
+- guard-friendly Option checks (`is_some?`, `is_none?`) remain available
 
 ### ⚠️ Partial
 
-- destructuring `some(value)` requires helper calls (no direct constructor pattern)
+- `some(pattern)` supports exactly one inner pattern
 
 ### ❌ Not implemented
 
-- `some(x)` pattern syntax
+- multi-argument option constructor patterns (`some(a, b)`)
 
 ---
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -613,6 +613,12 @@ class MapPattern(Node):
 
 
 @dataclass
+class SomePattern(Node):
+    inner: Node
+    span: SourceSpan | None = None
+
+
+@dataclass
 class CaseClause(Node):
     pattern: Node
     guard: Optional[Node]
@@ -811,6 +817,13 @@ class IrPatGlob(IrPattern):
 
 
 @dataclass
+class IrPatSome(IrPattern):
+    """Option constructor pattern that matches `some(value)` values."""
+
+    inner: IrPattern
+
+
+@dataclass
 class IrCaseClause(IrNode):
     """Single case arm with optional guard."""
 
@@ -973,6 +986,8 @@ def lower_pattern(pattern: Node) -> IrPattern:
         return IrPatMap([(key, lower_pattern(value)) for key, value in pattern.items])
     if isinstance(pattern, GlobPattern):
         return IrPatGlob(compile_glob_pattern(pattern.pattern))
+    if isinstance(pattern, SomePattern):
+        return IrPatSome(lower_pattern(pattern.inner))
     raise RuntimeError(f"Unknown pattern during lowering: {pattern!r}")
 
 
@@ -1470,6 +1485,23 @@ class Parser:
         # single param shorthand cases: 0 ->, name ->, [x, y] ->, name ? ... ->
         # tuple case: ( ... ) ->
         # We only detect enough for v0.1.
+        if self.at("IDENT") and self.peek(1).kind == "LPAREN":
+            depth = 0
+            j = self.i + 1
+            while True:
+                tok = self.tokens[j]
+                if tok.kind == "LPAREN":
+                    depth += 1
+                elif tok.kind == "RPAREN":
+                    depth -= 1
+                    if depth == 0:
+                        j += 1
+                        while self.tokens[j].kind == "NEWLINE":
+                            j += 1
+                        return self.tokens[j].kind in {"ARROW", "QMARK"}
+                elif tok.kind == "EOF":
+                    return False
+                j += 1
         if self.at("NUMBER", "STRING", "IDENT", "GLOB"):
             j = self.i + 1
             while self.tokens[j].kind == "NEWLINE":
@@ -1558,6 +1590,16 @@ class Parser:
                 return Nil(span=self.span_for_tokens(tok, tok))
             if tok.text == "none":
                 return NoneOption(span=self.span_for_tokens(tok, tok))
+            if tok.text == "some" and self.at("LPAREN"):
+                start = self.eat("LPAREN")
+                self.skip_newlines()
+                inner = self.parse_pattern_atom()
+                self.skip_newlines()
+                if self.at("COMMA"):
+                    comma = self.eat("COMMA")
+                    raise SyntaxError(f"some(...) pattern expects exactly one inner pattern at {comma.pos}")
+                end = self.eat("RPAREN")
+                return SomePattern(inner, span=self.span_for_tokens(tok, end))
             if tok.text == "_":
                 return WildcardPattern(span=self.span_for_tokens(tok, tok))
             return Var(tok.text, span=self.span_for_tokens(tok, tok))
@@ -2502,6 +2544,10 @@ class Evaluator:
             if not isinstance(arg, str):
                 return None
             return {} if glob_match(pattern.matcher, arg) else None
+        if isinstance(pattern, IrPatSome):
+            if not isinstance(arg, GeniaOptionSome):
+                return None
+            return self.match_pattern_atom(pattern.inner, arg.value)
         if isinstance(pattern, IrPatList):
             if not isinstance(arg, list):
                 return None

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -86,10 +86,26 @@ def test_option_values_work_with_pattern_matching(run):
     src = '\n'.join([
         'status(opt) =',
         '  none -> "missing" |',
-        '  x ? is_some?(x) -> unwrap_or("?", x)',
+        '  some(x) -> x',
         '[status(get?("name", {name: "Genia"})), status(none)]',
     ])
     assert run(src) == ["Genia", "missing"]
+
+
+def test_some_pattern_supports_nested_shapes(run):
+    src = '\n'.join([
+        'extract_name(opt) =',
+        '  some({name}) -> name |',
+        '  _ -> "?"',
+        '[extract_name(some({name: "Genia"})), extract_name(some({})), extract_name(none)]',
+    ])
+    assert run(src) == ["Genia", "?", "?"]
+
+
+def test_some_pattern_rejects_multiple_inner_patterns(run):
+    with pytest.raises(SyntaxError, match="some\\(\\.\\.\\.\\) pattern expects exactly one inner pattern"):
+        run('f(x) = some(a, b) -> a')
+
 
 def test_unwrap_or_requires_option(run):
     with pytest.raises(TypeError, match="unwrap_or expected an option value"):


### PR DESCRIPTION
### Motivation
- Provide ergonomic first-class pattern matching for Option values so callers can directly destructure `some(value)` in function clauses and case arms. 
- Keep behavior minimal and predictable by accepting exactly one inner pattern for `some(...)` and rejecting multi-item forms.

### Description
- Add AST node `SomePattern` and IR node `IrPatSome`, with lowering from `SomePattern` to `IrPatSome` in `lower_pattern` in `src/genia/interpreter.py`. 
- Extend the parser to accept `some(pattern)` in pattern positions (single inner pattern only) and to surface a clear `SyntaxError` for multi-argument forms. 
- Implement runtime matching against `GeniaOptionSome` by evaluating `IrPatSome` in the evaluator so `some(x)` and nested shapes like `some({name})` destructure correctly. 
- Update case-start detection so function bodies beginning with constructor-style patterns are parsed as case expressions, add tests in `tests/test_option.py`, and update state/docs (`GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, and `docs/book/*`) to reflect the implemented semantics.

### Testing
- Ran `pytest -q tests/test_option.py` and observed `18 passed` (all option-related tests passed). 
- Ran `pytest -q tests/test_lists_and_patterns.py tests/test_patterns_duplicate_bindings.py tests/test_cases.py` and observed all tests passed (`64 passed`). 
- All modified tests and the pattern/list/case suites that were run succeeded after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d14b945ef88329a0d84b106f4617ad)