### PR TITLE
Add shared IR semantic spec coverage

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -15,11 +15,12 @@ Implemented today:
   - cli
   - flow
   - error
-- The implemented shared Semantic Spec System currently executes **eval** cases only.
+- The implemented shared Semantic Spec System currently executes **eval** and **ir** cases.
 - The current shared spec runner compares normalized:
-  - stdout
-  - stderr
-  - exit_code
+  - eval `stdout`
+  - eval `stderr`
+  - eval `exit_code`
+  - IR portable normalized output
 - The working Python implementation lives in:
   - `src/genia/`
   - `tests/`
@@ -40,23 +41,24 @@ Scaffolded or planned, not implemented as hosts:
 
 **Maturity:**
 
-- Shared host contract is **Partial**: the contract categories above are documented, but executable shared spec coverage is implemented only for `eval` in the Python reference host. Other hosts are not implemented.
-- Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist, but only for eval behavior in this phase.
+- Shared host contract is **Partial**: the contract categories above are documented, and executable shared spec coverage is implemented for `eval` and `ir` in the Python reference host. Other hosts are not implemented.
+- Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist for `eval` and `ir` behavior in this phase.
 - Flow and CLI behavior are implemented in Python, but shared semantic-spec coverage for those categories is **not implemented yet**.
-- IR stability remains **Partial**: the minimal portable Core IR contract is documented, and the Python runtime guards that boundary, but shared semantic-spec case coverage for IR is **not implemented yet**.
+- IR stability remains **Partial**: the minimal portable Core IR contract is documented, the Python runtime guards that boundary, and shared semantic-spec case coverage now validates that contract in the Python reference host.
 
 **Explicit limitations:**
 
 - Only Python is implemented; all other hosts are planned or scaffolded only.
 - No browser runtime or playground is implemented; browser artifacts are documentation only.
 - No generic multi-host runner exists; all conformance is validated against the Python reference host.
-- Shared semantic-spec case files exist only under `spec/eval/` in this phase.
-- The current shared semantic-spec runner does not yet execute parse, ir, cli, flow, or error categories as shared spec files.
+- Shared semantic-spec case files currently exist under `spec/eval/` and `spec/ir/` in this phase.
+- The current shared semantic-spec runner does not yet execute parse, cli, flow, or error categories as shared spec files.
 - Flow is implemented as a lazy, pull-based, single-use runtime value; async, multi-port, and advanced flow features are not present.
 - Flow orchestration supports both `refine(..steps)` (preferred) and `rules(..fns)` (compatibility); both are available and behave identically.
 - Step/rule helpers are available as both `step_*` (preferred) and `rule_*` (compatibility) names.
 - CLI contract covers file, command, pipe, and REPL modes as described; no shell tokenization, `$1`/`$2`/`ARGV`-style, or advanced CLI features exist.
-- The current shared semantic-spec runner asserts only `stdout`, `stderr`, and `exit_code` for eval cases.
+- The current shared semantic-spec runner asserts `stdout`, `stderr`, and `exit_code` for eval cases.
+- The current shared semantic-spec runner compares normalized portable Core IR output for IR cases.
 - Only the minimal portable Core IR node families are used in the contract; host-local optimized nodes (e.g., `IrListTraversalLoop`) are excluded.
 
 **GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.**
@@ -96,12 +98,12 @@ LANGUAGE CONTRACT:
 
 - The Semantic Spec System defines observable behavior for the following categories:
   - parse (scaffold-only)
-  - ir (scaffold-only)
+  - ir (**active**, executable shared spec files)
   - eval (**active**, executable shared spec files)
   - cli (scaffold-only)
   - flow (scaffold-only)
   - error (scaffold-only)
-- Only `eval` is implemented as executable shared spec files in the Python reference host. All other categories are present as scaffolds only.
+- Only `eval` and `ir` are implemented as executable shared spec files in the Python reference host. Other categories are present as scaffolds only.
 - The spec is authoritative for covered categories; uncovered behavior is not guaranteed.
 - Coverage is still partial and experimental; see below for category status.
 
@@ -109,12 +111,13 @@ PYTHON REFERENCE HOST:
 
 - Python is the only implemented host and is the reference host.
 - All conformance is validated against the Python reference host.
-- The current shared spec runner executes only eval cases (`spec/eval/`), comparing normalized `stdout`, `stderr`, and `exit_code`.
-- Other categories (`parse`, `ir`, `cli`, `flow`, `error`) are present as scaffolds for future shared spec coverage.
+- The current shared spec runner executes eval cases (`spec/eval/`), comparing normalized `stdout`, `stderr`, and `exit_code`.
+- The current shared spec runner also executes IR cases (`spec/ir/`), comparing normalized portable Core IR output before host-local optimization.
+- Other categories (`parse`, `cli`, `flow`, `error`) are present as scaffolds for future shared spec coverage.
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.
 
 **Summary:**
-- Only `eval` is active for executable shared spec files; other categories are scaffold-only.
+- `eval` and `ir` are active for executable shared spec files; other categories are scaffold-only.
 - `GENIA_STATE.md` is the final authority for implemented behavior. All other docs/specs must align with this contract.
 
 **Host implementation location:**
@@ -128,8 +131,8 @@ PYTHON REFERENCE HOST:
 **Limitations:**
 - Only Python is implemented; all other hosts are planned or scaffolded only.
 - No browser runtime or playground is implemented; browser artifacts are documentation only.
-- Shared semantic-spec case files exist only under `spec/eval/` in this phase.
-- The current shared semantic-spec runner does not yet execute parse, ir, cli, flow, or error categories as shared spec files.
+- Shared semantic-spec case files exist under `spec/eval/` and `spec/ir/` in this phase.
+- The current shared semantic-spec runner does not yet execute parse, cli, flow, or error categories as shared spec files.
 
 **GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.**
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ This repository currently provides:
 
 **LANGUAGE CONTRACT:**
 - The portable contract covers: parse, ir, eval, cli, flow, error (see `GENIA_STATE.md` for current scope).
-- Only `eval` is active for executable shared spec files; other categories are scaffold-only.
+- `eval` and `ir` are active for executable shared spec files; other categories are scaffold-only.
 - Within the current implemented shared semantic-spec scope, observable outputs are compared in normalized form and Python-specific leakage is not part of the portable contract.
 - CLI pipe mode and Flow are part of the current shared public behavior.
 
 **PYTHON REFERENCE HOST:**
 - Python is the only implemented host and is the reference host.
-- The shared contract categories above exist now, but the implemented shared semantic-spec suite currently covers `eval` only.
+- The shared contract categories above exist now, and the implemented shared semantic-spec suite currently covers `eval` and `ir`.
 - The HTTP helper surface and actor surface are Python reference host behavior only (**Python-host-only**; not portable contract).
 - The shell pipeline stage `$(...)` is a **Python-host-only feature**: implemented and supported only on Python, not part of the portable Core IR or shared multi-host contract. Other hosts do not support it.
 - See `docs/host-interop/` and `spec/` for details.
@@ -69,19 +69,20 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
 **LANGUAGE CONTRACT:**
 - The spec system covers these categories:
   - eval (active, executable shared spec files)
+  - ir (active, executable shared spec files)
   - cli (scaffold-only)
   - flow (scaffold-only)
   - pattern (scaffold-only)
   - error (scaffold-only)
   - parse (scaffold-only)
-  - ir (scaffold-only)
-- Spec coverage has expanded beyond eval, but only eval is implemented as executable shared spec files in the Python reference host.
+- Spec coverage has expanded beyond eval, and `eval` plus `ir` are implemented as executable shared spec files in the Python reference host.
 - The spec is authoritative for covered categories; uncovered behavior is not guaranteed.
 - Coverage is still partial and experimental.
 
 **PYTHON REFERENCE HOST:**
 - Python is the only implemented host and is the reference host.
-- The current shared spec runner executes only eval cases (spec/eval/), comparing normalized stdout, stderr, and exit_code.
+- The current shared spec runner executes eval cases (spec/eval/), comparing normalized stdout, stderr, and exit_code.
+- The current shared spec runner executes IR cases (spec/ir/), comparing normalized portable Core IR output before host-local optimization.
 - Other categories are present as scaffolds for future shared spec coverage.
 
 **How to run the spec suite:**
@@ -92,12 +93,13 @@ python -m tools.spec_runner
 
 **What the spec guarantees:**
 - For eval: the runner executes each case independently and compares `stdout`, `stderr`, and `exit_code` with newline normalization.
+- For ir: the runner executes each case independently and compares normalized portable Core IR output captured before host-local optimization.
 - For other categories: present as scaffolds only; no executable shared spec files yet.
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.
 
 **Limitations:**
 - Spec coverage is expanded but still partial and experimental.
-- Only eval is active for executable shared spec files; other categories are scaffold-only.
+- Only eval and ir are active for executable shared spec files; other categories are scaffold-only.
 - GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.
 
 ## Quick start
@@ -418,6 +420,7 @@ The current Python host may still apply small post-lowering optimizations such a
 Boundary validation note:
 
 - lowered programs are validated against the minimal portable Core IR contract before host-local optimization in the current Python reference host
+- shared IR semantic-spec cases validate that lowering contract in the current Python reference host
 
 ## Multi-Host Direction
 
@@ -449,8 +452,8 @@ For formal status term definitions see `docs/host-interop/HOST_INTEROP.md` §Sta
 Current shared spec status:
 
 - implemented shared case files currently exist under `spec/eval/`
