### PR TITLE
feat(spec): activate parse shared spec runner (issue #147)

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -15,7 +15,7 @@ Implemented today:
   - cli
   - flow
   - error
-- The implemented shared Semantic Spec System currently executes **eval**, **ir**, **cli**, **flow**, and **error** cases.
+- The implemented shared Semantic Spec System currently executes **eval**, **ir**, **cli**, **flow**, **error**, and **parse** cases.
 - The current shared spec runner compares normalized:
   - eval `stdout`
   - eval `stderr`
@@ -30,6 +30,7 @@ Implemented today:
   - error `stderr`
   - error `exit_code`
   - IR portable normalized output
+  - parse normalized AST (exact match for `kind: ok`) or parse error type + message substring (for `kind: error`)
 - The working Python implementation lives in:
   - `src/genia/`
   - `tests/`
@@ -50,8 +51,8 @@ Scaffolded or planned, not implemented as hosts:
 
 **Maturity:**
 
-- Shared host contract is **Partial**: the contract categories above are documented, and executable shared spec coverage is implemented for `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` behavior in the Python reference host. Other hosts are not implemented.
-- Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist for `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` behavior in this phase.
+- Shared host contract is **Partial**: the contract categories above are documented, and executable shared spec coverage is implemented for `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior in the Python reference host. Other hosts are not implemented.
+- Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist for `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior in this phase.
 - Flow behavior is implemented in Python, and shared semantic-spec coverage for flow is now **active but partial**. Current flow shared coverage is limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)` behavior, `rules(..fns)` compatibility behavior, `step_*` / `rule_*` equivalence, the `rules()` identity stage, and error propagation via invalid-reducer-on-flow diagnostic. Advanced Flow behavior is not covered by shared semantic specs in this phase.
 - IR stability remains **Partial**: the minimal portable Core IR contract is documented, the Python runtime guards that boundary, and shared semantic-spec case coverage now validates that contract in the Python reference host.
 
@@ -60,8 +61,8 @@ Scaffolded or planned, not implemented as hosts:
 - Only Python is implemented; all other hosts are planned or scaffolded only.
 - No browser runtime or playground is implemented; browser artifacts are documentation only.
 - No generic multi-host runner exists; all conformance is validated against the Python reference host.
-- Shared semantic-spec case files currently exist under `spec/eval/`, `spec/ir/`, `spec/cli/`, `spec/flow/`, and `spec/error/` in this phase.
-- The current shared semantic-spec runner does not yet execute parse categories as shared spec files.
+- Shared semantic-spec case files currently exist under `spec/eval/`, `spec/ir/`, `spec/cli/`, `spec/flow/`, `spec/error/`, and `spec/parse/` in this phase.
+- Parse shared semantic-spec coverage is limited to initial cases for stable, already-implemented syntax forms; parse spec coverage expands only when new forms are explicitly added and tested.
 - Flow is implemented as a lazy, pull-based, single-use runtime value; async, multi-port, and advanced flow features are not present.
 - Flow orchestration supports both `refine(..steps)` (preferred) and `rules(..fns)` (compatibility); both are available and behave identically.
 - Step/rule helpers are available as both `step_*` (preferred) and `rule_*` (compatibility) names.
@@ -71,6 +72,7 @@ Scaffolded or planned, not implemented as hosts:
 - The current shared semantic-spec runner asserts `stdout`, `stderr`, and `exit_code` for CLI cases.
 - The current shared semantic-spec runner asserts `stdout`, `stderr`, and `exit_code` for error cases.
 - The current shared semantic-spec runner compares normalized portable Core IR output for IR cases.
+- The current shared semantic-spec runner compares normalized parse output for parse cases: exact AST for `kind: ok`, type and message substring for `kind: error`.
 - Only the minimal portable Core IR node families are used in the contract; host-local optimized nodes (e.g., `IrListTraversalLoop`) are excluded.
 
 **GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.**
@@ -109,14 +111,13 @@ Clarifications:
 LANGUAGE CONTRACT:
 
 - The Semantic Spec System defines observable behavior for the following categories:
-  - parse (scaffold-only)
+  - parse (**active**, executable shared spec files; initial coverage only)
   - ir (**active**, executable shared spec files)
   - eval (**active**, executable shared spec files)
   - cli (**active**, executable shared spec files)
   - flow (**active**, executable shared spec files; first-wave coverage only)
   - error (**active**, executable shared spec files; initial coverage only)
-- `eval`, `ir`, `cli`, and first-wave `flow` behavior are implemented as executable shared spec files in the Python reference host. Other categories are present as scaffolds only.
-- `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` behavior are implemented as executable shared spec files in the Python reference host. Other categories are present as scaffolds only.
+- `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior are implemented as executable shared spec files in the Python reference host.
 - The spec is authoritative for covered categories; uncovered behavior is not guaranteed.
 - Coverage is still partial and experimental; see below for category status.
 
