### PR TITLE
feat(spec): activate error category and prove normalized error contract

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -15,7 +15,7 @@ Implemented today:
   - cli
   - flow
   - error
-- The implemented shared Semantic Spec System currently executes **eval**, **ir**, **cli**, and **flow** cases.
+- The implemented shared Semantic Spec System currently executes **eval**, **ir**, **cli**, **flow**, and **error** cases.
 - The current shared spec runner compares normalized:
   - eval `stdout`
   - eval `stderr`
@@ -26,6 +26,9 @@ Implemented today:
   - flow `stdout`
   - flow `stderr`
   - flow `exit_code`
+  - error `stdout`
+  - error `stderr`
+  - error `exit_code`
   - IR portable normalized output
 - The working Python implementation lives in:
   - `src/genia/`
@@ -47,8 +50,8 @@ Scaffolded or planned, not implemented as hosts:
 
 **Maturity:**
 
-- Shared host contract is **Partial**: the contract categories above are documented, and executable shared spec coverage is implemented for `eval`, `ir`, `cli`, and first-wave `flow` behavior in the Python reference host. Other hosts are not implemented.
-- Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist for `eval`, `ir`, `cli`, and first-wave `flow` behavior in this phase.
+- Shared host contract is **Partial**: the contract categories above are documented, and executable shared spec coverage is implemented for `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` behavior in the Python reference host. Other hosts are not implemented.
+- Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist for `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` behavior in this phase.
 - Flow behavior is implemented in Python, and shared semantic-spec coverage for flow is now **active but partial**. Current flow shared coverage is limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)` behavior, `rules(..fns)` compatibility behavior, `step_*` / `rule_*` equivalence, the `rules()` identity stage, and error propagation via invalid-reducer-on-flow diagnostic. Advanced Flow behavior is not covered by shared semantic specs in this phase.
 - IR stability remains **Partial**: the minimal portable Core IR contract is documented, the Python runtime guards that boundary, and shared semantic-spec case coverage now validates that contract in the Python reference host.
 
@@ -57,8 +60,8 @@ Scaffolded or planned, not implemented as hosts:
 - Only Python is implemented; all other hosts are planned or scaffolded only.
 - No browser runtime or playground is implemented; browser artifacts are documentation only.
 - No generic multi-host runner exists; all conformance is validated against the Python reference host.
-- Shared semantic-spec case files currently exist under `spec/eval/`, `spec/ir/`, `spec/cli/`, and `spec/flow/` in this phase.
-- The current shared semantic-spec runner does not yet execute parse or error categories as shared spec files.
+- Shared semantic-spec case files currently exist under `spec/eval/`, `spec/ir/`, `spec/cli/`, `spec/flow/`, and `spec/error/` in this phase.
+- The current shared semantic-spec runner does not yet execute parse categories as shared spec files.
 - Flow is implemented as a lazy, pull-based, single-use runtime value; async, multi-port, and advanced flow features are not present.
 - Flow orchestration supports both `refine(..steps)` (preferred) and `rules(..fns)` (compatibility); both are available and behave identically.
 - Step/rule helpers are available as both `step_*` (preferred) and `rule_*` (compatibility) names.
@@ -66,6 +69,7 @@ Scaffolded or planned, not implemented as hosts:
 - CLI contract covers file, command, pipe, and REPL modes as described; no shell tokenization, `$1`/`$2`/`ARGV`-style, or advanced CLI features exist.
 - The current shared semantic-spec runner asserts `stdout`, `stderr`, and `exit_code` for eval cases.
 - The current shared semantic-spec runner asserts `stdout`, `stderr`, and `exit_code` for CLI cases.
+- The current shared semantic-spec runner asserts `stdout`, `stderr`, and `exit_code` for error cases.
 - The current shared semantic-spec runner compares normalized portable Core IR output for IR cases.
 - Only the minimal portable Core IR node families are used in the contract; host-local optimized nodes (e.g., `IrListTraversalLoop`) are excluded.
 
@@ -110,8 +114,9 @@ LANGUAGE CONTRACT:
   - eval (**active**, executable shared spec files)
   - cli (**active**, executable shared spec files)
   - flow (**active**, executable shared spec files; first-wave coverage only)
-  - error (scaffold-only)
+  - error (**active**, executable shared spec files; initial coverage only)
 - `eval`, `ir`, `cli`, and first-wave `flow` behavior are implemented as executable shared spec files in the Python reference host. Other categories are present as scaffolds only.
+- `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` behavior are implemented as executable shared spec files in the Python reference host. Other categories are present as scaffolds only.
 - The spec is authoritative for covered categories; uncovered behavior is not guaranteed.
 - Coverage is still partial and experimental; see below for category status.
 
@@ -122,9 +127,12 @@ PYTHON REFERENCE HOST:
 - The current shared spec runner executes eval cases (`spec/eval/`), comparing normalized `stdout`, `stderr`, and `exit_code`.
 - The current shared spec runner executes CLI cases (`spec/cli/`) through the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`.
 - The current shared spec runner executes Flow cases (`spec/flow/`) through command-source execution in the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`. Flow shared coverage is limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, and error propagation via invalid-reducer-on-flow diagnostic.
+- The current shared spec runner executes error cases (`spec/error/`) through the same eval execution path used by eval cases, comparing exact normalized `stdout`, exact normalized `stderr`, and exact `exit_code`.
 - CLI shared spec coverage proves deterministic non-interactive file mode, `-c` command mode, and `-p` pipe mode behavior. REPL mode is not included in shared executable spec coverage.
 - The observable CLI shared-spec contract is limited to `stdout`, `stderr`, and `exit_code`.
+- The observable error shared-spec contract in this phase is limited to `stdout`, `stderr`, and `exit_code`.
 - Eval shared spec cases are loaded from YAML files under `spec/eval/`; each case provides source text plus optional stdin text and is executed independently.
+- Error shared spec cases are loaded from YAML files under `spec/error/`; each case provides source text plus optional stdin text, requires `stdout: ""`, exact `stderr`, and `exit_code: 1`, and may include informational `notes` that are not machine-asserted.
 - The current eval shared case inventory covers deterministic command-source eval output for:
   - final rendered expression results
   - direct `stdout` output
@@ -134,12 +142,15 @@ PYTHON REFERENCE HOST:
   - deterministic eval failures with exact `stderr` and `exit_code`
 - Eval normalization is limited to line-ending normalization for `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Eval comparison is otherwise exact: `stdout`, `stderr`, and `exit_code` must match exactly after that line-ending normalization.