-- `spec/parser/`, `spec/ir/`, `spec/cli/`, `spec/flows/`, and `spec/errors/` remain scaffold-only in this phase
-- the shared runner is implemented, but its current executable shared case coverage is eval only
+- `spec/parse/`, `spec/cli/`, `spec/flows/`, and `spec/errors/` remain scaffold-only in this phase
+- the shared runner is implemented, and its current executable shared case coverage is eval plus ir
 
 ## Browser playground architecture
 

--- a/docs/architecture/core-ir-portability.md
+++ b/docs/architecture/core-ir-portability.md
@@ -70,6 +70,24 @@ Hosts must preserve these lowering invariants:
 - case/function patterns lower into explicit `IrPat*` pattern families
 - lowering output uses only the minimal portable Core IR node families listed above
 
+## Executable Validation
+
+This portability contract is executable in the shared Semantic Spec System for the current Python reference host.
+
+Shared IR cases under `spec/ir/` validate:
+
+- parse
+- lower
+- normalize portable Core IR
+- compare against shared expected IR
+
+Contract rule:
+
+- shared IR validation happens before host-local optimization
+- host-local optimized nodes are rejected from the shared IR path
+
+Python is the only executing host today. This does not imply multi-host IR execution exists.
+
 
 ## Strict Error Normalization and Category Boundaries
 
@@ -112,6 +130,7 @@ The Python reference host now includes a lightweight guard:
 Shared conformance work should continue to assert:
 
 - lowering snapshots/shape
+- executable shared IR cases at the portable boundary
 - eval behavior after lowering
 - CLI/Flow/error contracts at observable boundaries
 
@@ -121,6 +140,7 @@ Implemented today:
 
 - frozen minimal portable Core IR contract (this document)
 - Python-host guard to detect host-local node leakage before optimization
+- executable shared IR semantic-spec validation in the Python reference host
 - tests that lock the boundary between lowered portable IR and host-local optimized IR
 
 Not implemented today:

--- a/docs/architecture/issue-131-ir-shared-semantic-spec-design.md
+++ b/docs/architecture/issue-131-ir-shared-semantic-spec-design.md
@@ -1,0 +1,475 @@
+# Issue #131 Design Note
+
+## 1. Design Summary
+
+- Reuse the existing shared spec runner and its current YAML-based case discovery model, extending it minimally to load and execute `ir` cases in addition to `eval`.
+- Add one IR-specific normalization path in the Python host adapter that converts lowered portable IR into a deterministic host-neutral structure before comparison.
+- Capture IR exactly at the `parse -> lower` boundary and stop before any host-local optimization or evaluation path.
+- Reject host-local optimized nodes in the shared IR path instead of filtering them out, so boundary violations fail loudly and immediately.
+- Keep expectations diff-friendly by using a canonical structured representation with stable ordering and explicit portable node-family names, never Python `repr()` output.
+
+## 2. IR Case Representation
+
+Files under `spec/ir/` should use YAML, matching the current shared spec system and avoiding a second fixture format.
+
+Each file should represent exactly one IR case.
+
+Required top-level fields:
+
+- `name`: unique case name; file stem must match
+- `category`: must be `ir`
+- `input`: mapping
+- `expected`: mapping
+
+Required `input` fields:
+
+- `source`: Genia source text to parse and lower
+
+Required `expected` fields:
+
+- `ir`: normalized portable IR representation
+
+Recommended optional top-level fields:
+
+- `notes`: short contract note for maintainers only if needed
+
+No `stdin`, `argv`, eval output fields, parser AST fields, or host-specific metadata should appear in IR cases.
+
+Example shape at the schema level:
+
+```yaml
+name: example-name
+category: ir
+input:
+  source: |
+    some source
+expected:
+  ir:
+    ...
+```
+
+### Expected IR Representation
+
+The expected IR should be a canonical structured YAML mapping/list tree, equivalent to canonical JSON data but written in YAML for readability.
+
+Node representation:
+
+- each IR node is a mapping
+- every node has a required `node` field containing the portable node-family name
+- child nodes are nested mappings or lists
+- optional fields that are absent in the portable contract are omitted rather than represented with Python-specific placeholders
+- explicit `null` is allowed only where absence is part of the portable contract, such as the `context` side of `IrOptionNone(..., None, ...)`
+
+Pattern representation follows the same rule:
+
+- each pattern node is a mapping
+- every pattern node has a required `node` field containing the portable `IrPat*` family name
+
+Literal and identifier representation:
+
+- literals are represented by portable scalar values or nested portable nodes where required by the contract
+- identifiers are represented as plain strings in named fields such as `name`
+- operator names use a canonical symbolic or enum string chosen once and used consistently across all cases
+
+Ordering rules:
+
+- program-level node order is preserved
+- pipeline `stages` order is preserved
+- list item order is preserved
+- map entry order is preserved exactly as produced by portable lowering
+- case clause order is preserved
+
+This representation is portable, deterministic, and diff-friendly because it is plain structured data with explicit node-family names and no host object formatting.
+
+## 3. IR Normalization Layer
+
+The normalization layer should live in the Python host adapter area, alongside existing host normalization responsibilities.
+
+Recommended module location:
+
+- `hosts/python/ir_normalize.py` as a dedicated module
+
+Alternative acceptable location:
+
+- extend `hosts/python/normalize.py` only if IR normalization remains a clearly separate entrypoint
+
+Inputs:
+
+- the lowered IR tree produced by the current Python reference host at the portable Core IR boundary
+
+Output:
+
+- a canonical nested mapping/list/scalar structure suitable for YAML/JSON equality comparison in shared specs
+
+Normalization guarantees:
+
+- no Python class names beyond the portable contract node-family names
+- no memory addresses
+- no module-qualified repr output
+- stable ordering for all ordered child collections
+- only portable Core IR node families and documented portable pattern families
+
+Normalization responsibilities:
+
+- walk the lowered IR tree recursively
+- emit canonical field names per node family
+- preserve only portable semantic shape
+- omit span/debug metadata and any host-local execution details
+
+Host-local optimized node handling:
+
+- preferred behavior is rejection, not filtering
+- if a host-local optimized node appears anywhere in the tree being normalized for a shared IR case, normalization must stop and return an explicit failure
+
+That rejection keeps the shared IR path honest. Filtering would hide a portability-boundary violation instead of proving the boundary.
+
+## 4. Runner Integration
+
+The IR category should plug into the existing spec runner as one more supported category, not as a separate tool.
+
+### `spec/manifest.json`
+
+Update the manifest so the shared host contract clearly marks IR as an executable shared category for the Python reference host once implementation lands.
+
+Design intent:
+
+- keep `ir` as an existing shared contract category
+- update the host test contract entry for lowering so it matches the normalized portable IR comparison surface used by the runner
+- do not broaden the manifest beyond the current Python reference host
+
+### Loader / Discovery
+
+Extend the current YAML loader so it can:
+
+- discover files from `spec/ir/*.yaml`
+- validate the IR case schema
+- produce a loaded spec object carrying `category="ir"`, `input.source`, and `expected.ir`
+
+This is best done by extending the current generic loader, not by creating a second standalone IR loader unless the existing loader becomes unreasonably contorted.
+
+### Dispatch
+
+Runner dispatch remains category-based:
+
+- `eval` cases keep their current path
+- `ir` cases dispatch to the Python host IR execution path
+
+### Python host execution path
+
+For `ir` cases, execution is:
+
+1. parse source
+2. lower source to portable Core IR
+3. validate that no host-local optimized nodes appear
+4. normalize portable IR into the canonical shared representation
+5. compare actual normalized IR against expected normalized IR
+
+### Pass Condition
+
+An IR case passes only if:
+
+- parsing and lowering succeed
+- no forbidden host-local node appears
+- normalized actual IR exactly equals normalized expected IR
+
+### Failure Reporting
+
+Failure output should be field-based like the current runner, but the compared field is `ir`.
+
+Expected reporting shape:
+
+- case header: `FAIL ir <name> (<path>)`
+- failing field: `ir`
+- readable expected vs actual rendering of the canonical normalized structure
+
+If lowering leaks a forbidden host-local node, failure reporting should make that explicit instead of collapsing it into a generic runtime crash.
+
+## 5. Lowering Pipeline Boundary
+
+IR must be captured at:
+
+`parse -> lower -> STOP`
+
+It must not include:
+
+- optimization
+- evaluation
+- CLI wrapping
+- any host execution strategy after portable lowering
+
+Exact boundary in the current Python reference host design:
+
+- parse source with the existing parser entrypoint
+- obtain lowered IR from the existing lowering function that returns the minimal portable Core IR program tree
+- do not pass that tree through any optimization function
+
+The design depends on the same lowering boundary already guarded by the current Python implementation and documented in `docs/architecture/core-ir-portability.md`.
+
+This guarantees that shared IR validation is proving the portable Core IR boundary rather than a later host-local execution form.
+
+## 6. Exclusion Of Host-Local Nodes
+
+Enforcement mechanism:
+
+- normalization performs an explicit validation pass over the entire lowered IR tree before or during recursive normalization
+- forbidden node families are identified from the documented host-local post-lowering set, starting with `IrListTraversalLoop`
+
+Preferred check location:
+
+- during normalization, because the normalizer is already the last stop before shared comparison
+
+Acceptable alternative:
+
+- a dedicated validation helper immediately before normalization, as long as the shared IR path still fails before any comparison or serialization
+
+Required behavior:
+
+- if a forbidden node appears, the case fails with an explicit boundary error naming the forbidden node
+- the error must say that host-local optimized IR appeared in the shared portable IR path
+
+No silent dropping or rewriting of forbidden nodes is allowed.
+
+## 7. Initial Case Set Design
+
+First-wave IR cases should stay narrow and prove only the documented portable contract that already lowers today.
+
+### Literals
+
+Representative cases:
+
+- single literal expression
+- list of mixed literal forms including `nil`
+
+What they validate:
+
+- `IrLiteral` shape
+- expression-statement wrapping where relevant
+- explicit `nil -> IrOptionNone(IrLiteral("nil"), None, ...)` lowering
+
+### Variables
+
+Representative cases:
+
+- bare variable reference
+- variable inside a simple binary or call context
+
+What they validate:
+
+- `IrVar` lowering
+- identifiers represented host-neutrally
+
+### Function Calls
+
+Representative cases:
+
+- ordinary call with positional args
+- call using spread where already implemented
+
+What they validate:
+
+- `IrCall` shape
+- ordered argument lowering
+- explicit `IrSpread` nodes where documented
+
+### Pipelines
+
+Representative cases:
+
+- simple multi-stage pipeline
+- pipeline containing a slash-accessor stage or call-shaped stage already proven locally today
+
+What they validate:
+
+- one explicit `IrPipeline` node
+- ordered `stages` list
+- no regression to nested call shape
+
+### Blocks / Expression Statements
+
+Representative cases:
+
+- multi-expression block with final expression result shape
+- top-level expression statement case
+
+What they validate:
+
+- `IrBlock`
+- `IrExprStmt`
+- ordered child expression lowering
+
+### Lists / Maps / Spread
+
+Representative cases:
+
+- list literal with spread item
+- map literal with documented key forms already normalized by lowering
+
+What they validate:
+
+- `IrList`
+- `IrMap`
+- `IrSpread`
+- stable entry/item ordering
+
+### Option Constructors
+
+Representative cases:
+
+- `some(x)`
+- `none(reason, context)`
+- `nil`
+
+What they validate:
+
+- explicit `IrOptionSome`
+- explicit `IrOptionNone`
+- exact portable absence shape for `nil`
+
+### Pattern-Related Lowering
+
+Representative cases:
+
+- case/function with tuple and list patterns
+- case/function with `some(...)`, `none(...)`, wildcard, bind, literal, rest, map, or glob patterns already documented and lowering today
+
+What they validate:
+
+- documented `IrPat*` families only
+- preserved clause order
+- explicit guard lowering where present
+
+### Regression Boundary Case
+
+Representative case:
+
+- a source form known to produce a host-local optimization later in the Python host, but whose shared IR capture must remain portable at the pre-optimization boundary
+
+What it validates:
+
+- host-local optimized nodes do not appear in shared IR output
+- the IR spec path stops before optimization
+
+## 8. File / Module Impact
+
+Expected files to add:
+
+- `docs/architecture/issue-131-ir-shared-semantic-spec-design.md`
+- `spec/ir/*.yaml`
+- `hosts/python/ir_normalize.py` or equivalent dedicated IR normalization module
+
+Expected files to modify:
+
+- `spec/ir/README.md`
+- `spec/README.md`
+- `spec/manifest.json`
+- `tools/spec_runner/README.md`
+- `tools/spec_runner/loader.py`
+- `tools/spec_runner/executor.py`
+- `tools/spec_runner/comparator.py`
+- `tools/spec_runner/reporter.py`
+- `tools/spec_runner/runner.py` if summary/report flow needs category-aware handling
+- `hosts/python/exec_ir.py`
+- `hosts/python/adapter.py` only if needed to align the IR execution path with the new normalization contract
+- `hosts/python/normalize.py` only if shared host normalization interfaces need a small extension rather than a new module
+
+Scope discipline:
+
+- prefer extending existing runner modules over adding a second runner stack
+- keep changes localized to `spec/`, `tools/spec_runner/`, `hosts/python/`, and the required truth-sync docs
+- avoid cross-cutting edits in runtime/evaluator code unless implementation later discovers a narrow adapter need
+
+## 9. Doc Sync Plan (Design-Level)
+
+Docs that will need updates after implementation exists:
+
+- `GENIA_STATE.md`
+- `README.md`
+- `docs/architecture/core-ir-portability.md`
+- `tools/spec_runner/README.md`
+- `spec/README.md`
+- `spec/ir/README.md`
+
+Required doc changes in substance:
+
+- state that the IR category is executable in the shared spec runner once that is true
+- keep the distinction explicit between portable lowered IR and host-local optimized IR
+- describe the shared comparison surface for IR as normalized portable IR, not Python object output
+- remove scaffold-only wording for IR only after runner support and executable cases are present
+
+## 10. Risks & Edge Cases
+
+### Risk: normalization mirrors Python internals
+
+If normalization simply serializes dataclass fields or `repr()` output, shared expectations will leak Python details.
+
+Mitigation:
+
+- define and implement an explicit portable schema
+- allow only canonical portable field names and node-family names in normalized output
+
+### Risk: ordering instability
+
+If maps, clauses, or stage lists are normalized inconsistently, specs will flap or hide regressions.
+
+Mitigation:
+
+- preserve source/lowering order for ordered constructs
+- define field order once in the normalizer and fixture examples
+
+### Risk: partial lowering paths bypass the boundary
+
+If one execution path uses optimized IR while another uses lowered IR, shared cases become unreliable.
+
+Mitigation:
+
+- make `exec_ir` call the direct parse/lower path only
+- keep optimization and eval out of the IR category path entirely
+
+### Risk: future IR node additions break snapshots unexpectedly
+
+If new nodes are added locally without contract updates, IR cases may start failing in confusing ways.
+
+Mitigation:
+
+- make the normalizer reject unknown or non-portable nodes explicitly
+- keep the portable contract synchronized through `docs/architecture/core-ir-portability.md` and `spec/manifest.json`
+
+### Risk: forbidden host-local nodes are hidden
+
+If forbidden nodes are filtered out instead of rejected, the shared suite may pass while the boundary is already broken.
+
+Mitigation:
+
+- reject forbidden nodes with explicit failure text
+- keep the host-local node list anchored to the documented portability contract
+
+### Risk: runner abstraction grows too much
+
+If IR support introduces category-specific machinery everywhere, the simple runner becomes harder to maintain.
+
+Mitigation:
+
+- keep one generic loader/comparator structure with narrow category branches only where data shape differs
+- reuse the existing reporting format
+
+## 11. Non-Goals (Reinforced)
+
+- no IR redesign
+- no parser changes
+- no eval coupling
+- no multi-host support
+- no expansion of the portable IR contract
+
+This design exists only to make the current documented contract executable and provable in the Python reference host.
+
+## 12. Design Validation Check
+
+This design matches the Issue #131 spec note exactly:
+
+- it reuses the current shared spec runner instead of creating a new system
+- it adds only the minimum IR category extension needed for executable shared cases
+- it introduces no new language semantics and no new IR node families
+- it keeps Python-specific representations out of shared expectations
+- it captures IR at the portable lowering boundary before optimization
+- it treats host-local optimized IR as an explicit failure in the shared IR path
+- it remains small, composable, and scoped to the current Python reference host only