@@ -146,11 +147,12 @@ PYTHON REFERENCE HOST:
 - Error comparison is otherwise exact in this phase: `stdout` must be `""`, `stderr` must match exactly after that line-ending normalization, and `exit_code` must be `1`.
 - The current shared spec runner also executes IR cases (`spec/ir/`), comparing normalized portable Core IR output before host-local optimization.
 - Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface and does not machine-assert structured phase/category/message fields.
-- Other categories (`parse`) are present as scaffolds for future shared spec coverage.
+- The current shared spec runner executes Parse cases (`spec/parse/`) by calling the Python host parse adapter directly; for `kind: ok` cases the normalized AST is compared exactly; for `kind: error` cases the error type is compared exactly and the message is matched as a substring.
+- Parse shared coverage is active but initial only: the current inventory covers stable, already-implemented syntax forms. Parse spec coverage expands only when new forms are explicitly added and tested.
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.
 
 **Summary:**
-- `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` are active for executable shared spec files; other categories are scaffold-only.
+- `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` are active for executable shared spec files.
 - `GENIA_STATE.md` is the final authority for implemented behavior. All other docs/specs must align with this contract.
 
 **Host implementation location:**

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ This repository currently provides:
 
 **LANGUAGE CONTRACT:**
 - The portable contract covers: parse, ir, eval, cli, flow, error (see `GENIA_STATE.md` for current scope).
-- `eval`, `ir`, `cli`, and first-wave `flow` are active for executable shared spec files; other categories are scaffold-only.
+- `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` are active for executable shared spec files.
 - Within the current implemented shared semantic-spec scope, eval and cli compare normalized `stdout`, normalized `stderr`, and exact `exit_code`; Python-specific leakage is not part of the portable contract.
 - CLI pipe mode and Flow are part of the current shared public behavior.
 
 **PYTHON REFERENCE HOST:**
 - Python is the only implemented host and is the reference host.
-- The shared contract categories above exist now, and the implemented shared semantic-spec suite currently covers `eval`, `ir`, `cli`, and first-wave `flow`.
+- The shared contract categories above exist now, and the implemented shared semantic-spec suite currently covers `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse`.
 - CLI shared specs use the same top-level YAML envelope as other executable shared specs and cover deterministic non-interactive file, command, and pipe modes.
 - REPL mode is not covered by shared executable specs.
 - The current eval and cli shared case inventory covers deterministic `stdout`, `stderr`, and `exit_code` behavior.
@@ -75,8 +75,8 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
   - cli (active, executable shared spec files)
   - flow (active, executable shared spec files; first-wave coverage only)
   - error (active, executable shared spec files; initial coverage only)