+- Error normalization is limited to the same line-ending normalization used for eval `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
+- Error comparison is otherwise exact in this phase: `stdout` must be `""`, `stderr` must match exactly after that line-ending normalization, and `exit_code` must be `1`.
 - The current shared spec runner also executes IR cases (`spec/ir/`), comparing normalized portable Core IR output before host-local optimization.
-- Other categories (`parse`, `error`) are present as scaffolds for future shared spec coverage.
+- Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface and does not machine-assert structured phase/category/message fields.
+- Other categories (`parse`) are present as scaffolds for future shared spec coverage.
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.
 
 **Summary:**
-- `eval`, `ir`, `cli`, and first-wave `flow` are active for executable shared spec files; other categories are scaffold-only.
+- `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` are active for executable shared spec files; other categories are scaffold-only.
 - `GENIA_STATE.md` is the final authority for implemented behavior. All other docs/specs must align with this contract.
 
 **Host implementation location:**
@@ -153,8 +164,8 @@ PYTHON REFERENCE HOST:
 **Limitations:**
 - Only Python is implemented; all other hosts are planned or scaffolded only.
 - No browser runtime or playground is implemented; browser artifacts are documentation only.
-- Shared semantic-spec case files exist under `spec/eval/`, `spec/ir/`, `spec/cli/`, and `spec/flow/` in this phase.
-- The current shared semantic-spec runner does not yet execute parse or error categories as shared spec files.
+- Shared semantic-spec case files exist under `spec/eval/`, `spec/ir/`, `spec/cli/`, `spec/flow/`, and `spec/error/` in this phase.
+- The current shared semantic-spec runner does not yet execute parse categories as shared spec files.
 
 **GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.**
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
   - ir (active, executable shared spec files)
   - cli (active, executable shared spec files)
   - flow (active, executable shared spec files; first-wave coverage only)
-  - error (scaffold-only)
+  - error (active, executable shared spec files; initial coverage only)
   - parse (scaffold-only)
-- Spec coverage has expanded beyond eval, and `eval`, `ir`, `cli`, and first-wave `flow` behavior are implemented as executable shared spec files in the Python reference host.
+- Spec coverage has expanded beyond eval, and `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` behavior are implemented as executable shared spec files in the Python reference host.
 - The spec is authoritative for covered categories; uncovered behavior is not guaranteed.
 - Coverage is still partial and experimental.
 
@@ -86,9 +86,11 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
 - The current shared spec runner executes CLI cases (spec/cli/), comparing normalized stdout, stderr, and exit_code.
 - The current shared spec runner executes IR cases (spec/ir/), comparing normalized portable Core IR output before host-local optimization.
 - The current shared spec runner executes Flow cases (spec/flow/) through command-source execution, comparing normalized stdout, stderr, and exit_code.
+- The current shared spec runner executes Error cases (spec/error/) through the same eval execution path used by eval cases, comparing normalized stdout, stderr, and exit_code.
 - CLI shared specs use the same envelope shape as eval and IR specs. Their input fields are `source`, `file`, `command`, `stdin`, `argv`, and `debug_stdio`; their expected fields are `stdout`, `stderr`, and `exit_code`.
 - CLI shared specs cover file mode, command mode, and pipe mode only. REPL is excluded from shared executable coverage.
 - Flow shared coverage is partial and limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, and error propagation via invalid-reducer-on-flow diagnostic.
+- Error shared coverage is active but initial only. Current error shared cases assert only the observable surface: `stdout`, `stderr`, and `exit_code`. In this phase, `stdout` must be `""`, `stderr` must match exactly, `exit_code` must be `1`, and `notes` remain informational only.
 - Other categories are present as scaffolds for future shared spec coverage.
 
 **How to run the spec suite:**
@@ -102,12 +104,13 @@ python -m tools.spec_runner
 - For cli: the runner executes deterministic non-interactive CLI cases and compares `stdout`, `stderr`, and `exit_code` with newline normalization.
 - For ir: the runner executes each case independently and compares normalized portable Core IR output captured before host-local optimization.
 - For flow: the runner executes first-wave command-source Flow cases and compares `stdout`, `stderr`, and `exit_code` with newline normalization.
+- For error: the runner executes initial normalized error cases and compares only `stdout`, `stderr`, and `exit_code`.
 - For other categories: present as scaffolds only; no executable shared spec files yet.
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.
 
 **Limitations:**
 - Spec coverage is expanded but still partial and experimental.
-- Only eval, ir, cli, and first-wave flow are active for executable shared spec files; other categories are scaffold-only.
+- Only eval, ir, cli, first-wave flow, and initial error are active for executable shared spec files; other categories are scaffold-only.
 - GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.
 
 ## Quick start

--- a/docs/host-interop/HOST_INTEROP.md
+++ b/docs/host-interop/HOST_INTEROP.md
@@ -5,7 +5,7 @@ This document defines the shared portability contract for Genia hosts.
 
 **LANGUAGE CONTRACT**
 - The shared host contract currently covers these spec categories: parse, ir, eval, cli, flow, error.
-- The contract requires host-neutral observable behavior; the current implemented shared semantic-spec suite applies executable comparison for `eval` and `ir` only.
+- The contract requires host-neutral observable behavior; the current implemented shared semantic-spec suite applies executable comparison for `eval`, `ir`, `cli`, `flow`, and initial `error` behavior in the Python reference host.
 
 **PYTHON REFERENCE HOST**
 - Python is the only implemented host and is the reference host today.
@@ -34,8 +34,8 @@ Current status:
 - Python is the only implemented reference host.
 - The Python host adapter in `hosts/python/` implements the shared host contract for the categories above, using the core runtime in `src/genia/`.
 - Node.js, Java, Rust, Go, and C++ are planned hosts only.
-- `spec/` and `tools/spec_runner/` now include an implemented shared semantic-spec runner plus `eval` and `ir` case files.
-- executable shared semantic-spec coverage is currently limited to `eval` and `ir`; the other categories remain scaffolded as shared spec surfaces.
+- `spec/` and `tools/spec_runner/` now include an implemented shared semantic-spec runner plus active `eval`, `ir`, `cli`, `flow`, and initial `error` case files.
+- executable shared semantic-spec coverage is currently active for `eval`, `ir`, `cli`, `flow`, and initial `error`; parse remains scaffolded as a shared spec surface.
 
 ## Authority Order
 
@@ -63,8 +63,19 @@ Notes:
 
 - In the current implemented shared semantic-spec suite:
   - eval comparison is limited to normalized `stdout`, normalized `stderr`, and `exit_code`
+  - cli comparison is limited to normalized `stdout`, normalized `stderr`, and `exit_code`
+  - flow comparison is limited to normalized `stdout`, normalized `stderr`, and `exit_code`
+  - error comparison is limited to normalized observable `stdout`, normalized observable `stderr`, and `exit_code`
   - IR comparison is limited to normalized portable Core IR output
-- Error objects include required fields: category, message, and span (when applicable). Categories are strictly separated (parse/runtime/CLI).
+- Error shared specs in this phase assert only the observable runner surface:
+  - `stdout`
+  - `stderr`
+  - `exit_code`
+- Current error shared cases require:
+  - `stdout` exactly `""`
+  - `stderr` exact match
+  - `exit_code` exactly `1`
+- Error phase/category/message remain contract concepts, but they are not structured runner fields in this phase.
 - Malformed, missing, or unsupported cases fail validation with explicit normalized errors; nothing is silently skipped.
 - Output ordering and structure are deterministic and stable.
 - Only the minimal portable Core IR node families are used in lowering and output (see `docs/architecture/core-ir-portability.md`).
@@ -76,14 +87,19 @@ Notes:
 
 ## Host Adapter and Spec Runner Model
 
-The Python host adapter exposes a single `run_case(case: SpecCase) -> SpecResult` entrypoint. In the current implemented shared semantic-spec system, the shared runner executes `eval` and `ir` cases only.
+The Python host adapter exposes a single `run_case(case: SpecCase) -> SpecResult` entrypoint. In the current implemented shared semantic-spec system, the shared runner executes `eval`, `ir`, `cli`, `flow`, and initial `error` cases.
 
-The shared spec runner loads YAML eval and IR cases, executes them against the Python reference host, and compares:
+The shared spec runner loads YAML eval, cli, flow, error, and IR cases, executes them against the Python reference host, and compares:
 
 - eval: normalized `stdout`, normalized `stderr`, and `exit_code`
+- cli: normalized `stdout`, normalized `stderr`, and `exit_code`
+- flow: normalized `stdout`, normalized `stderr`, and `exit_code`
+- error: normalized `stdout`, normalized `stderr`, and `exit_code`
 - ir: normalized portable Core IR output
 
-This runner does not yet provide implemented shared case coverage for parse, cli, flow, or error categories.
+- Error specs reuse eval execution; there is no separate error execution path in the runner.
+- Error `notes` are informational only and are not machine-asserted.
+- This runner does not yet provide implemented shared case coverage for parse.
 
 Other hosts are not implemented yet. "Portable" means: any future host must pass the same contract and normalization rules, but only Python is enforced today.
 
@@ -176,7 +192,7 @@ The cross-host error model should normalize at least:
   - filename
   - line/column when available
 
-Hosts may attach additional native debugging details, but shared tests should assert only the normalized contract.
+Hosts may attach additional native debugging details, but shared tests should assert only the normalized contract. In the current executable `spec/error/` phase, that asserted surface is limited to `stdout`, `stderr`, and `exit_code`; structured phase/category/source-location fields are not machine-asserted yet.
 
 ## Capability Registry Model
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -23,7 +23,8 @@ This directory holds the shared cross-host spec suite for Genia.
 - `ir` — **active** (executable shared spec files)
 - `cli` — **active** (executable shared spec files)
 - `flow` — **active** (executable shared spec files; first-wave coverage only)
-- `parse`, `error` — **scaffold-only** (no executable shared spec files yet)
+- `parse` — **scaffold-only** (no executable shared spec files yet)
+- `error` — **active** (executable shared spec files; initial coverage only)
 
 Browser execution is planned to use the Python reference host on a backend service in the current playground direction; this does not add a second implemented host today.
 
@@ -39,12 +40,13 @@ Browser execution is planned to use the Python reference host on a backend servi
 - `eval/`: implemented eval cases (active)
 - `cli/`: implemented CLI cases (active)
 - `flow/`: implemented Flow cases (active; first-wave coverage only)
-- `error/`: error scaffold only
+- `error/`: implemented error cases (active; initial coverage only)
 
 **Note:**
-- `eval/`, `ir/`, `cli/`, and `flow/` contain executable shared spec files in this phase.
+- `eval/`, `ir/`, `cli/`, `flow/`, and `error/` contain executable shared spec files in this phase.
 - Flow shared coverage is intentionally limited to first-wave observable contract cases.
-- Other category directories are present as scaffolds only and must contain only `README.md`.
+- Error shared coverage is intentionally limited to initial observable normalized error contract cases.
+- Other scaffold-only category directories must contain only `README.md`.
 
 ## Shared YAML Envelope
 
@@ -88,7 +90,9 @@ For CLI specs, `stdin` is piped input data, not program text. Current shared pip
 **Normalization:**
 - In the implemented eval suite, stdout/stderr line endings are normalized to `\n`. Trailing newlines remain significant.
 - In the implemented CLI suite, stdout/stderr line endings are normalized to `\n` and trailing newlines are stripped before comparison.
+- In the implemented Error suite, stdout/stderr line endings are normalized to `\n`. Trailing newlines remain significant.
 - Internal whitespace is not trimmed or collapsed. Stderr is not otherwise normalized.
+- In the implemented Error suite, the asserted surface remains only `stdout`, `stderr`, and `exit_code`; current cases require `stdout: ""`, exact `stderr`, and `exit_code: 1`.
 - In the implemented IR suite, portable Core IR is normalized before comparison.
 
 **Test Types:**

--- a/spec/error/README.md
+++ b/spec/error/README.md
@@ -1,5 +1,39 @@
-# Error Spec Scaffold
+# Error Shared Specs
 
-This directory is scaffold-only in this phase.
-No executable shared spec files exist here yet.
-Only README.md is allowed.
+This directory now holds the active executable shared error specs for the current phase.
+
+## Scope
+
+- Error specs assert normalized observable behavior only.
+- The asserted surface is:
+  - `stdout`
+  - `stderr`
+  - `exit_code`
+- In this phase:
+  - `stdout` must be exactly `""`
+  - `stderr` must be an exact match
+  - `exit_code` must be exactly `1`
+
+## Execution Model
+
+- Error specs reuse the eval execution path.
+- There is no separate error execution path or subprocess.
+- The runner uses the same shared YAML envelope as other executable categories.
+
+## Notes Field
+
+- `notes` is informational only.
+- `notes` is not read by the runner and is not machine-asserted.
+- `notes` may document human-readable contract concepts such as:
+  - `error_phase`
+  - `error_category`
+  - `message_source`
+
+## Current Coverage
+
+- Coverage is active but initial, not complete.
+- Phase, category, and message remain contract concepts, but they are not structured runner fields in this phase.
+- The current initial inventory is:
+  - `error-eval-undefined-name`
+  - `error-parse-bad-rest-pattern`
+  - `error-eval-assignment-target`

--- a/spec/error/error-eval-assignment-target.yaml
+++ b/spec/error/error-eval-assignment-target.yaml
@@ -1,0 +1,14 @@
+name: error-eval-assignment-target
+category: error
+description: SyntaxError when assignment target is not a simple name
+input:
+  source: |
+    (1 + 2) = 3
+expected:
+  stdout: ""
+  stderr: "Error: Assignment target must be a simple name\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: SyntaxError
+  message_source: GENIA_RULES.md section 8.3 and GENIA_REPL_README.md

--- a/spec/error/error-eval-undefined-name.yaml
+++ b/spec/error/error-eval-undefined-name.yaml
@@ -1,0 +1,14 @@
+name: error-eval-undefined-name
+category: error
+description: NameError when evaluating an undefined name
+input:
+  source: |
+    undefined_name
+expected:
+  stdout: ""
+  stderr: "Error: Undefined name: undefined_name\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: NameError
+  message_source: spec/eval/error-undefined-name.yaml (passing)

--- a/spec/error/error-parse-bad-rest-pattern.yaml
+++ b/spec/error/error-parse-bad-rest-pattern.yaml
@@ -1,0 +1,15 @@
+name: error-parse-bad-rest-pattern
+category: error
+description: SyntaxError when rest pattern is not in final list position
+input:
+  source: |
+    f(xs) = [..rest, x] -> x
+    f([1, 2, 3])
+expected:
+  stdout: ""
+  stderr: "Error: ..rest must be the final item in a list pattern\n"
+  exit_code: 1
+notes: |
+  error_phase: parse
+  error_category: SyntaxError
+  message_source: spec/eval/error-bad-rest-pattern.yaml (passing)

--- a/tests/test_portability_contract_sync.py
+++ b/tests/test_portability_contract_sync.py
@@ -129,7 +129,7 @@ def test_spec_category_dirs_allow_active_specs_only():
     category_dirs = [
         "parse", "ir", "eval", "cli", "flow", "error"
     ]
-    activated = {"eval", "ir", "cli", "flow"}
+    activated = {"eval", "ir", "cli", "flow", "error"}
     for dirname in category_dirs:
         d = spec_dir / dirname
         assert d.is_dir(), f"spec/{dirname}/ missing"

--- a/tools/spec_runner/README.md
+++ b/tools/spec_runner/README.md
@@ -7,14 +7,15 @@ The shared spec runner loads shared spec cases, executes them against the Python
 
 ## Runner Scope (Current Phase)
 
-- **Active categories:** `eval`, `ir`, `cli`, `flow` (executable shared spec files)
-- **Scaffold-only:** `parse`, `error` (no executable shared spec files yet)
-- YAML spec files are loaded from `spec/eval/`, `spec/ir/`, `spec/cli/`, and `spec/flow/`
+- **Active categories:** `eval`, `ir`, `cli`, `flow`, `error` (executable shared spec files)
+- **Scaffold-only:** `parse`
+- YAML spec files are loaded from `spec/eval/`, `spec/ir/`, `spec/cli/`, `spec/flow/`, and `spec/error/`
 - The loader uses one shared top-level envelope for active executable categories: `name`, `id`, `category`, `description`, `input`, `expected`, and `notes`
 - Comparison fields:
   - eval: `stdout`, `stderr`, `exit_code`
   - cli: `stdout`, `stderr`, `exit_code`
   - flow: `stdout`, `stderr`, `exit_code`
+  - error: `stdout`, `stderr`, `exit_code`
   - ir: normalized portable Core IR
 
 Browser execution is planned to use the Python reference host on a backend service in the current playground direction; this does not add a second implemented host today.
@@ -27,17 +28,21 @@ python -m tools.spec_runner
 
 ## How it works
 
-- Cases are loaded from `spec/eval/*.yaml`, `spec/cli/*.yaml`, `spec/ir/*.yaml`, and `spec/flow/*.yaml`
+- Cases are loaded from `spec/eval/*.yaml`, `spec/cli/*.yaml`, `spec/ir/*.yaml`, `spec/flow/*.yaml`, and `spec/error/*.yaml`
 - Each case is executed independently against the Python reference host
 - CLI cases are executed through the Python host adapter
 - Flow cases are executed through command-source execution in the Python host adapter; the runner does not route Flow cases through CLI pipe mode
+- Error cases reuse the eval execution path; there is no separate error subprocess or error-specific execution path
 - CLI file mode uses `input.file`; command mode uses `input.command` with empty `input.stdin`; pipe mode uses `input.command` as `-p <command>` when `input.stdin` is non-empty, with that stdin passed directly as subprocess input
 - The runner does not construct shell pipelines for CLI specs
 - Eval, CLI, and Flow cases normalize `stdout`/`stderr` line endings before comparison
+- Error cases use the same line-ending normalization as eval before comparison
 - The current CLI suite covers deterministic non-interactive file, command, and pipe cases. REPL is not covered by shared executable specs
 - The current Flow suite covers first-wave observable contract cases only: lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, and error propagation via invalid-reducer-on-flow diagnostic
+- The current Error suite covers initial normalized observable contract cases only: `stdout`, `stderr`, and `exit_code`, with `stdout` expected to be `""`, `stderr` matched exactly, and `exit_code` expected to be `1`
 - IR cases normalize portable Core IR before comparison and fail if host-local optimized IR appears in the shared IR path
 - Failures are reported per spec with expected vs actual fields
+- `notes` is informational only and is not read by the runner; phase/category/message remain contract concepts, not structured runner fields in this phase
 
 **Example failure output:**
 
@@ -52,8 +57,9 @@ FAIL eval arithmetic-basic (/path/to/spec/eval/arithmetic-basic.yaml)
 - For eval, the runner normalizes line endings for `stdout`/`stderr` to `\n`; trailing newlines remain significant.
 - For flow, the runner normalizes line endings for `stdout`/`stderr` to `\n`; trailing newlines remain significant.
 - For cli, the runner normalizes line endings for `stdout`/`stderr` to `\n` and strips trailing newlines before comparison.
+- For error, the runner normalizes line endings for `stdout`/`stderr` to `\n`; trailing newlines remain significant.
 - Internal whitespace is not trimmed or collapsed. Stderr is not otherwise normalized.
-- For eval, cli, and flow, the compared surface remains only `stdout`, `stderr`, and `exit_code`
+- For eval, cli, flow, and error, the compared surface remains only `stdout`, `stderr`, and `exit_code`
 - For IR, the runner compares normalized host-neutral portable Core IR output
 - For IR, execution flow is `source -> parse -> lower -> normalize -> compare`
 - It does not trim meaningful whitespace

--- a/tools/spec_runner/loader.py
+++ b/tools/spec_runner/loader.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - exercised in runtime en
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Only executable shared-spec categories belong here.
-SPEC_CATEGORIES = ["eval", "cli", "ir", "flow"]
+SPEC_CATEGORIES = ["eval", "cli", "ir", "flow", "error"]
 SPEC_ROOTS = [REPO_ROOT / "spec" / cat for cat in SPEC_CATEGORIES]
 
 # All categories use the same top-level envelope.
@@ -35,6 +35,7 @@ ALLOWED_INPUT_KEYS_BY_CATEGORY = {
     "ir": {"source"},
     "cli": {"source", "file", "command", "stdin", "argv", "debug_stdio"},
     "flow": {"source", "stdin"},
+    "error": {"source", "stdin"},
 }
 
 ALLOWED_EXPECTED_KEYS_BY_CATEGORY = {
@@ -42,6 +43,7 @@ ALLOWED_EXPECTED_KEYS_BY_CATEGORY = {
     "ir": {"ir"},
     "cli": {"stdout", "stderr", "exit_code"},
     "flow": {"stdout", "stderr", "exit_code"},
+    "error": {"stdout", "stderr", "exit_code"},
 }
 
 FLOW_TERMINAL_PATTERN = re.compile(r"\b(?:collect|run)\b")
@@ -117,7 +119,7 @@ def _validate_input(category: str, input_data: dict[str, Any]) -> None:
     if not isinstance(input_data["source"], str):
         raise ValueError("input.source must be a string")
 
-    if category == "eval":
+    if category in ("eval", "error"):
         if "stdin" in input_data and not isinstance(input_data["stdin"], str):
             raise ValueError("input.stdin must be a string")
         return


### PR DESCRIPTION
- activate 'error' in spec runner (loader only)
- add shared error specs:
  - error-eval-undefined-name
  - error-parse-bad-rest-pattern
  - error-eval-assignment-target
- reuse eval execution path (no new executor/comparator behavior)
- enforce exact stdout/stderr/exit_code contract
- confirm notes field is informational only

TDD:
- specs fail pre-activation (unsupported category)
- pass after loader activation
- full suite passing

Docs:
- mark error category as active
- clarify observable error contract surface
- note initial coverage only

No runtime changes. No new execution paths.