--- a/docs/architecture/issue-131-ir-shared-semantic-spec-proof.md
+++ b/docs/architecture/issue-131-ir-shared-semantic-spec-proof.md
@@ -1,0 +1,202 @@
+# Issue #131 Spec Note
+
+## 1. Change Name
+
+IR shared semantic-spec proof for Python reference host
+
+## 2. Purpose
+
+This change makes the documented Core IR portability boundary executable and testable in the shared Semantic Spec System.
+
+Python is proving the existing shared contract. Python is not defining new language behavior in this change.
+
+## 3. Scope Lock
+
+### In Scope
+
+- executable shared IR cases under `spec/ir/`
+- portable lowering-shape assertions for the minimal Core IR
+- manifest/runner category contract for IR cases
+- verification that portable lowering excludes host-local optimized nodes
+- doc wording needed to keep `GENIA_STATE.md`, `README.md`, spec docs, and related contract docs truthful
+
+### Out of Scope
+
+- Core IR redesign
+- parser redesign
+- eval redesign
+- non-Python hosts
+- generic multi-host runner
+- including host-local optimized nodes in shared IR expectations
+- snapshotting host parser ASTs or Python-specific internal objects
+
+## 4. Source Of Truth
+
+Repo truth order for this change:
+
+1. `AGENTS.md`
+2. `GENIA_STATE.md`
+3. `GENIA_RULES.md`
+4. `GENIA_REPL_README.md`
+5. `README.md`
+6. `spec/*`
+7. `docs/host-interop/*`
+8. `docs/architecture/*`
+
+`GENIA_STATE.md` is the final authority.
+
+If any existing doc, spec note, runner README, or host doc conflicts with `GENIA_STATE.md`, `GENIA_STATE.md` wins.
+
+## 5. Current Implemented Reality
+
+Implemented reality in the repository today:
+
+- Python is the only implemented host and the reference host.
+- Shared semantic-spec categories are `parse`, `ir`, `eval`, `cli`, `flow`, and `error`.
+- `eval` and `ir` are currently executable in the shared spec runner.
+- IR stability is `Partial`, not `Stable`.
+- The minimal portable Core IR contract is already documented in `docs/architecture/core-ir-portability.md`.
+- Host-local optimized nodes such as `IrListTraversalLoop` are explicitly outside the portable contract.
+
+This spec note does not change that implemented reality by itself. It defines the contract that later Design and Implementation steps must make executable.
+
+## 6. Portable IR Contract To Prove
+
+Shared IR semantic-spec cases must assert the portable lowering contract already documented for the current Python reference host.
+
+Required assertions:
+
+- lowering output must use only the minimal portable Core IR node families listed in `docs/architecture/core-ir-portability.md`
+- pattern lowering must use only the documented `IrPat*` families
+- pipelines lower as one explicit `IrPipeline(source, stages=[...])` node with ordered stages
+- `some(x)` lowers as `IrOptionSome(...)`
+- `none(...)` lowers as `IrOptionNone(...)`
+- `nil` lowers to `IrOptionNone(IrLiteral("nil"), None, ...)`
+- host-local optimized nodes must not appear in the portable lowered IR output
+- shared IR expectations must not depend on Python-specific object/class formatting
+
+This contract is about lowering shape at the portable Core IR boundary only.
+
+## 7. Case Format Requirements
+
+An IR shared spec case must supply:
+
+- source input as Genia source text
+- any case metadata needed to identify the case and category
+- one portable IR expectation for the lowered result at the minimal Core IR boundary
+
+For the IR category, the runner must compare:
+
+- the host-produced lowered portable IR representation
+- against the case’s expected portable IR representation
+
+The expected representation is not chosen by this spec step. The Design step must select it. Whatever representation is chosen must satisfy all of these constraints:
+
+- portable
+- deterministic
+- host-neutral
+- readable in diffs
+- excludes host object noise
+
+The representation may be full normalized IR text, structured normalized JSON, or another normalized portable form only if it satisfies those constraints.
+
+Normalization requirements:
+
+- normalization must remove Python-specific leakage such as class repr formatting, memory identity, module-qualified object names, and other host object noise
+- normalization must preserve the observable portable lowering shape
+- normalization must preserve ordered structure where order is part of the contract, including pipeline stage order and list/map entry order where lowering preserves it
+- normalization must preserve explicit portable node-family names or an exact host-neutral equivalent that still proves the same contract
+
+Pass/fail contract:
+
+- pass: the lowered output matches the expected portable normalized representation exactly
+- fail: any portable node-family mismatch, ordering mismatch, explicit constructor mismatch, unexpected host-local node, or host-specific leakage in the compared output
+
+IR shared cases must not compare Python parser ASTs, Python dataclass reprs, or other Python-internal structures.
+
+## 8. Category Boundary
+
+IR shared specs assert lowering-shape conformance at the portable Core IR boundary.
+
+They do not assert:
+
+- eval results
+- CLI behavior
+- parser AST structure
+
+Any host-local post-lowering optimization is outside the IR shared contract for this issue.
+
+## 9. Required Case Inventory
+
+Minimum first-wave IR coverage must include executable shared cases for the lowering shapes that are already documented and already lower today.
+
+Required first-wave coverage:
+
+- literals
+- variable references
+- calls
+- pipelines
+- blocks and expression statements where relevant to portable lowering shape
+- lists, maps, and spread where already implemented
+- option constructors: `some`, `none`, `nil`
+- case lowering with pattern families that are already documented
+
+Include function definitions, assignments, and imports only when both of these are true:
+
+- they are part of the documented portable Core IR contract
+- they already lower today in the Python reference host
+
+The first wave must include at least one regression case proving exclusion of host-local optimized nodes from the portable lowered IR output.
+
+## 10. Failure Modes The Spec Must Catch
+
+The IR shared spec contract must catch at least these failures:
+
+- portable lowering includes `IrListTraversalLoop`
+- pipeline lowering regresses into nested calls instead of `IrPipeline`
+- option constructors stop lowering to explicit `IrOptionSome` or `IrOptionNone`
+- `nil` stops lowering to explicit `IrOptionNone(IrLiteral("nil"), None, ...)`
+- pattern lowering stops using documented `IrPat*` families
+- IR output depends on Python repr/class names
+- docs imply broader IR shared coverage than the runner actually executes
+
+## 11. Truthfulness Requirements
+
+Docs may say IR shared semantic-spec coverage is active because the runner executes IR cases in the Python reference host today.
+
+Docs must not imply:
+
+- multi-host IR execution exists
+- host-local optimized IR is part of the shared portable contract
+
+Examples in docs must remain labeled consistently with the repository documentation truth model.
+
+## 12. Acceptance Criteria
+
+This issue is complete only when all of the following are true:
+
+- `spec/ir/` contains executable shared IR cases
+- the Python reference host executes the IR category in the shared spec runner
+- IR expectations validate the documented minimal portable Core IR contract
+- host-local optimized nodes are excluded from shared IR expectations
+- `GENIA_STATE.md`, `README.md`, `docs/architecture/core-ir-portability.md`, and `tools/spec_runner/README.md` remain aligned
+
+## 13. Non-Goals / Do Not Drift
+
+Do not drift beyond the current documented contract:
+
+- do not add new Core IR nodes
+- do not broaden the contract beyond what docs already define
+- do not collapse the boundary between portable IR and host-local optimized IR
+- do not claim multi-host support exists
+- do not redesign error normalization unless needed only to state the IR boundary truthfully
+
+## 14. Handoff To Design
+
+The Design step must decide exactly:
+
+- exact spec case file schema for IR
+- exact normalized representation used for IR expectations
+- exact runner plumbing and manifest changes
+- exact doc files that need wording changes
+- exact tests needed for regression protection