-  - parse (scaffold-only)
-- Spec coverage has expanded beyond eval, and `eval`, `ir`, `cli`, first-wave `flow`, and initial `error` behavior are implemented as executable shared spec files in the Python reference host.
+  - parse (active, executable shared spec files; initial coverage only)
+- Spec coverage has expanded to all six categories: `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior are all implemented as executable shared spec files in the Python reference host.
 - The spec is authoritative for covered categories; uncovered behavior is not guaranteed.
 - Coverage is still partial and experimental.
 
@@ -87,11 +87,12 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
 - The current shared spec runner executes IR cases (spec/ir/), comparing normalized portable Core IR output before host-local optimization.
 - The current shared spec runner executes Flow cases (spec/flow/) through command-source execution, comparing normalized stdout, stderr, and exit_code.
 - The current shared spec runner executes Error cases (spec/error/) through the same eval execution path used by eval cases, comparing normalized stdout, stderr, and exit_code.
+- The current shared spec runner executes Parse cases (spec/parse/) by calling the Python host parse adapter directly; for `kind: ok` cases the normalized AST is compared exactly; for `kind: error` cases the error type is compared exactly and the message is matched as a substring.
 - CLI shared specs use the same envelope shape as eval and IR specs. Their input fields are `source`, `file`, `command`, `stdin`, `argv`, and `debug_stdio`; their expected fields are `stdout`, `stderr`, and `exit_code`.
 - CLI shared specs cover file mode, command mode, and pipe mode only. REPL is excluded from shared executable coverage.
 - Flow shared coverage is partial and limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, and error propagation via invalid-reducer-on-flow diagnostic.
 - Error shared coverage is active but initial only. Current error shared cases assert only the observable surface: `stdout`, `stderr`, and `exit_code`. In this phase, `stdout` must be `""`, `stderr` must match exactly, `exit_code` must be `1`, and `notes` remain informational only.
-- Other categories are present as scaffolds for future shared spec coverage.
+- Parse shared coverage is active but initial only. Current parse shared cases cover stable, already-implemented syntax forms. Parse spec coverage expands only when new forms are explicitly added and tested.
 
 **How to run the spec suite:**
 
@@ -462,10 +463,11 @@ For formal status term definitions see `docs/host-interop/HOST_INTEROP.md` §Sta
 
 Current shared spec status:
 
-- implemented shared case files currently exist under `spec/eval/`, `spec/ir/`, `spec/cli/`, and `spec/flow/`
-- `spec/parse/` and `spec/error/` remain scaffold-only in this phase
+- implemented shared case files currently exist under `spec/eval/`, `spec/ir/`, `spec/cli/`, `spec/flow/`, `spec/error/`, and `spec/parse/`
 - flow shared coverage is partial and limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, and error propagation via invalid-reducer-on-flow diagnostic
-- the shared runner is implemented, and its current executable shared case coverage is eval, ir, cli, and first-wave flow
+- error shared coverage is initial only; current cases assert `stdout: ""`, exact `stderr`, and `exit_code: 1`
+- parse shared coverage is initial only; current cases cover stable, already-implemented syntax forms
+- the shared runner is implemented, and its current executable shared case coverage is eval, ir, cli, first-wave flow, initial error, and initial parse
 
 ## Browser playground architecture
 

--- a/docs/host-interop/HOST_INTEROP.md
+++ b/docs/host-interop/HOST_INTEROP.md
@@ -34,8 +34,8 @@ Current status:
 - Python is the only implemented reference host.
 - The Python host adapter in `hosts/python/` implements the shared host contract for the categories above, using the core runtime in `src/genia/`.
 - Node.js, Java, Rust, Go, and C++ are planned hosts only.
-- `spec/` and `tools/spec_runner/` now include an implemented shared semantic-spec runner plus active `eval`, `ir`, `cli`, `flow`, and initial `error` case files.
-- executable shared semantic-spec coverage is currently active for `eval`, `ir`, `cli`, `flow`, and initial `error`; parse remains scaffolded as a shared spec surface.
+- `spec/` and `tools/spec_runner/` now include an implemented shared semantic-spec runner plus active `eval`, `ir`, `cli`, `flow`, initial `error`, and initial `parse` case files.
+- executable shared semantic-spec coverage is currently active for `eval`, `ir`, `cli`, `flow`, initial `error`, and initial `parse`.
 
 ## Authority Order
 

--- a/hosts/python/exec_parse.py
+++ b/hosts/python/exec_parse.py
@@ -1,7 +1,11 @@
-"""
-Parse-only execution for Genia Python host adapter.
-"""
+"""Parse-only execution for Genia Python host adapter."""
+
+from .parse_adapter import parse_and_normalize
+
 
 def exec_parse(case) -> dict:
-    # TODO: Call parser from src/genia/interpreter.py and return AST snapshot
-    return {"ast": "TODO: AST snapshot"}
+    if isinstance(case.input, dict):
+        source = case.input["source"]
+    else:
+        source = case.input
+    return parse_and_normalize(source)

--- a/spec/README.md
+++ b/spec/README.md
@@ -23,7 +23,7 @@ This directory holds the shared cross-host spec suite for Genia.
 - `ir` — **active** (executable shared spec files)
 - `cli` — **active** (executable shared spec files)
 - `flow` — **active** (executable shared spec files; first-wave coverage only)
-- `parse` — **scaffold-only** (no executable shared spec files yet)
+- `parse` — **active** (executable shared spec files; initial coverage only)
 - `error` — **active** (executable shared spec files; initial coverage only)
 
 Browser execution is planned to use the Python reference host on a backend service in the current playground direction; this does not add a second implemented host today.
@@ -35,7 +35,7 @@ Browser execution is planned to use the Python reference host on a backend servi
 
 ## Directory Layout
 
-- `parse/`: parse scaffold only
+- `parse/`: implemented parse cases (active; initial coverage only)
 - `ir/`: implemented IR cases (active)
 - `eval/`: implemented eval cases (active)
 - `cli/`: implemented CLI cases (active)
@@ -43,10 +43,10 @@ Browser execution is planned to use the Python reference host on a backend servi
 - `error/`: implemented error cases (active; initial coverage only)
 
 **Note:**
-- `eval/`, `ir/`, `cli/`, `flow/`, and `error/` contain executable shared spec files in this phase.
+- `eval/`, `ir/`, `cli/`, `flow/`, `error/`, and `parse/` contain executable shared spec files in this phase.
 - Flow shared coverage is intentionally limited to first-wave observable contract cases.
 - Error shared coverage is intentionally limited to initial observable normalized error contract cases.
-- Other scaffold-only category directories must contain only `README.md`.
+- Parse shared coverage is intentionally limited to initial stable syntax forms; parse spec coverage expands only when new forms are explicitly added and tested.
 
 ## Shared YAML Envelope
 
@@ -87,6 +87,24 @@ CLI mode mapping:
 
 For CLI specs, `stdin` is piped input data, not program text. Current shared pipe-mode specs use non-empty `stdin` to select `-p <command>`. Shared executable specs do not cover REPL mode.
 
+## Parse Specs
+
+Parse specs live under `spec/parse/` and use `category: parse`.
+
+Parse `input` fields:
+
+- `source`
+
+Parse `expected` fields:
+
+- `parse` — a mapping with:
+  - `kind: ok` plus `ast: {...}` for a successful parse
+  - `kind: error` plus `type: SyntaxError` and `message: "..."` for a parse failure
+
+For `kind: error` cases, `message` is matched as a substring of the actual error message.
+
+Parse specs validate the normalized parse boundary: the parser produces a deterministic, host-neutral AST snapshot for valid inputs, and a deterministic error type plus message for invalid inputs. Only stable, already-implemented syntax forms may appear in parse specs.
+
 **Normalization:**
 - In the implemented eval suite, stdout/stderr line endings are normalized to `\n`. Trailing newlines remain significant.
 - In the implemented CLI suite, stdout/stderr line endings are normalized to `\n` and trailing newlines are stripped before comparison.
@@ -94,6 +112,7 @@ For CLI specs, `stdin` is piped input data, not program text. Current shared pip
 - Internal whitespace is not trimmed or collapsed. Stderr is not otherwise normalized.
 - In the implemented Error suite, the asserted surface remains only `stdout`, `stderr`, and `exit_code`; current cases require `stdout: ""`, exact `stderr`, and `exit_code: 1`.
 - In the implemented IR suite, portable Core IR is normalized before comparison.
+- In the implemented Parse suite, the asserted surface is `expected.parse`; successful cases compare the normalized AST exactly; error cases compare `type` exactly and `message` as a substring.
 
 **Test Types:**
 - Shared contract tests: validate the cross-host contract for the categories above

--- a/spec/parse/README.md
+++ b/spec/parse/README.md
@@ -1,5 +1,41 @@
-# Parse Spec Scaffold
+# Parse Spec Suite
 
-This directory is scaffold-only in this phase.
-No executable shared spec files exist here yet.
-Only README.md is allowed.
+This directory holds the shared executable parse spec files for Genia.
+
+**Status: active (initial coverage only)**
+
+## What parse specs assert
+
+Parse specs validate the parse boundary: the parser produces a deterministic, host-neutral normalized AST for valid inputs, and a deterministic error type plus message for invalid inputs.
+
+Only stable, already-implemented syntax forms may appear in parse specs. Parse spec coverage expands only when new forms are explicitly added and tested.
+
+## Spec format
+
+Parse specs use the standard shared YAML envelope with `category: parse`.
+
+`input` fields:
+- `source` — the Genia source text to parse
+
+`expected` fields:
+- `parse` — a mapping with:
+  - `kind: ok` plus `ast: {...}` for a successful parse (AST compared exactly)
+  - `kind: error` plus `type: SyntaxError` and `message: "..."` for a parse failure (`message` matched as substring)
+
+## Example
+
+```yaml
+name: parse-literal-number
+category: parse
+description: Number literal parses to a Literal node
+input:
+  source: "42"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Literal
+      value: 42
+```
+
+**GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.**

--- a/spec/parse/parse-assignment-simple.yaml
+++ b/spec/parse/parse-assignment-simple.yaml
@@ -1,0 +1,14 @@
+name: parse-assignment-simple
+category: parse
+description: Simple assignment parses to an Assign node
+input:
+  source: "x = 1"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Assign
+      name: x
+      value:
+        kind: Literal
+        value: 1

--- a/spec/parse/parse-error-unclosed-paren.yaml
+++ b/spec/parse/parse-error-unclosed-paren.yaml
@@ -1,0 +1,10 @@
+name: parse-error-unclosed-paren
+category: parse
+description: Unclosed parenthesis produces a SyntaxError
+input:
+  source: "(1 + 2"
+expected:
+  parse:
+    kind: error
+    type: SyntaxError
+    message: "Expected RPAREN"

--- a/spec/parse/parse-literal-number.yaml
+++ b/spec/parse/parse-literal-number.yaml
@@ -1,0 +1,11 @@
+name: parse-literal-number
+category: parse
+description: Number literal parses to a Literal node
+input:
+  source: "42"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Literal
+      value: 42

--- a/tests/test_parse_shared_spec_runner.py
+++ b/tests/test_parse_shared_spec_runner.py
@@ -1,0 +1,231 @@
+"""Tests proving parse specs are integrated into the main shared spec runner.
+
+These tests assert behavior introduced in issue-147:
+  - parse is in SPEC_CATEGORIES
+  - load_spec accepts category: parse with expected.parse
+  - discover_specs includes parse specs from spec/parse/
+  - execute_spec handles category: parse via parse_and_normalize
+  - compare_spec handles category: parse results
+  - the main runner total includes parse spec cases
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.spec_runner.comparator import compare_spec
+from tools.spec_runner.executor import ActualResult, execute_spec
+from tools.spec_runner.loader import LoadedSpec, discover_specs, load_spec
+from tools.spec_runner.runner import main as run_spec_suite
+
+
+REPO = Path(__file__).resolve().parents[1]
+PARSE_DIR = REPO / "spec" / "parse"
+
+
+def _parse_spec(
+    *,
+    name: str,
+    source: str,
+    expected_parse: object,
+    path: Path | None = None,
+) -> LoadedSpec:
+    return LoadedSpec(
+        name=name,
+        category="parse",
+        source=source,
+        stdin="",
+        expected_stdout=None,
+        expected_stderr=None,
+        expected_exit_code=None,
+        expected_ir=None,
+        expected_parse=expected_parse,
+        path=path or (PARSE_DIR / f"{name}.yaml"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Loader tests
+# ---------------------------------------------------------------------------
+
+def test_loader_accepts_parse_category_ok_spec() -> None:
+    """load_spec must accept a parse spec with kind: ok without raising."""
+    spec = load_spec(PARSE_DIR / "parse-literal-number.yaml")
+    assert spec.category == "parse"
+    assert spec.source == "42"
+    assert spec.expected_parse == {"kind": "ok", "ast": {"kind": "Literal", "value": 42}}
+
+
+def test_loader_accepts_parse_category_error_spec() -> None:
+    """load_spec must accept a parse spec with kind: error without raising."""
+    spec = load_spec(PARSE_DIR / "parse-error-unclosed-paren.yaml")
+    assert spec.category == "parse"
+    assert spec.source == "(1 + 2"
+    assert spec.expected_parse["kind"] == "error"
+    assert spec.expected_parse["type"] == "SyntaxError"
+    assert "Expected RPAREN" in spec.expected_parse["message"]
+
+
+def test_loader_rejects_parse_spec_with_missing_parse_field(tmp_path: Path) -> None:
+    """load_spec must reject a parse spec missing expected.parse."""
+    p = tmp_path / "bad-parse.yaml"
+    p.write_text(
+        "name: bad-parse\ncategory: parse\ninput:\n  source: \"42\"\nexpected: {}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="missing required field: expected.parse"):
+        load_spec(p)
+
+
+def test_loader_rejects_parse_spec_with_invalid_kind(tmp_path: Path) -> None:
+    """load_spec must reject expected.parse.kind values other than ok or error."""
+    p = tmp_path / "bad-kind.yaml"
+    p.write_text(
+        "name: bad-kind\ncategory: parse\ninput:\n  source: \"42\"\nexpected:\n  parse:\n    kind: unknown\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="kind must be 'ok' or 'error'"):
+        load_spec(p)
+
+
+# ---------------------------------------------------------------------------
+# Discovery tests
+# ---------------------------------------------------------------------------
+
+def test_discover_specs_includes_parse_specs() -> None:
+    """discover_specs must include parse specs from spec/parse/ in the specs list."""
+    specs, invalid_specs = discover_specs()
+    parse_specs = [s for s in specs if s.category == "parse"]
+    assert len(parse_specs) >= 1, (
+        f"Expected at least one parse spec; found 0. "
+        f"invalid_specs={[str(i.path) + ': ' + i.message for i in invalid_specs]}"
+    )
+
+
+def test_discover_specs_parse_names_present() -> None:
+    """discover_specs must include the expected parse spec names."""
+    specs, _ = discover_specs()
+    parse_names = {s.name for s in specs if s.category == "parse"}
+    expected = {"parse-literal-number", "parse-assignment-simple", "parse-error-unclosed-paren"}
+    assert expected.issubset(parse_names), f"Missing parse specs: {expected - parse_names}"
+
+
+def test_discover_specs_has_no_invalid_specs_after_parse_integration() -> None:
+    """After integration, discover_specs must not put parse specs in invalid_specs."""
+    _, invalid_specs = discover_specs()
+    parse_invalids = [i for i in invalid_specs if "parse" in str(i.path)]
+    assert parse_invalids == [], f"Parse specs reported as invalid: {parse_invalids}"
+
+
+# ---------------------------------------------------------------------------
+# Executor tests
+# ---------------------------------------------------------------------------
+
+def test_execute_spec_parse_ok() -> None:
+    """execute_spec must handle category=parse and return a parse result."""
+    spec = _parse_spec(
+        name="parse-literal-number",
+        source="42",
+        expected_parse={"kind": "ok", "ast": {"kind": "Literal", "value": 42}},
+    )
+    actual = execute_spec(spec)
+    assert actual.parse is not None
+    assert actual.parse["kind"] == "ok"
+    assert actual.parse["ast"] == {"kind": "Literal", "value": 42}
+
+
+def test_execute_spec_parse_error() -> None:
+    """execute_spec must handle a parse failure spec and return kind: error."""
+    spec = _parse_spec(
+        name="parse-error-unclosed-paren",
+        source="(1 + 2",
+        expected_parse={"kind": "error", "type": "SyntaxError", "message": "Expected RPAREN"},
+    )
+    actual = execute_spec(spec)
+    assert actual.parse is not None
+    assert actual.parse["kind"] == "error"
+    assert actual.parse["type"] == "SyntaxError"
+    assert "Expected RPAREN" in actual.parse["message"]
+
+
+# ---------------------------------------------------------------------------
+# Comparator tests
+# ---------------------------------------------------------------------------
+
+def test_compare_spec_parse_ok_match() -> None:
+    """compare_spec must return no failures when the parse result matches exactly."""
+    spec = _parse_spec(
+        name="parse-literal-number",
+        source="42",
+        expected_parse={"kind": "ok", "ast": {"kind": "Literal", "value": 42}},
+    )
+    actual = ActualResult(parse={"kind": "ok", "ast": {"kind": "Literal", "value": 42}})
+    failures = compare_spec(spec, actual)
+    assert failures == []
+
+
+def test_compare_spec_parse_ok_ast_mismatch() -> None:
+    """compare_spec must report a parse.ast failure on mismatch."""
+    spec = _parse_spec(
+        name="parse-literal-number",
+        source="42",
+        expected_parse={"kind": "ok", "ast": {"kind": "Literal", "value": 42}},
+    )
+    actual = ActualResult(parse={"kind": "ok", "ast": {"kind": "Literal", "value": 99}})
+    failures = compare_spec(spec, actual)
+    assert len(failures) == 1
+    assert failures[0].field == "parse.ast"
+
+
+def test_compare_spec_parse_ok_kind_mismatch() -> None:
+    """compare_spec must report a parse.kind failure when ok was expected but error occurred."""
+    spec = _parse_spec(
+        name="parse-literal-number",
+        source="42",
+        expected_parse={"kind": "ok", "ast": {"kind": "Literal", "value": 42}},
+    )
+    actual = ActualResult(parse={"kind": "error", "type": "SyntaxError", "message": "oops"})
+    failures = compare_spec(spec, actual)
+    assert any(f.field == "parse.kind" for f in failures)
+
+
+def test_compare_spec_parse_error_match() -> None:
+    """compare_spec must return no failures when error parse result matches."""
+    spec = _parse_spec(
+        name="parse-error-unclosed-paren",
+        source="(1 + 2",
+        expected_parse={"kind": "error", "type": "SyntaxError", "message": "Expected RPAREN"},
+    )
+    actual = ActualResult(parse={"kind": "error", "type": "SyntaxError", "message": "Expected RPAREN at line 1"})
+    failures = compare_spec(spec, actual)
+    assert failures == []
+
+
+def test_compare_spec_parse_error_message_mismatch() -> None:
+    """compare_spec must report parse.message failure when message substring is absent."""
+    spec = _parse_spec(
+        name="parse-error-unclosed-paren",
+        source="(1 + 2",
+        expected_parse={"kind": "error", "type": "SyntaxError", "message": "Expected RPAREN"},
+    )
+    actual = ActualResult(parse={"kind": "error", "type": "SyntaxError", "message": "something else"})
+    failures = compare_spec(spec, actual)
+    assert any(f.field == "parse.message" for f in failures)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end runner test
+# ---------------------------------------------------------------------------
+
+def test_runner_includes_parse_specs_in_total(capsys: pytest.CaptureFixture[str]) -> None:
+    """The main spec runner must include parse specs in the total count."""
+    run_spec_suite()
+    captured = capsys.readouterr()
+    # Extract total from "Summary: total=N ..."
+    import re
+    m = re.search(r"total=(\d+)", captured.out)
+    assert m is not None, "No summary line in runner output"
+    total = int(m.group(1))
+    # After integration, parse specs (3 new) must be counted
+    assert total >= 3, f"Expected at least 3 parse specs in total; got total={total}"

--- a/tests/test_portability_contract_sync.py
+++ b/tests/test_portability_contract_sync.py
@@ -129,7 +129,7 @@ def test_spec_category_dirs_allow_active_specs_only():
     category_dirs = [
         "parse", "ir", "eval", "cli", "flow", "error"
     ]
-    activated = {"eval", "ir", "cli", "flow", "error"}
+    activated = {"eval", "ir", "cli", "flow", "error", "parse"}
     for dirname in category_dirs:
         d = spec_dir / dirname
         assert d.is_dir(), f"spec/{dirname}/ missing"

--- a/tools/spec_runner/README.md
+++ b/tools/spec_runner/README.md
@@ -7,9 +7,8 @@ The shared spec runner loads shared spec cases, executes them against the Python
 
 ## Runner Scope (Current Phase)
 
-- **Active categories:** `eval`, `ir`, `cli`, `flow`, `error` (executable shared spec files)
-- **Scaffold-only:** `parse`
-- YAML spec files are loaded from `spec/eval/`, `spec/ir/`, `spec/cli/`, `spec/flow/`, and `spec/error/`
+- **Active categories:** `eval`, `ir`, `cli`, `flow`, `error`, `parse` (executable shared spec files)
+- YAML spec files are loaded from `spec/eval/`, `spec/ir/`, `spec/cli/`, `spec/flow/`, `spec/error/`, and `spec/parse/`
 - The loader uses one shared top-level envelope for active executable categories: `name`, `id`, `category`, `description`, `input`, `expected`, and `notes`
 - Comparison fields:
   - eval: `stdout`, `stderr`, `exit_code`
@@ -17,6 +16,7 @@ The shared spec runner loads shared spec cases, executes them against the Python
   - flow: `stdout`, `stderr`, `exit_code`
   - error: `stdout`, `stderr`, `exit_code`
   - ir: normalized portable Core IR
+  - parse: normalized AST (exact match for `kind: ok`) or error type + message substring (for `kind: error`)
 
 Browser execution is planned to use the Python reference host on a backend service in the current playground direction; this does not add a second implemented host today.
 
@@ -28,11 +28,12 @@ python -m tools.spec_runner
 
 ## How it works
 
-- Cases are loaded from `spec/eval/*.yaml`, `spec/cli/*.yaml`, `spec/ir/*.yaml`, `spec/flow/*.yaml`, and `spec/error/*.yaml`
+- Cases are loaded from `spec/eval/*.yaml`, `spec/cli/*.yaml`, `spec/ir/*.yaml`, `spec/flow/*.yaml`, `spec/error/*.yaml`, and `spec/parse/*.yaml`
 - Each case is executed independently against the Python reference host
 - CLI cases are executed through the Python host adapter
 - Flow cases are executed through command-source execution in the Python host adapter; the runner does not route Flow cases through CLI pipe mode
 - Error cases reuse the eval execution path; there is no separate error subprocess or error-specific execution path
+- Parse cases call the Python host parse adapter directly (`parse_and_normalize`); no subprocess is invoked
 - CLI file mode uses `input.file`; command mode uses `input.command` with empty `input.stdin`; pipe mode uses `input.command` as `-p <command>` when `input.stdin` is non-empty, with that stdin passed directly as subprocess input
 - The runner does not construct shell pipelines for CLI specs
 - Eval, CLI, and Flow cases normalize `stdout`/`stderr` line endings before comparison
@@ -62,6 +63,7 @@ FAIL eval arithmetic-basic (/path/to/spec/eval/arithmetic-basic.yaml)
 - For eval, cli, flow, and error, the compared surface remains only `stdout`, `stderr`, and `exit_code`
 - For IR, the runner compares normalized host-neutral portable Core IR output
 - For IR, execution flow is `source -> parse -> lower -> normalize -> compare`
+- For parse, the runner compares the normalized parse result: exact AST match for `kind: ok`; type exact + message substring for `kind: error`
 - It does not trim meaningful whitespace
 
 **GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.**

--- a/tools/spec_runner/comparator.py
+++ b/tools/spec_runner/comparator.py
@@ -20,6 +20,24 @@ def compare_spec(spec: LoadedSpec, actual: ActualResult) -> list[ComparisonFailu
             failures.append(ComparisonFailure("ir", spec.expected_ir, actual.ir))
         return failures
 
+    if spec.category == "parse":
+        expected = spec.expected_parse
+        actual_parse = actual.parse
+        if expected["kind"] == "ok":
+            if actual_parse["kind"] != "ok":
+                failures.append(ComparisonFailure("parse.kind", "ok", actual_parse["kind"]))
+            elif actual_parse["ast"] != expected["ast"]:
+                failures.append(ComparisonFailure("parse.ast", expected["ast"], actual_parse["ast"]))
+        else:
+            if actual_parse["kind"] != "error":
+                failures.append(ComparisonFailure("parse.kind", "error", actual_parse["kind"]))
+            else:
+                if actual_parse["type"] != expected["type"]:
+                    failures.append(ComparisonFailure("parse.type", expected["type"], actual_parse["type"]))
+                if expected["message"] not in actual_parse["message"]:
+                    failures.append(ComparisonFailure("parse.message", expected["message"], actual_parse["message"]))
+        return failures
+
     if actual.stdout != spec.expected_stdout:
         failures.append(
             ComparisonFailure("stdout", spec.expected_stdout, actual.stdout)

--- a/tools/spec_runner/executor.py
+++ b/tools/spec_runner/executor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from types import SimpleNamespace
 
+from hosts.python import parse_and_normalize
 from hosts.python.exec_cli import exec_cli
 from hosts.python.exec_eval import run_eval_subprocess
 from hosts.python.exec_flow import exec_flow
@@ -17,6 +18,7 @@ class ActualResult:
     stderr: str | None = None
     exit_code: int | None = None
     ir: object | None = None
+    parse: object | None = None
 
 
 def _normalize_text(text: str) -> str:
@@ -28,6 +30,10 @@ def _strip_trailing_newlines(text: str) -> str:
 
 
 def execute_spec(spec: LoadedSpec) -> ActualResult:
+    if spec.category == "parse":
+        result = parse_and_normalize(spec.source)
+        return ActualResult(parse=result)
+
     if spec.category == "ir":
         result = exec_ir(SimpleNamespace(input={"source": spec.source}, stdin=None))
         return ActualResult(ir=result["ir"])

--- a/tools/spec_runner/loader.py
+++ b/tools/spec_runner/loader.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - exercised in runtime en
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 # Only executable shared-spec categories belong here.
-SPEC_CATEGORIES = ["eval", "cli", "ir", "flow", "error"]
+SPEC_CATEGORIES = ["eval", "cli", "ir", "flow", "error", "parse"]
 SPEC_ROOTS = [REPO_ROOT / "spec" / cat for cat in SPEC_CATEGORIES]
 
 # All categories use the same top-level envelope.
@@ -36,6 +36,7 @@ ALLOWED_INPUT_KEYS_BY_CATEGORY = {
     "cli": {"source", "file", "command", "stdin", "argv", "debug_stdio"},
     "flow": {"source", "stdin"},
     "error": {"source", "stdin"},
+    "parse": {"source"},
 }
 
 ALLOWED_EXPECTED_KEYS_BY_CATEGORY = {
@@ -44,6 +45,7 @@ ALLOWED_EXPECTED_KEYS_BY_CATEGORY = {
     "cli": {"stdout", "stderr", "exit_code"},
     "flow": {"stdout", "stderr", "exit_code"},
     "error": {"stdout", "stderr", "exit_code"},
+    "parse": {"parse"},
 }
 
 FLOW_TERMINAL_PATTERN = re.compile(r"\b(?:collect|run)\b")
@@ -66,6 +68,7 @@ class LoadedSpec:
     argv: list[str] | None = None
     debug_stdio: bool = False
     spec_id: str | None = None
+    expected_parse: Any | None = None
 
 
 @dataclass(frozen=True)
@@ -124,7 +127,7 @@ def _validate_input(category: str, input_data: dict[str, Any]) -> None:
             raise ValueError("input.stdin must be a string")
         return
 
-    if category == "ir":
+    if category in ("ir", "parse"):
         return
 
     if category == "flow":
@@ -201,6 +204,27 @@ def _validate_expected(category: str, expected_data: dict[str, Any]) -> None:
             raise ValueError("expected.ir must not be null")
         return
 
+    if category == "parse":
+        if "parse" not in expected_data:
+            raise ValueError("missing required field: expected.parse")
+        parse_result = expected_data["parse"]
+        if not isinstance(parse_result, dict):
+            raise ValueError("expected.parse must be a mapping")
+        if "kind" not in parse_result:
+            raise ValueError("expected.parse.kind is required")
+        kind = parse_result["kind"]
+        if kind not in ("ok", "error"):
+            raise ValueError(f"expected.parse.kind must be 'ok' or 'error', got {kind!r}")
+        if kind == "ok":
+            if "ast" not in parse_result:
+                raise ValueError("expected.parse.ast is required when kind is 'ok'")
+        else:
+            if "type" not in parse_result:
+                raise ValueError("expected.parse.type is required when kind is 'error'")
+            if "message" not in parse_result:
+                raise ValueError("expected.parse.message is required when kind is 'error'")
+        return
+
     for required_key in ("stdout", "stderr", "exit_code"):
         if required_key not in expected_data:
             raise ValueError(f"missing required field: expected.{required_key}")
@@ -242,6 +266,7 @@ def load_spec(path: Path) -> LoadedSpec:
         argv=input_data.get("argv", []),
         debug_stdio=input_data.get("debug_stdio", False),
         spec_id=data.get("id"),
+        expected_parse=expected_data.get("parse"),
     )
 
 


### PR DESCRIPTION
- integrate parse category into shared spec runner (loader, executor, comparator)
- add normalized parse execution via hosts/python/exec_parse.py
- add initial parse specs (literal, assignment, error case)
- add tests covering parse runner integration (loader, executor, comparator, end-to-end)
- update spec activation set to include parse

docs:
- mark parse as active in GENIA_STATE.md, spec/README.md, tools/spec_runner/README.md, README.md, and host interop docs
- document parse spec YAML format and contract

invariants:
- no new language semantics introduced
- existing eval/ir/cli/flow/error behavior unchanged
- parse output normalized and host-neutral (no raw Python AST)

tests:
- full suite passing
- spec runner passing with parse cases included