--- a/docs/architecture/spec-system.md
+++ b/docs/architecture/spec-system.md
@@ -10,26 +10,25 @@ This document describes the implemented Semantic Spec System in the repository t
 
 ## Structure
 
-- shared spec files currently live in `spec/eval/`
+- shared spec files currently live in `spec/eval/` and `spec/ir/`
 - the runner lives in `tools/spec_runner/`
-- the current runner executes YAML eval cases against the Python reference host
+- the current runner executes YAML eval and IR cases against the Python reference host
 - the current comparison surface is:
-  - `stdout`
-  - `stderr`
-  - `exit_code`
+  - eval: `stdout`, `stderr`, `exit_code`
+  - ir: normalized portable Core IR
 
 ## Contract Relationship
 
 **LANGUAGE CONTRACT:**
 - shared semantic-spec categories are `parse`, `ir`, `eval`, `cli`, `flow`, and `error`
-- implemented shared case coverage currently exists for `eval` only
+- implemented shared case coverage currently exists for `eval` and `ir`
 
 **PYTHON REFERENCE HOST:**
 - Python is the only implemented host
-- Python executes the current shared eval spec suite
+- Python executes the current shared eval and IR spec suites
 
 ## Current Limitations
 
-- parse, ir, cli, flow, and error shared spec files are not implemented yet
-- current runner normalization is limited to line-ending normalization for stdout/stderr
+- parse, cli, flow, and error shared spec files are not implemented yet
+- current runner normalization is limited to line-ending normalization for eval stdout/stderr plus portable IR normalization for IR cases
 - no generic multi-host runner exists in this phase

--- a/hosts/python/exec_ir.py
+++ b/hosts/python/exec_ir.py
@@ -2,6 +2,21 @@
 IR generation execution for Genia Python host adapter.
 """
 
+from genia.interpreter import Parser, lex, lower_program
+
+from .ir_normalize import normalize_portable_ir
+
+
 def exec_ir(case) -> dict:
-    # TODO: Parse and lower to Core IR using src/genia/interpreter.py
-    return {"ir": "TODO: Core IR snapshot"}
+    if isinstance(case.input, str):
+        source = case.input
+    elif isinstance(case.input, dict):
+        source = case.input.get("source")
+        if not isinstance(source, str):
+            raise TypeError("ir case input.source must be a string")
+    else:
+        raise TypeError("ir case input must be a string or mapping")
+
+    ast_nodes = Parser(lex(source)).parse_program()
+    lowered = lower_program(ast_nodes)
+    return {"ir": normalize_portable_ir(lowered)}

--- a/hosts/python/ir_normalize.py
+++ b/hosts/python/ir_normalize.py
@@ -1,0 +1,336 @@
+"""
+Portable Core IR normalization for shared semantic specs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from genia.interpreter import (
+    Boolean,
+    IrAnnotation,
+    IrAssign,
+    IrBinary,
+    IrBlock,
+    IrCall,
+    IrCase,
+    IrCaseClause,
+    IrDelay,
+    IrExprStmt,
+    IrFuncDef,
+    IrImport,
+    IrLambda,
+    IrList,
+    IrLiteral,
+    IrMap,
+    IrNode,
+    IrOptionNone,
+    IrOptionSome,
+    IrPattern,
+    IrPatBind,
+    IrPatGlob,
+    IrPatList,
+    IrPatLiteral,
+    IrPatMap,
+    IrPatNone,
+    IrPatRest,
+    IrPatSome,
+    IrPatTuple,
+    IrPatWildcard,
+    IrPipeline,
+    IrQuote,
+    IrQuasiQuote,
+    IrSpread,
+    IrUnary,
+    IrUnquote,
+    IrUnquoteSplicing,
+    IrVar,
+    ListLiteral,
+    MapLiteral,
+    Number,
+    String,
+    Var,
+    assert_portable_core_ir,
+)
+
+
+def normalize_portable_ir(nodes: Iterable[IrNode]) -> list[dict[str, Any]]:
+    lowered = list(nodes)
+    assert_portable_core_ir(lowered)
+    return [_normalize_ir_node(node) for node in lowered]
+
+
+def _normalize_ir_node(node: IrNode) -> dict[str, Any]:
+    if isinstance(node, IrAnnotation):
+        return {
+            "node": "IrAnnotation",
+            "name": node.name,
+            "value": _normalize_ir_node(node.value),
+        }
+    if isinstance(node, IrLiteral):
+        return {
+            "node": "IrLiteral",
+            "value": node.value,
+        }
+    if isinstance(node, IrOptionNone):
+        return {
+            "node": "IrOptionNone",
+            "reason": _normalize_ir_node(node.reason),
+            "context": None if node.context is None else _normalize_ir_node(node.context),
+        }
+    if isinstance(node, IrOptionSome):
+        return {
+            "node": "IrOptionSome",
+            "value": _normalize_ir_node(node.value),
+        }
+    if isinstance(node, IrVar):
+        return {
+            "node": "IrVar",
+            "name": node.name,
+        }
+    if isinstance(node, IrQuote):
+        return {
+            "node": "IrQuote",
+            "expr": _normalize_quoted_syntax(node.expr),
+        }
+    if isinstance(node, IrDelay):
+        return {
+            "node": "IrDelay",
+            "expr": _normalize_ir_node(node.expr),
+        }
+    if isinstance(node, IrQuasiQuote):
+        return {
+            "node": "IrQuasiQuote",
+            "expr": _normalize_quoted_syntax(node.expr),
+        }
+    if isinstance(node, IrUnquote):
+        return {
+            "node": "IrUnquote",
+            "expr": _normalize_ir_node(node.expr),
+        }
+    if isinstance(node, IrUnquoteSplicing):
+        return {
+            "node": "IrUnquoteSplicing",
+            "expr": _normalize_ir_node(node.expr),
+        }
+    if isinstance(node, IrUnary):
+        return {
+            "node": "IrUnary",
+            "op": node.op,
+            "expr": _normalize_ir_node(node.expr),
+        }
+    if isinstance(node, IrBinary):
+        return {
+            "node": "IrBinary",
+            "left": _normalize_ir_node(node.left),
+            "op": node.op,
+            "right": _normalize_ir_node(node.right),
+        }
+    if isinstance(node, IrPipeline):
+        return {
+            "node": "IrPipeline",
+            "source": _normalize_ir_node(node.source),
+            "stages": [_normalize_ir_node(stage) for stage in node.stages],
+        }
+    if isinstance(node, IrCall):
+        return {
+            "node": "IrCall",
+            "fn": _normalize_ir_node(node.fn),
+            "args": [_normalize_ir_node(arg) for arg in node.args],
+        }
+    if isinstance(node, IrExprStmt):
+        return {
+            "node": "IrExprStmt",
+            "expr": _normalize_ir_node(node.expr),
+        }
+    if isinstance(node, IrBlock):
+        return {
+            "node": "IrBlock",
+            "exprs": [_normalize_ir_node(expr) for expr in node.exprs],
+        }
+    if isinstance(node, IrList):
+        return {
+            "node": "IrList",
+            "items": [_normalize_ir_node(item) for item in node.items],
+        }
+    if isinstance(node, IrMap):
+        return {
+            "node": "IrMap",
+            "items": [
+                {
+                    "key": key,
+                    "value": _normalize_ir_node(value),
+                }
+                for key, value in node.items
+            ],
+        }
+    if isinstance(node, IrSpread):
+        return {
+            "node": "IrSpread",
+            "expr": _normalize_ir_node(node.expr),
+        }
+    if isinstance(node, IrCaseClause):
+        normalized = {
+            "node": "IrCaseClause",
+            "pattern": _normalize_pattern(node.pattern),
+            "result": _normalize_ir_node(node.result),
+        }
+        if node.guard is not None:
+            normalized["guard"] = _normalize_ir_node(node.guard)
+        return normalized
+    if isinstance(node, IrCase):
+        return {
+            "node": "IrCase",
+            "clauses": [_normalize_ir_node(clause) for clause in node.clauses],
+        }
+    if isinstance(node, IrLambda):
+        normalized = {
+            "node": "IrLambda",
+            "params": list(node.params),
+            "body": _normalize_ir_node(node.body),
+        }
+        if node.rest_param is not None:
+            normalized["rest_param"] = node.rest_param
+        return normalized
+    if isinstance(node, IrAssign):
+        normalized = {
+            "node": "IrAssign",
+            "name": node.name,
+            "expr": _normalize_ir_node(node.expr),
+        }
+        if node.annotations:
+            normalized["annotations"] = [_normalize_ir_node(annotation) for annotation in node.annotations]
+        return normalized
+    if isinstance(node, IrFuncDef):
+        normalized = {
+            "node": "IrFuncDef",
+            "name": node.name,
+            "params": list(node.params),
+            "body": _normalize_ir_node(node.body),
+        }
+        if node.rest_param is not None:
+            normalized["rest_param"] = node.rest_param
+        if node.docstring is not None:
+            normalized["docstring"] = node.docstring
+        if node.annotations:
+            normalized["annotations"] = [_normalize_ir_node(annotation) for annotation in node.annotations]
+        return normalized
+    if isinstance(node, IrImport):
+        normalized = {
+            "node": "IrImport",
+            "module_name": node.module_name,
+        }
+        if node.alias is not None:
+            normalized["alias"] = node.alias
+        return normalized
+
+    raise TypeError(
+        "Portable Core IR normalization failed: unsupported node "
+        f"{type(node).__name__} in shared IR path."
+    )
+
+
+def _normalize_pattern(pattern: IrPattern) -> dict[str, Any]:
+    if isinstance(pattern, IrPatLiteral):
+        return {
+            "node": "IrPatLiteral",
+            "value": pattern.value,
+        }
+    if isinstance(pattern, IrPatBind):
+        return {
+            "node": "IrPatBind",
+            "name": pattern.name,
+        }
+    if isinstance(pattern, IrPatWildcard):
+        return {"node": "IrPatWildcard"}
+    if isinstance(pattern, IrPatRest):
+        return {
+            "node": "IrPatRest",
+            "name": pattern.name,
+        }
+    if isinstance(pattern, IrPatTuple):
+        return {
+            "node": "IrPatTuple",
+            "items": [_normalize_pattern(item) for item in pattern.items],
+        }
+    if isinstance(pattern, IrPatList):
+        return {
+            "node": "IrPatList",
+            "items": [_normalize_pattern(item) for item in pattern.items],
+        }
+    if isinstance(pattern, IrPatMap):
+        return {
+            "node": "IrPatMap",
+            "items": [
+                {
+                    "key": key,
+                    "value": _normalize_pattern(value),
+                }
+                for key, value in pattern.items
+            ],
+        }
+    if isinstance(pattern, IrPatGlob):
+        return {
+            "node": "IrPatGlob",
+            "pattern": pattern.matcher.source,
+        }
+    if isinstance(pattern, IrPatSome):
+        return {
+            "node": "IrPatSome",
+            "inner": _normalize_pattern(pattern.inner),
+        }
+    if isinstance(pattern, IrPatNone):
+        return {
+            "node": "IrPatNone",
+            "reason": None if pattern.reason is None else _normalize_pattern(pattern.reason),
+            "context": None if pattern.context is None else _normalize_pattern(pattern.context),
+        }
+
+    raise TypeError(
+        "Portable Core IR normalization failed: unsupported pattern "
+        f"{type(pattern).__name__} in shared IR path."
+    )
+
+
+def _normalize_quoted_syntax(expr: Any) -> dict[str, Any]:
+    if isinstance(expr, String):
+        return {"kind": "Literal", "value": expr.value}
+    if isinstance(expr, Number):
+        return {"kind": "Literal", "value": expr.value}
+    if isinstance(expr, Boolean):
+        return {"kind": "Literal", "value": expr.value}
+    if isinstance(expr, Var):
+        return {"kind": "Var", "name": expr.name}
+    if isinstance(expr, ListLiteral):
+        return {
+            "kind": "List",
+            "items": [_normalize_quoted_syntax(item) for item in expr.items],
+        }
+    if isinstance(expr, MapLiteral):
+        return {
+            "kind": "Map",
+            "items": [
+                {
+                    "key": _normalize_quoted_map_key(key),
+                    "value": _normalize_quoted_syntax(value),
+                }
+                for key, value in expr.items
+            ],
+        }
+
+    raise TypeError(
+        "Portable Core IR normalization failed: unsupported quoted syntax "
+        f"{type(expr).__name__} in shared IR path."
+    )
+
+
+def _normalize_quoted_map_key(key: Any) -> str:
+    if isinstance(key, Var):
+        return key.name
+    if isinstance(key, String):
+        return key.value
+
+    raise TypeError(
+        "Portable Core IR normalization failed: unsupported quoted map key "
+        f"{type(key).__name__} in shared IR path."
+    )

--- a/spec/README.md
+++ b/spec/README.md
@@ -20,7 +20,8 @@ This directory holds the shared cross-host spec suite for Genia.
 ## Implemented Shared Spec Coverage
 
 - `eval` — **active** (executable shared spec files)
-- `parse`, `ir`, `cli`, `flow`, `error` — **scaffold-only** (no executable shared spec files yet)
+- `ir` — **active** (executable shared spec files)
+- `parse`, `cli`, `flow`, `error` — **scaffold-only** (no executable shared spec files yet)
 
 Browser execution is planned to use the Python reference host on a backend service in the current playground direction; this does not add a second implemented host today.
 
@@ -32,18 +33,19 @@ Browser execution is planned to use the Python reference host on a backend servi
 ## Directory Layout
 
 - `parse/`: parse scaffold only
-- `ir/`: IR scaffold only
+- `ir/`: implemented IR cases (active)
 - `eval/`: implemented eval cases (active)
 - `cli/`: CLI scaffold only
 - `flow/`: flow scaffold only
 - `error/`: error scaffold only
 
 **Note:**
-- Only `eval/` contains executable shared spec files in this phase.
-- All other category directories are present as scaffolds only and must contain only `README.md`.
+- `eval/` and `ir/` contain executable shared spec files in this phase.
+- Other category directories are present as scaffolds only and must contain only `README.md`.
 
 **Normalization:**
-In the implemented eval suite, stdout/stderr line endings are normalized before comparison. The current shared runner compares only `stdout`, `stderr`, and `exit_code`.
+- In the implemented eval suite, stdout/stderr line endings are normalized before comparison.
+- In the implemented IR suite, portable Core IR is normalized before comparison.
 
 **Test Types:**
 - Shared contract tests: validate the cross-host contract for the categories above

--- a/spec/ir/README.md
+++ b/spec/ir/README.md
@@ -1,5 +1,14 @@
-# IR Spec Scaffold
+# IR Shared Specs
 
-This directory is scaffold-only in this phase.
-No executable shared spec files exist here yet.
-Only README.md is allowed.
+This directory contains executable shared IR semantic-spec cases.
+
+Python is the only executing host today.
+
+Cases in this directory assert portable Core IR lowering shape at the pre-optimization boundary:
+
+- parse
+- lower
+- normalize portable IR
+- compare against shared expected IR
+
+Host-local optimized nodes are outside this contract and must not appear in shared IR expectations.

--- a/spec/ir/call-spread.yaml
+++ b/spec/ir/call-spread.yaml
@@ -1,0 +1,22 @@
+name: call-spread
+category: ir
+input:
+  source: |
+    f(..[1, 2])
+expected:
+  ir:
+    - node: IrExprStmt
+      expr:
+        node: IrCall
+        fn:
+          node: IrVar
+          name: f
+        args:
+          - node: IrSpread
+            expr:
+              node: IrList
+              items:
+                - node: IrLiteral
+                  value: 1
+                - node: IrLiteral
+                  value: 2

--- a/spec/ir/case-patterns.yaml
+++ b/spec/ir/case-patterns.yaml
@@ -1,0 +1,49 @@
+name: case-patterns
+category: ir
+input:
+  source: |
+    classify(xs) = ([x, ..rest]) ? x > 0 -> some(x) | (_) -> nil
+expected:
+  ir:
+    - node: IrFuncDef
+      name: classify
+      params:
+        - xs
+      body:
+        node: IrCase
+        clauses:
+          - node: IrCaseClause
+            pattern:
+              node: IrPatTuple
+              items:
+                - node: IrPatList
+                  items:
+                    - node: IrPatBind
+                      name: x
+                    - node: IrPatRest
+                      name: rest
+            guard:
+              node: IrBinary
+              left:
+                node: IrVar
+                name: x
+              op: GT
+              right:
+                node: IrLiteral
+                value: 0
+            result:
+              node: IrOptionSome
+              value:
+                node: IrVar
+                name: x
+          - node: IrCaseClause
+            pattern:
+              node: IrPatTuple
+              items:
+                - node: IrPatWildcard
+            result:
+              node: IrOptionNone
+              reason:
+                node: IrLiteral
+                value: nil
+              context: null

--- a/spec/ir/import-pipeline-stage.yaml
+++ b/spec/ir/import-pipeline-stage.yaml
@@ -1,0 +1,26 @@
+name: import-pipeline-stage
+category: ir
+input:
+  source: |
+    import python.json as pyjson
+    "null" |> pyjson/loads
+expected:
+  ir:
+    - node: IrImport
+      module_name: python.json
+      alias: pyjson
+    - node: IrExprStmt
+      expr:
+        node: IrPipeline
+        source:
+          node: IrLiteral
+          value: "null"
+        stages:
+          - node: IrBinary
+            left:
+              node: IrVar
+              name: pyjson
+            op: SLASH
+            right:
+              node: IrVar
+              name: loads

--- a/spec/ir/option-constructors.yaml
+++ b/spec/ir/option-constructors.yaml
@@ -1,0 +1,33 @@
+name: option-constructors
+category: ir
+input:
+  source: |
+    [some(1), none("parse_failed", {source: "x"}), nil]
+expected:
+  ir:
+    - node: IrExprStmt
+      expr:
+        node: IrList
+        items:
+          - node: IrOptionSome
+            value:
+              node: IrLiteral
+              value: 1
+          - node: IrOptionNone
+            reason:
+              node: IrQuote
+              expr:
+                kind: Literal
+                value: parse_failed
+            context:
+              node: IrMap
+              items:
+                - key: source
+                  value:
+                    node: IrLiteral
+                    value: x
+          - node: IrOptionNone
+            reason:
+              node: IrLiteral
+              value: nil
+            context: null

--- a/spec/ir/pipeline-explicit.yaml
+++ b/spec/ir/pipeline-explicit.yaml
@@ -1,0 +1,18 @@
+name: pipeline-explicit
+category: ir
+input:
+  source: |
+    3 |> inc |> double
+expected:
+  ir:
+    - node: IrExprStmt
+      expr:
+        node: IrPipeline
+        source:
+          node: IrLiteral
+          value: 3
+        stages:
+          - node: IrVar
+            name: inc
+          - node: IrVar
+            name: double

--- a/spec/manifest.json
+++ b/spec/manifest.json
@@ -99,7 +99,7 @@
     },
     "lower": {
       "input": "source string",
-      "output": "minimal portable Core IR JSON",
+      "output": "normalized minimal portable Core IR JSON",
       "optional_host_local_output": "optional optimized host-local IR JSON payload"
     },
     "eval": {

--- a/tests/test_ir_shared_spec.py
+++ b/tests/test_ir_shared_spec.py
@@ -1,0 +1,19 @@
+import pytest
+
+from genia.interpreter import Parser, lex, lower_program, optimize_program
+from hosts.python.ir_normalize import normalize_portable_ir
+
+
+def test_shared_ir_normalization_rejects_host_local_optimized_nodes():
+    src = """
+    nth(n, xs) =
+      (_, []) -> nil |
+      (0, [x, .._]) -> x |
+      (n, [_, ..rest]) -> nth(n - 1, rest)
+    """
+
+    ast_nodes = Parser(lex(src)).parse_program()
+    optimized = optimize_program(lower_program(ast_nodes))
+
+    with pytest.raises(RuntimeError, match="IrListTraversalLoop appeared before host-local optimization"):
+        normalize_portable_ir(optimized)

--- a/tests/test_ir_shared_spec_contract.py
+++ b/tests/test_ir_shared_spec_contract.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from genia.interpreter import Parser, lex, lower_program
+from hosts.python.ir_normalize import normalize_portable_ir
+from tools.spec_runner.comparator import compare_spec
+from tools.spec_runner.executor import ActualResult, execute_spec
+from tools.spec_runner.loader import load_spec
+
+
+REPO = Path(__file__).resolve().parents[1]
+IR_DIR = REPO / "spec" / "ir"
+
+
+def _lower_and_normalize(source: str) -> list[dict]:
+    ast_nodes = Parser(lex(source)).parse_program()
+    return normalize_portable_ir(lower_program(ast_nodes))
+
+
+def test_normalized_ir_is_deterministic_across_repeated_runs() -> None:
+    source = 'import python.json as pyjson\n"null" |> pyjson/loads'
+
+    first = _lower_and_normalize(source)
+    second = _lower_and_normalize(source)
+
+    assert first == second
+
+
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        ("42", [{"node": "IrExprStmt", "expr": {"node": "IrLiteral", "value": 42}}]),
+        ("value", [{"node": "IrExprStmt", "expr": {"node": "IrVar", "name": "value"}}]),
+        (
+            "f(1, 2)",
+            [
+                {
+                    "node": "IrExprStmt",
+                    "expr": {
+                        "node": "IrCall",
+                        "fn": {"node": "IrVar", "name": "f"},
+                        "args": [
+                            {"node": "IrLiteral", "value": 1},
+                            {"node": "IrLiteral", "value": 2},
+                        ],
+                    },
+                }
+            ],
+        ),
+    ],
+)
+def test_representative_ir_nodes_normalize_to_portable_shape(source: str, expected: list[dict]) -> None:
+    assert _lower_and_normalize(source) == expected
+
+
+def test_pipeline_normalization_keeps_explicit_pipeline_shape() -> None:
+    normalized = _lower_and_normalize("3 |> inc |> double")
+    expr = normalized[0]["expr"]
+
+    assert expr["node"] == "IrPipeline"
+    assert expr["source"] == {"node": "IrLiteral", "value": 3}
+    assert expr["stages"] == [
+        {"node": "IrVar", "name": "inc"},
+        {"node": "IrVar", "name": "double"},
+    ]
+
+
+def test_option_constructor_normalization_keeps_documented_portable_forms() -> None:
+    normalized = _lower_and_normalize('[some(1), none("parse_failed", {source: "x"}), nil]')
+    items = normalized[0]["expr"]["items"]
+
+    assert items[0] == {"node": "IrOptionSome", "value": {"node": "IrLiteral", "value": 1}}
+    assert items[1]["node"] == "IrOptionNone"
+    assert items[1]["reason"] == {
+        "node": "IrQuote",
+        "expr": {"kind": "Literal", "value": "parse_failed"},
+    }
+    assert items[2] == {
+        "node": "IrOptionNone",
+        "reason": {"node": "IrLiteral", "value": "nil"},
+        "context": None,
+    }
+
+
+def test_pattern_lowering_normalization_uses_only_documented_irpat_families() -> None:
+    normalized = _lower_and_normalize(
+        'classify(xs) = ([x, ..rest]) ? x > 0 -> some(x) | (_) -> nil'
+    )
+    clauses = normalized[0]["body"]["clauses"]
+
+    assert clauses[0]["pattern"] == {
+        "node": "IrPatTuple",
+        "items": [
+            {
+                "node": "IrPatList",
+                "items": [
+                    {"node": "IrPatBind", "name": "x"},
+                    {"node": "IrPatRest", "name": "rest"},
+                ],
+            }
+        ],
+    }
+    assert clauses[1]["pattern"] == {
+        "node": "IrPatTuple",
+        "items": [{"node": "IrPatWildcard"}],
+    }
+
+
+def test_normalized_ir_does_not_leak_python_specific_formatting() -> None:
+    normalized = _lower_and_normalize("3 |> inc |> double")
+    rendered = repr(normalized)
+
+    assert "SourceSpan" not in rendered
+    assert "<memory>" not in rendered
+    assert "span" not in rendered
+    assert " at 0x" not in rendered
+    assert "IrPipeline(" not in rendered
+
+
+def test_compare_spec_reports_ir_mismatch_on_expected_shape_difference() -> None:
+    spec = load_spec(IR_DIR / "pipeline-explicit.yaml")
+    actual = execute_spec(spec)
+    mutated_expected = [{"node": "IrExprStmt", "expr": {"node": "IrCall"}}]
+    mismatched_spec = spec.__class__(
+        name=spec.name,
+        category=spec.category,
+        source=spec.source,
+        stdin=spec.stdin,
+        expected_stdout=spec.expected_stdout,
+        expected_stderr=spec.expected_stderr,
+        expected_exit_code=spec.expected_exit_code,
+        expected_ir=mutated_expected,
+        path=spec.path,
+    )
+
+    failures = compare_spec(mismatched_spec, actual)
+
+    assert len(failures) == 1
+    assert failures[0].field == "ir"
+    assert failures[0].expected == mutated_expected
+    assert failures[0].actual == actual.ir
+
+
+def test_loader_rejects_ir_spec_missing_expected_ir(tmp_path: Path) -> None:
+    spec_path = tmp_path / "broken-ir.yaml"
+    spec_path.write_text(
+        "\n".join(
+            [
+                "name: broken-ir",
+                "category: ir",
+                "input:",
+                "  source: |",
+                "    1",
+                "expected: {}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"missing required field: expected\.ir"):
+        load_spec(spec_path)
+
+
+def test_loader_rejects_ir_spec_with_eval_only_fields(tmp_path: Path) -> None:
+    spec_path = tmp_path / "broken-fields.yaml"
+    spec_path.write_text(
+        "\n".join(
+            [
+                "name: broken-fields",
+                "category: ir",
+                "input:",
+                "  source: |",
+                "    1",
+                "expected:",
+                "  stdout: ''",
+                "  stderr: ''",
+                "  exit_code: 0",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"unknown expected fields"):
+        load_spec(spec_path)
+
+
+def test_executor_dispatches_ir_category_to_ir_result_shape() -> None:
+    spec = load_spec(IR_DIR / "call-spread.yaml")
+
+    actual = execute_spec(spec)
+
+    assert isinstance(actual, ActualResult)
+    assert actual.ir == spec.expected_ir
+    assert actual.stdout is None
+    assert actual.stderr is None
+    assert actual.exit_code is None

--- a/tests/test_portability_contract_sync.py
+++ b/tests/test_portability_contract_sync.py
@@ -122,15 +122,15 @@ def test_manifest_core_ir_patterns_match_architecture_doc():
         assert f"`{name}`" in arch_doc, f"{name} missing from core-ir-portability.md"
 
 
-def test_spec_category_dirs_allow_eval_phase1_specs_only():
-    """Phase 1 allows YAML files only in spec/eval; other category dirs remain scaffolds."""
+def test_spec_category_dirs_allow_eval_and_ir_specs_only():
+    """Current phase allows YAML files only in active shared spec category dirs."""
     spec_dir = REPO / "spec"
     # Canonical categories as defined in GENIA_STATE.md and spec/README.md
     category_dirs = [
         "parse", "ir", "eval", "cli", "flow", "error"
     ]
-    # Only eval is officially activated for YAML specs in this phase
-    activated = {"eval"}
+    # Only eval and ir are officially activated for YAML specs in this phase
+    activated = {"eval", "ir"}
     for dirname in category_dirs:
         d = spec_dir / dirname
         assert d.is_dir(), f"spec/{dirname}/ missing"

--- a/tests/test_spec_ir_runner_blackbox.py
+++ b/tests/test_spec_ir_runner_blackbox.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+from tools.spec_runner.comparator import compare_spec
+from tools.spec_runner.executor import execute_spec
+from tools.spec_runner.loader import discover_specs, load_spec
+
+
+IR_DIR = Path(__file__).resolve().parents[1] / "spec" / "ir"
+EVAL_DIR = Path(__file__).resolve().parents[1] / "spec" / "eval"
+
+
+def test_discover_specs_includes_ir_cases() -> None:
+    specs, invalid_specs = discover_specs()
+
+    assert not invalid_specs
+    ir_names = {spec.name for spec in specs if spec.category == "ir"}
+    assert {
+        "pipeline-explicit",
+        "option-constructors",
+        "import-pipeline-stage",
+        "call-spread",
+        "case-patterns",
+    }.issubset(ir_names)
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        "pipeline-explicit.yaml",
+        "option-constructors.yaml",
+        "import-pipeline-stage.yaml",
+        "call-spread.yaml",
+        "case-patterns.yaml",
+    ],
+)
+def test_ir_spec_fixture(fname: str) -> None:
+    spec = load_spec(IR_DIR / fname)
+    actual = execute_spec(spec)
+    failures = compare_spec(spec, actual)
+    assert not failures, f"Failures: {failures}"
+
+
+def test_existing_eval_category_still_executes_through_shared_runner() -> None:
+    spec = load_spec(EVAL_DIR / "arithmetic-basic.yaml")
+    actual = execute_spec(spec)
+    failures = compare_spec(spec, actual)
+
+    assert actual.ir is None
+    assert not failures, f"Failures: {failures}"

--- a/tools/spec_runner/README.md
+++ b/tools/spec_runner/README.md
@@ -7,10 +7,12 @@ The shared spec runner loads shared spec cases, executes them against the Python
 
 ## Runner Scope (Current Phase)
 
-- **Active category:** `eval` (executable shared spec files)
-- **Scaffold-only:** `parse`, `ir`, `cli`, `flow`, `error` (no executable shared spec files yet)
-- YAML spec files are loaded only from `spec/eval/`
-- Comparison fields: `stdout`, `stderr`, `exit_code`
+- **Active categories:** `eval`, `ir` (executable shared spec files)
+- **Scaffold-only:** `parse`, `cli`, `flow`, `error` (no executable shared spec files yet)
+- YAML spec files are loaded from `spec/eval/` and `spec/ir/`
+- Comparison fields:
+  - eval: `stdout`, `stderr`, `exit_code`
+  - ir: normalized portable Core IR
 
 Browser execution is planned to use the Python reference host on a backend service in the current playground direction; this does not add a second implemented host today.
 
@@ -22,9 +24,10 @@ python -m tools.spec_runner
 
 ## How it works
 
-- Cases are loaded from `spec/eval/*.yaml`
+- Cases are loaded from `spec/eval/*.yaml` and `spec/ir/*.yaml`
 - Each case is executed independently against the Python reference host
-- `stdout`/`stderr` line endings are normalized before comparison
+- Eval cases normalize `stdout`/`stderr` line endings before comparison
+- IR cases normalize portable Core IR before comparison and fail if host-local optimized IR appears in the shared IR path
 - Failures are reported per spec with expected vs actual fields
 
 **Example failure output:**
@@ -37,8 +40,9 @@ FAIL eval arithmetic-basic (/path/to/spec/eval/arithmetic-basic.yaml)
 ```
 
 **Normalization:**
-- The runner normalizes line endings for `stdout`/`stderr`
+- For eval, the runner normalizes line endings for `stdout`/`stderr`
+- For IR, the runner compares normalized host-neutral portable Core IR output
+- For IR, execution flow is `source -> parse -> lower -> normalize -> compare`
 - It does not trim meaningful whitespace
-- It compares only `stdout`, `stderr`, and `exit_code` for eval cases
 
 **GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.**

--- a/tools/spec_runner/comparator.py
+++ b/tools/spec_runner/comparator.py
@@ -15,6 +15,11 @@ class ComparisonFailure:
 
 def compare_spec(spec: LoadedSpec, actual: ActualResult) -> list[ComparisonFailure]:
     failures: list[ComparisonFailure] = []
+    if spec.category == "ir":
+        if actual.ir != spec.expected_ir:
+            failures.append(ComparisonFailure("ir", spec.expected_ir, actual.ir))
+        return failures
+
     if actual.stdout != spec.expected_stdout:
         failures.append(
             ComparisonFailure("stdout", spec.expected_stdout, actual.stdout)

--- a/tools/spec_runner/executor.py
+++ b/tools/spec_runner/executor.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 
 from hosts.python.exec_eval import run_eval_subprocess
+from hosts.python.exec_ir import exec_ir
 
 from .loader import LoadedSpec
 
 
 @dataclass(frozen=True)
 class ActualResult:
-    stdout: str
-    stderr: str
-    exit_code: int
+    stdout: str | None = None
+    stderr: str | None = None
+    exit_code: int | None = None
+    ir: object | None = None
 
 
 def _normalize_text(text: str) -> str:
@@ -19,6 +22,10 @@ def _normalize_text(text: str) -> str:
 
 
 def execute_spec(spec: LoadedSpec) -> ActualResult:
+    if spec.category == "ir":
+        result = exec_ir(SimpleNamespace(input={"source": spec.source}, stdin=None))
+        return ActualResult(ir=result["ir"])
+
     result = run_eval_subprocess(spec.source, spec.stdin or None)
     return ActualResult(
         stdout=_normalize_text(result["stdout"]),

--- a/tools/spec_runner/loader.py
+++ b/tools/spec_runner/loader.py
@@ -14,11 +14,25 @@ except ModuleNotFoundError as exc:  # pragma: no cover - exercised in runtime en
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SPEC_CATEGORIES = ["eval", "error", "flow", "pattern", "cli"]
+SPEC_CATEGORIES = ["eval", "error", "flow", "pattern", "cli", "ir"]
 SPEC_ROOTS = [REPO_ROOT / "spec" / cat for cat in SPEC_CATEGORIES]
-ALLOWED_TOP_LEVEL_KEYS = {"name", "category", "input", "expected"}
-ALLOWED_INPUT_KEYS = {"source", "stdin"}
-ALLOWED_EXPECTED_KEYS = {"stdout", "stderr", "exit_code"}
+ALLOWED_TOP_LEVEL_KEYS = {"name", "category", "input", "expected", "notes"}
+ALLOWED_INPUT_KEYS_BY_CATEGORY = {
+    "eval": {"source", "stdin"},
+    "error": {"source", "stdin"},
+    "flow": {"source", "stdin"},
+    "pattern": {"source", "stdin"},
+    "cli": {"source", "stdin"},
+    "ir": {"source"},
+}
+ALLOWED_EXPECTED_KEYS_BY_CATEGORY = {
+    "eval": {"stdout", "stderr", "exit_code"},
+    "error": {"stdout", "stderr", "exit_code"},
+    "flow": {"stdout", "stderr", "exit_code"},
+    "pattern": {"stdout", "stderr", "exit_code"},
+    "cli": {"stdout", "stderr", "exit_code"},
+    "ir": {"ir"},
+}
 
 
 @dataclass(frozen=True)
@@ -27,9 +41,10 @@ class LoadedSpec:
     category: str
     source: str
     stdin: str
-    expected_stdout: str
-    expected_stderr: str
-    expected_exit_code: int
+    expected_stdout: str | None
+    expected_stderr: str | None
+    expected_exit_code: int | None
+    expected_ir: Any | None
     path: Path
 
 
@@ -61,19 +76,25 @@ def load_spec(path: Path) -> LoadedSpec:
         raise ValueError(f"unsupported category: {data['category']}")
 
     input_data = _validate_mapping(data["input"], field_name="input")
-    unknown_input = set(input_data) - ALLOWED_INPUT_KEYS
+    allowed_input_keys = ALLOWED_INPUT_KEYS_BY_CATEGORY[data["category"]]
+    unknown_input = set(input_data) - allowed_input_keys
     if unknown_input:
         raise ValueError(f"unknown input fields: {sorted(unknown_input)}")
     if "source" not in input_data:
         raise ValueError("missing required field: input.source")
 
     expected_data = _validate_mapping(data["expected"], field_name="expected")
-    unknown_expected = set(expected_data) - ALLOWED_EXPECTED_KEYS
+    allowed_expected_keys = ALLOWED_EXPECTED_KEYS_BY_CATEGORY[data["category"]]
+    unknown_expected = set(expected_data) - allowed_expected_keys
     if unknown_expected:
         raise ValueError(f"unknown expected fields: {sorted(unknown_expected)}")
-    for required_key in ("stdout", "stderr", "exit_code"):
-        if required_key not in expected_data:
-            raise ValueError(f"missing required field: expected.{required_key}")
+    if data["category"] == "ir":
+        if "ir" not in expected_data:
+            raise ValueError("missing required field: expected.ir")
+    else:
+        for required_key in ("stdout", "stderr", "exit_code"):
+            if required_key not in expected_data:
+                raise ValueError(f"missing required field: expected.{required_key}")
 
     if not isinstance(data["name"], str) or not data["name"]:
         raise ValueError("name must be a non-empty string")
@@ -83,21 +104,26 @@ def load_spec(path: Path) -> LoadedSpec:
         raise ValueError("input.source must be a string")
     if "stdin" in input_data and not isinstance(input_data["stdin"], str):
         raise ValueError("input.stdin must be a string")
-    if not isinstance(expected_data["stdout"], str):
-        raise ValueError("expected.stdout must be a string")
-    if not isinstance(expected_data["stderr"], str):
-        raise ValueError("expected.stderr must be a string")
-    if not isinstance(expected_data["exit_code"], int):
-        raise ValueError("expected.exit_code must be an integer")
+    if data["category"] == "ir":
+        if expected_data["ir"] is None:
+            raise ValueError("expected.ir must not be null")
+    else:
+        if not isinstance(expected_data["stdout"], str):
+            raise ValueError("expected.stdout must be a string")
+        if not isinstance(expected_data["stderr"], str):
+            raise ValueError("expected.stderr must be a string")
+        if not isinstance(expected_data["exit_code"], int):
+            raise ValueError("expected.exit_code must be an integer")
 
     return LoadedSpec(
         name=data["name"],
         category=data["category"],
         source=input_data["source"],
         stdin=input_data.get("stdin", ""),
-        expected_stdout=expected_data["stdout"],
-        expected_stderr=expected_data["stderr"],
-        expected_exit_code=expected_data["exit_code"],
+        expected_stdout=expected_data.get("stdout"),
+        expected_stderr=expected_data.get("stderr"),
+        expected_exit_code=expected_data.get("exit_code"),
+        expected_ir=expected_data.get("ir"),
         path=path,
     )
 


### PR DESCRIPTION

# Prove Python Core IR contract via shared semantic specs (#131)

## Summary

This PR makes the **Core IR portability contract executable and verifiable** by enabling the **IR category in the shared semantic-spec system (Python reference host only)**.

The change ensures that lowering into the **minimal portable Core IR** is no longer just documented—it is now **proven by executable spec cases**.

---

## What this does

* Enables **`spec/ir/`** as an executable category in the shared spec runner (Python only)
* Validates lowering at the correct boundary:

  ```
  parse → lower → (capture IR here) → normalize → compare
  ```
* Introduces a **deterministic, host-neutral IR normalization layer**
* Enforces exclusion of **host-local optimized nodes** (e.g., `IrListTraversalLoop`) from the shared contract
* Adds representative IR conformance cases:

  * literals
  * variables
  * calls
  * pipelines
  * option constructors (`some`, `none`, `nil`)
  * selected pattern-lowering cases (as currently implemented)
* Adds regression tests for:

  * forbidden node leakage
  * normalization determinism
  * runner integration

---

## What this does NOT do

* ❌ Does NOT redesign Core IR
* ❌ Does NOT expand the portable IR contract
* ❌ Does NOT include host-local optimized nodes in shared expectations
* ❌ Does NOT add or implement additional hosts
* ❌ Does NOT change parser or eval semantics

This PR is strictly about **proving the existing contract**, not evolving it.

---

## Contract enforced

The following are now explicitly validated by shared IR specs:

* Lowered IR contains **only portable Core IR nodes** as defined in:

  * `docs/architecture/core-ir-portability.md`
* Pipelines lower to a single `IrPipeline(source, stages=[...])`
* Option constructors lower as:

  * `some(x)` → `IrOptionSome(...)`
  * `none(...)` → `IrOptionNone(...)`
  * `nil` → `IrOptionNone(...)`
* **Host-local optimized nodes are forbidden** in shared IR validation

---

## Key implementation pieces

* IR category integration in spec runner
* IR normalization layer (Python IR → portable representation)
* Forbidden node detection and explicit failure
* Minimal spec/ir fixtures for contract proof

---

## Tests

Added/updated tests to verify:

* IR category executes via spec runner
* Lowering is captured before optimization
* Normalized IR is deterministic and host-neutral
* Forbidden nodes are rejected with clear errors
* Representative IR cases pass
* Existing categories remain unaffected

---

## Docs

Updated to reflect actual behavior:

* **GENIA_STATE.md**

  * IR category now executable (Python only)
  * Status remains **Partial**
* **core-ir-portability.md**

  * clarified portable vs optimized IR boundary
  * added executable validation note
* **spec runner docs**

  * IR category execution flow documented
* **README**

  * mentions IR contract validation (without overselling)

All docs now match implementation exactly—no speculative claims.

---

## Why this matters

Before this PR:

* Core IR portability was **documented but not enforced**

After this PR:

* Core IR portability is **explicit, testable, and regression-safe**

This establishes the **Core IR as a real portability boundary**, not just a design intention.

---

## Follow-ups (not in this PR)

* Extend shared spec execution to other categories (parse, cli, flow, etc.)
* Add additional IR case coverage as language features expand
* Future host implementations can now target a **proven contract**

---

## Final note

This PR intentionally favors **small, provable truth** over broader coverage.

If something isn’t implemented, it is not claimed.

That’s the whole point.
