### PR TITLE
Expand shared-spec Option propagation coverage and add PyYAML dependency

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -127,7 +127,7 @@ PYTHON REFERENCE HOST:
 - All conformance is validated against the Python reference host.
 - The current shared spec runner executes eval cases (`spec/eval/`), comparing normalized `stdout`, `stderr`, and `exit_code`.
 - The current shared spec runner executes CLI cases (`spec/cli/`) through the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`.
-- The current shared spec runner executes Flow cases (`spec/flow/`) through command-source execution in the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`. Flow shared coverage is limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, and error propagation via invalid-reducer-on-flow diagnostic.
+- The current shared spec runner executes Flow cases (`spec/flow/`) through command-source execution in the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`. Flow shared coverage is limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, deterministic `keep_some(...)` option-filtering behavior, and error propagation via invalid-reducer-on-flow diagnostic.
 - The current shared spec runner executes error cases (`spec/error/`) through the same eval execution path used by eval cases, comparing exact normalized `stdout`, exact normalized `stderr`, and exact `exit_code`.
 - CLI shared spec coverage proves deterministic non-interactive file mode, `-c` command mode, and `-p` pipe mode behavior. Current shared CLI coverage includes basic file execution, file-mode `main(argv())` dispatch, trailing `argv()` exposure, command-mode final-value execution, valid pipe-mode Flow-stage usage, explicit `stdin` / `run` rejection, and current pipe-mode guidance for bare per-item stages, bare reducers, and non-Flow final results. REPL mode is not included in shared executable spec coverage.
 - The observable CLI shared-spec contract is limited to `stdout`, `stderr`, and `exit_code`.
@@ -140,6 +140,8 @@ PYTHON REFERENCE HOST:
   - direct `stderr` output
   - combined `stdout`/`stderr` output separation
   - stdin-fed eval cases whose compared surface remains `stdout`, `stderr`, and `exit_code`
+  - direct Option rendering for deterministic final-result output (`some(...)`, `none(...)`)
+  - pipeline Option propagation for deterministic final-result output (`some(...)` lift and `none(...)` short-circuit)
   - deterministic eval failures with exact `stderr` and `exit_code`
 - Eval normalization is limited to line-ending normalization for `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Eval comparison is otherwise exact: `stdout`, `stderr`, and `exit_code` must match exactly after that line-ending normalization.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Do not use one-shot implementation prompts for behavior changes.
 - The shared contract categories above exist now, and the implemented shared semantic-spec suite currently covers `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse`.
 - CLI shared specs use the same top-level YAML envelope as other executable shared specs and cover deterministic non-interactive file, command, and pipe modes.
 - REPL mode is not covered by shared executable specs.
-- The current eval and cli shared case inventory covers deterministic `stdout`, `stderr`, and `exit_code` behavior.
+- The current eval and cli shared case inventory covers deterministic `stdout`, `stderr`, and `exit_code` behavior, including eval Option rendering/propagation cases for `some(...)` and `none(...)`.
 - The HTTP helper surface and actor surface are Python reference host behavior only (**Python-host-only**; not portable contract).
 - The shell pipeline stage `$(...)` is a **Python-host-only feature**: implemented and supported only on Python, not part of the portable Core IR or shared multi-host contract. Other hosts do not support it.
 - See `docs/host-interop/` and `spec/` for details.
@@ -98,7 +98,7 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
 - The current shared spec runner executes Parse cases (spec/parse/) by calling the Python host parse adapter directly; for `kind: ok` cases the normalized AST is compared exactly; for `kind: error` cases the error type is compared exactly and the message is matched as a substring.
 - CLI shared specs use the same envelope shape as eval and IR specs. Their input fields are `source`, `file`, `command`, `stdin`, `argv`, and `debug_stdio`; their expected fields are `stdout`, `stderr`, and `exit_code`.
 - CLI shared specs cover file mode, command mode, and pipe mode only. Current shared CLI coverage includes basic file execution, file-mode `main(argv())` dispatch, trailing `argv()` exposure, command-mode final-value execution, valid pipe-mode Flow-stage usage, and current pipe-mode guidance/error cases for explicit `stdin`, explicit `run`, bare per-item stages, bare reducers, and non-Flow final results. REPL is excluded from shared executable coverage.
-- Flow shared coverage is partial and limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, and error propagation via invalid-reducer-on-flow diagnostic.
+- Flow shared coverage is partial and limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, deterministic `keep_some(...)` option-filtering behavior, and error propagation via invalid-reducer-on-flow diagnostic.
 - Error shared coverage is active but initial only. Current error shared cases assert only the observable surface: `stdout`, `stderr`, and `exit_code`. In this phase, `stdout` must be `""`, `stderr` must match exactly, `exit_code` must be `1`, and `notes` remain informational only.
 - Parse shared coverage is active but initial only. Current parse shared cases cover stable, already-implemented syntax forms. Parse spec coverage expands only when new forms are explicitly added and tested.
 

--- a/docs/architecture/issue-150-option-propagation-shared-spec-coverage-audit.md
+++ b/docs/architecture/issue-150-option-propagation-shared-spec-coverage-audit.md
@@ -1,0 +1,139 @@
+# Issue #150 Audit — Option Propagation Shared Spec Coverage
+
+CHANGE NAME: Issue #150 — Option Propagation Shared Spec Coverage
+
+## 0. Branch check
+
+- Work was not performed on `main`.
+- Branch matches issue intent: `issue-150-option-propagation-specs`.
+- Scope remains in spec/tests/docs surfaces for shared coverage.
+- No unrelated runtime/parser/stdlib feature additions were detected in this issue stack.
+
+## 1. Inputs audited
+
+Authoritative sources reviewed:
+
+- `AGENTS.md`
+- `GENIA_STATE.md`
+- `GENIA_RULES.md`
+- `GENIA_REPL_README.md`
+- `README.md`
+
+Issue pipeline artifacts reviewed:
+
+- Spec phase commit: `9612e90`
+- Design phase commit: `a36633f`
+- Test phase commit: `64e8356`
+- Implementation phase commit: `f6f5d88`
+- Docs sync phase commit: `488267c`
+
+Touched implementation/suite/docs files reviewed:
+
+- `spec/eval/option-some-render-basic.yaml`
+- `spec/eval/option-none-render-basic.yaml`
+- `spec/eval/pipeline-option-some-lift.yaml`
+- `spec/eval/pipeline-option-none-short-circuit.yaml`
+- `spec/flow/flow-keep-some-parse-int.yaml`
+- `tests/test_spec_ir_runner_blackbox.py`
+- `spec/eval/README.md`
+- `spec/flow/README.md`
+- `GENIA_STATE.md`
+- `README.md`
+
+## 2. Scope lock check
+
+Audit confirms this issue remained coverage-oriented:
+
+- Added shared spec cases proving existing Option behavior.
+- Added/updated tests and docs to reflect new shared coverage inventory.
+- Did not add new language or runtime semantics.
+
+## 3. Audit summary
+
+Status: **PASS WITH ISSUES**
+
+Summary:
+
+- Spec/design/test/implementation/docs phases are present and internally aligned for Issue #150.
+- Shared case additions and test inventory updates match the approved scope.
+- Full executable-suite verification could not be completed in this environment due missing `PyYAML` dependency.
+
+## 4. Spec ↔ implementation check
+
+Result: **Aligned**.
+
+- Added eval cases cover direct Option rendering and pipeline Option propagation.
+- Added flow case covers deterministic `keep_some(...)` filtering over `map(parse_int)`.
+- No spec-scope expansion beyond approved contract.
+
+## 5. Design ↔ implementation check
+
+Result: **Aligned**.
+
+- File placement follows designed category boundaries (`eval` and `flow`).
+- No runner schema changes or architectural drift were introduced.
+
+## 6. Test validity
+
+Strengths:
+
+- Blackbox discovery assertions include the new eval/flow case names.
+- Fixture parameterization includes the newly added case files.
+
+Limitations:
+
+- In this container, `pytest tests/test_spec_ir_runner_blackbox.py` fails at collection because `PyYAML` is unavailable.
+- Therefore, executable pass/fail evidence for the new cases is not available from this environment.
+
+## 7. Truthfulness review
+
+Result: **Aligned after docs-sync**.
+
+- `GENIA_STATE.md`, `README.md`, `spec/eval/README.md`, and `spec/flow/README.md` now describe the newly landed Option-related shared coverage.
+- Wording remains limited to implemented shared coverage and does not introduce new semantics.
+
+## 8. Cross-file consistency
+
+Result: **Mostly consistent**.
+
+Drift detected:
+
+- None in the Issue #150 touched surfaces after docs sync.
+
+Risk level: **Low**
+
+## 9. Philosophy check
+
+- preserve minimalism: **YES**
+- avoid hidden behavior: **YES**
+- keep semantics out of host: **YES**
+- align with pattern/option-first behavior: **YES**
+
+## 10. Complexity audit
+
+Assessment: **Minimal and necessary**.
+
+Justification:
+
+- Change set is bounded to case inventory + truth-surface updates.
+- No extra abstractions or architecture expansion.
+
+## 11. Issue list
+
+### Issue 1
+
+Severity: **Major (verification gap)**
+
+- File(s): test execution environment (not repository files)
+- Problem: shared-spec tests cannot execute due missing `yaml` module (`PyYAML`).
+- Why it matters: executable conformance proof for newly added cases cannot be confirmed in this environment.
+- Minimal fix: run audit checks in an environment with `PyYAML` available and rerun:
+  - `pytest tests/test_spec_ir_runner_blackbox.py`
+  - `python -m tools.spec_runner`
+
+## 12. Final audit verdict
+
+**PASS WITH ISSUES**
+
+- Repository changes for Issue #150 are structurally and semantically aligned with the approved spec/design scope.
+- Final confidence requires rerunning shared-spec execution in an environment where `PyYAML` is installed.

--- a/docs/architecture/issue-150-option-propagation-shared-spec-coverage-design.md
+++ b/docs/architecture/issue-150-option-propagation-shared-spec-coverage-design.md
@@ -1,0 +1,228 @@
+# Issue #150 Design — Option Propagation Shared Spec Coverage
+
+## 1. Design summary
+
+- Keep the current shared-spec architecture unchanged: one YAML case per file under existing active category directories.
+- Add a minimal set of executable shared cases proving already-implemented Option propagation behavior.
+- Keep category boundaries explicit:
+  - `eval` for direct Option/pipeline behavior
+  - `flow` for direct Flow-source Option filtering/propagation behavior
+  - `cli` only when mode-wrapper behavior is needed to prove the same documented contract
+- Reuse current runner loading and comparison surfaces exactly (`stdout`, `stderr`, `exit_code`).
+- Avoid schema changes, runner redesign, parser/runtime behavior changes, and stdlib surface changes.
+
+## 2. Scope lock (from spec)
+
+This design implements only the approved spec contract for Issue #150:
+
+Included:
+
+- executable shared coverage for existing `some(...)` / `none(...)` behavior
+- executable shared coverage for existing Option propagation through documented pipeline/Flow/helper paths
+- optional CLI-category additions only where needed to prove existing mode-observable behavior
+- runner/test updates only if necessary for case execution/discovery
+
+Excluded:
+
+- any new language semantics
+- parser syntax changes
+- runtime semantic changes
+- new stdlib APIs or helper semantics
+- non-Python host behavior
+
+## 3. Architecture overview
+
+This work lives entirely in the **Docs/Tests/Specs zone** (plus optional spec-runner tests if needed).
+
+Flow of data for this issue remains unchanged:
+
+1. YAML case files under `spec/<category>/` are discovered by the shared runner.
+2. Cases execute through existing host adapter paths for each category.
+3. Runner compares normalized observable surfaces only.
+4. Test modules validate discovery/execution expectations for the case inventory.
+
+No new runtime pathways are introduced.
+
+## 4. File / module changes
+
+## New files
+
+- `docs/architecture/issue-150-option-propagation-shared-spec-coverage-design.md` (this design doc)
+- planned shared case files (test phase):
+  - `spec/eval/option-some-render-basic.yaml`
+  - `spec/eval/option-none-render-basic.yaml`
+  - `spec/eval/pipeline-option-some-lift.yaml`
+  - `spec/eval/pipeline-option-none-short-circuit.yaml`
+  - `spec/flow/flow-keep-some-parse-int.yaml`
+- optional shared case files only if contract proof requires mode-specific behavior:
+  - `spec/cli/command-mode-option-propagation.yaml`
+  - `spec/cli/pipe-mode-option-flow-propagation.yaml`
+
+## Modified files (expected in later phases)
+
+- `tests/test_spec_ir_runner_blackbox.py` (case inventory/discovery assertions)
+- `tests/test_cli_shared_spec_runner.py` (only if new CLI cases are added)
+- optionally docs truth surfaces in docs phase if inventory/status wording needs synchronization:
+  - `GENIA_STATE.md`
+  - `GENIA_REPL_README.md`
+  - `README.md`
+  - `spec/eval/README.md`
+  - `spec/flow/README.md`
+  - `spec/cli/README.md`
+  - `tools/spec_runner/README.md`
+
+## Removed files
+
+- none
+
+## 5. Data shapes
+
+No new schema is introduced.
+
+All new shared cases must use existing category envelopes.
+
+### Eval/Flow/CLI case shape (existing)
+
+- `name: <string>`
+- `category: <eval|flow|cli>`
+- `input:`
+  - `source` or category-appropriate existing fields (e.g., CLI `command` / `file`)
+  - optional deterministic `stdin`
+  - optional existing `argv` where already used
+- `expected:`
+  - `stdout: <string>`
+  - `stderr: <string>`
+  - `exit_code: <int>`
+
+Normalization and assertion behavior remains current runner behavior only.
+
+## 6. Function / interface design
+
+No new runtime/prelude functions are designed.
+
+Interfaces touched are existing tooling/testing interfaces only:
+
+- shared case discovery in existing runner/test helpers
+- existing category executors for `eval`, `flow`, `cli`
+
+Potential test-level interface touchpoints (if needed):
+
+- case filename allowlists / snapshot expectations in blackbox tests
+- discovery count/ordering expectations in CLI shared runner tests
+
+No external interface changes.
+
+## 7. Control flow design
+
+Execution flow for new cases follows existing paths:
+
+1. Runner discovers YAML files by category.
+2. For each new case:
+   - loads `input`
+   - executes through category executor
+   - normalizes newline surfaces
+   - compares exact expected surfaces
+3. Aggregated pass/fail reporting remains unchanged.
+
+Decision points for case placement:
+
+- If behavior is ordinary Option/pipeline semantics without mode wrapping → `eval`.
+- If behavior requires direct Flow-source semantics (`stdin |> lines`) without CLI mode wrapper → `flow`.
+- If behavior is specifically about command/pipe mode wrapper effect on observable Option propagation → `cli`.
+
+## 8. Error handling design
+
+No new error model is added.
+
+Design constraints:
+
+- failure cases only assert currently documented, stable error surfaces
+- assertions remain on `stdout`/`stderr`/`exit_code` only
+- no traceback-shape or host-internal assertions
+
+Boundary enforcement:
+
+- unstable or undocumented diagnostics are not added to shared coverage in this issue
+- if wording stability is uncertain for a candidate failure case, drop it from shared cases
+
+## 9. Integration points
+
+Integration remains with existing modules only:
+
+- `spec/<category>/` case inventories
+- `tools/spec_runner` category execution paths
+- existing Python host adapter execution for active categories
+- shared-runner test modules under `tests/`
+
+No changes to interpreter architecture or prelude loading are part of this design.
+
+## 10. Test design input (for next phase)
+
+The **test phase** must add failing shared cases first (before any implementation fix), using the approved inventory.
+
+Primary invariants to encode as failing/passing shared assertions:
+
+- deterministic direct rendering for `some(...)` and `none`
+- deterministic `some(...)` lift behavior through ordinary stages
+- deterministic `none(...)` short-circuit behavior
+- deterministic Option filtering through existing Flow helper paths
+- no silent Option-structure loss at observable boundary
+
+Edge-case selection rules:
+
+- keep cases deterministic and minimal
+- one contract fact per case where practical
+- avoid overlap between `eval` and `cli` unless mode distinction is the point
+
+Runner-test updates:
+
+- update only if discovery assertions require the new filenames
+- avoid adding new runner features in this issue
+
+## 11. Doc impact (later docs phase)
+
+Potential docs updates depend on actual landed case inventory:
+
+- coverage inventory wording in `GENIA_STATE.md`
+- matching summary wording in `README.md` and `GENIA_REPL_README.md`
+- category README inventory notes in `spec/*/README.md`
+- runner docs in `tools/spec_runner/README.md`
+
+Docs updates must remain strictly factual to what executable cases actually cover.
+
+## 12. Constraints
+
+Must:
+
+- follow existing shared-spec file patterns
+- preserve minimal, deterministic observable assertions
+- keep semantics and host contract unchanged
+- keep category boundaries explicit
+
+Must not:
+
+- introduce new concepts beyond spec scope
+- depend on Python-specific leakage
+- redesign runner schema or execution model
+- change language/runtime behavior
+
+## 13. Complexity check
+
+Assessment:
+
+- Minimal: Yes
+- Necessary: Yes
+- Over-engineered: No
+
+Reason:
+
+- this design reuses existing infrastructure and adds only case inventory plus minimal test bookkeeping
+- it strengthens regression proof for already-implemented behavior without architecture churn
+
+## 14. Final check
+
+- Matches approved Issue #150 spec scope.
+- Introduces no new behavior.
+- Provides concrete file plan and placement rules for test/implementation phases.
+- Keeps shared contract assertions portable and observable.
+- Ready for failing-tests phase.

--- a/docs/architecture/issue-150-option-propagation-shared-spec-coverage-spec.md
+++ b/docs/architecture/issue-150-option-propagation-shared-spec-coverage-spec.md
@@ -1,0 +1,212 @@
+# Issue #150 Spec — Option Propagation Shared Spec Coverage
+
+## 1. Scope
+
+This issue defines a shared-semantic coverage expansion for already-implemented Option propagation behavior.
+
+Included in this phase:
+
+- executable shared spec cases proving existing `some(...)` / `none(...)` behavior
+- coverage across relevant active categories where this behavior is already observable:
+  - `eval`
+  - `flow`
+  - `cli` only where needed to prove existing pipe/command observable behavior
+- coverage for existing option-aware stdlib helpers only where already implemented and documented
+- runner/test updates only if required to execute the new shared cases
+
+Excluded from this phase:
+
+- new language semantics
+- new parser syntax
+- new pipeline semantics
+- new Flow semantics
+- new stdlib functions
+- host-surface expansion
+- non-Python hosts
+- broad refactors
+
+This issue is coverage expansion for existing contract behavior, not a feature change.
+
+## 2. Portable observable contract
+
+The shared contract to prove in this issue is limited to observable behavior already documented in `GENIA_STATE.md`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, and `README.md`:
+
+- direct Option surface rendering is deterministic for `some(...)` and `none(...)`
+- pipeline Option propagation behaves as currently documented:
+  - `none(...)` short-circuits remaining stages and returns unchanged
+  - `some(x)` lifts through ordinary stages by passing `x`
+  - lifted stage results preserve explicit Option results and wrap non-Option lifted results as documented
+- existing option-aware Flow helpers preserve current behavior where already documented (for example `keep_some` / `keep_some_else` usage paths)
+- observable outputs are asserted only through normalized shared surfaces (`stdout`, `stderr`, `exit_code`)
+
+This contract does not prove internals such as host object layouts, Python traceback structure, parser internals, or prelude file organization.
+
+## 3. Category placement boundaries
+
+To avoid semantic drift, the shared cases for this issue must obey category boundaries:
+
+- `eval`
+  - use for direct language/pipeline/Option propagation behavior not tied to CLI mode wrapping
+- `flow`
+  - use for direct Flow-source behavior (`stdin |> lines |> ...`) where Option-aware Flow helpers are the behavior under test
+- `cli`
+  - use only when Option propagation proof requires mode-specific wrapper behavior (`-c` / `-p`) already in current shared contract
+
+Boundary rules:
+
+- do not move ordinary pipeline semantics into `cli` unless mode behavior is part of the assertion
+- do not test pipe-mode wrapper mechanics in `flow`; that belongs to `cli`
+- do not add error-category cases unless the failure surface is already documented and stable for shared assertion
+
+## 4. Behavior inventory to prove
+
+The implementation/test phases should add a minimal, behavior-oriented inventory proving the current contract.
+
+Required behavior groups:
+
+1. Direct Option rendering in eval surface
+   - deterministic success output for `some(...)`
+   - deterministic success output for `none` / `none(...)` forms already documented
+
+2. Pipeline Option propagation in eval surface
+   - `some(...)` propagation through at least one ordinary stage path
+   - `none(...)` short-circuit of downstream stages
+   - no silent loss of Option structure at final observable boundary
+
+3. Option-aware helper propagation in existing stdlib paths
+   - list/value pipeline behavior using already-implemented helpers (`map`, `keep_some`, `keep_some_else`, `flat_map_some`, `unwrap_or`, or equivalent already-documented helpers)
+   - choose only helpers whose behavior is already stable and documented
+
+4. Flow-oriented Option behavior
+   - at least one deterministic Flow case showing Option filtering/propagation via already-implemented helpers
+   - behavior must stay in first-wave Flow contract boundaries
+
+5. CLI coverage only if needed
+   - add/adjust `cli` cases only where existing `-c` or `-p` observable behavior is necessary to prove Option propagation contract consistency
+
+Inventory size guidance:
+
+- prefer a small set of high-signal cases over broad matrix expansion
+- each case should prove one contract fact clearly
+- avoid duplicated proofs across categories
+
+## 5. Failure behavior coverage
+
+Failure coverage in this issue is narrow and contract-driven.
+
+Include only failures that are already documented/stable and directly tied to Option propagation or Option-aware helper usage.
+
+Do not include:
+
+- new diagnostics
+- Python traceback-shape assertions
+- undocumented misuse variants
+- speculative option-error semantics
+
+If a failure case is added, shared assertions must remain limited to documented observable surfaces (`stdout`, `stderr`, `exit_code`) with current normalization rules.
+
+## 6. Core invariants
+
+All shared cases added for this issue must preserve these invariants:
+
+- no new semantics are introduced
+- compared behavior is observable and deterministic
+- category boundaries remain explicit (`eval` vs `flow` vs `cli`)
+- Option propagation behavior matches current documented contract exactly
+- cases remain independent and reproducible
+- shared assertions do not depend on host-specific leakage
+- uncovered Option behavior remains unguaranteed
+
+## 7. Minimal example families
+
+Minimal candidate families (subject to syntax/runtime confirmation in later phases):
+
+- direct value rendering:
+  - `some(1)`
+  - `none`
+- basic Option filtering pipeline:
+  - `[some(1), none, some(2)] |> keep_some |> each(print)`
+
+Real pipeline/flow families:
+
+- `stdin |> lines |> map(parse_int) |> keep_some |> each(print)`
+- equivalent deterministic command-mode flow-to-value examples using already-documented helpers
+
+Examples in later phases must be validated against current syntax and current runtime behavior before they are committed as executable cases.
+
+## 8. Non-goals
+
+Out of scope for this issue:
+
+- introducing any new Option constructor/destructor semantics
+- changing pipeline lifting rules
+- changing Flow orchestration semantics
+- adding or renaming stdlib APIs
+- parser changes for new surface forms
+- proving non-Python hosts
+- making Option behavior claims not backed by executable shared cases
+
+## 9. Implementation boundary
+
+This spec is behavior-only.
+
+- it defines what must be proved by executable shared cases
+- it does not prescribe interpreter internals or runner internals
+- it remains portable at the contract level even though only Python is currently implemented
+
+Later implementation work may touch runner or tests only where required to execute the defined shared proofs.
+
+## 10. Documentation truth requirements
+
+Later docs-sync phase must ensure repository truth surfaces describe this issue accurately and narrowly:
+
+- describe this as shared coverage expansion for existing behavior
+- do not claim new Option semantics
+- do not imply broader Flow/pipeline guarantees than covered cases prove
+- do not imply non-Python host implementation
+
+Potential truth surfaces requiring synchronization if coverage inventory materially expands:
+
+- `GENIA_STATE.md`
+- `GENIA_REPL_README.md`
+- `README.md`
+- `spec/*` category READMEs
+- `tools/spec_runner/README.md`
+
+These edits belong to later phases unless a direct contradiction must be corrected immediately.
+
+## 11. Complexity check
+
+Assessment:
+
+- Minimal: Yes
+- Necessary: Yes
+- Overly complex: No
+
+Reason:
+
+- this issue reveals and hardens existing behavior by executable proof
+- it avoids semantic expansion while reducing regression risk in visible Option propagation paths
+
+## 12. Acceptance criteria for later phases
+
+Issue #150 is complete only when all of the following are true:
+
+- executable shared cases prove existing Option propagation behavior across relevant active categories
+- cases cover direct Option rendering plus propagation through supported pipeline/flow/helper paths already implemented
+- any CLI additions are strictly contract-necessary
+- runner/test changes (if any) are minimal and only support case execution/assertion
+- no new language/runtime semantics are introduced
+- docs are synchronized to the exact implemented coverage and no further
+
+## Spec decision summary
+
+This issue defines a narrow, implementation-ready contract for shared Option propagation coverage:
+
+- prove existing `some(...)` / `none(...)` observable behavior
+- prove existing pipeline/Flow propagation behavior where already implemented
+- prove only already-documented option-aware stdlib behavior
+- keep category boundaries explicit
+- avoid semantic expansion
+
+The next Design phase must map this contract into concrete case inventory and file placement without changing semantics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.14"
 description = "Genia language prototype interpreter and regression tests"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = []
+dependencies = [
+  "PyYAML>=6.0",
+]
 
 [dependency-groups]
 dev = [

--- a/spec/eval/README.md
+++ b/spec/eval/README.md
@@ -17,6 +17,8 @@ Current eval case inventory covers deterministic command-source eval behavior fo
 - direct `stderr` output
 - combined `stdout`/`stderr` output separation
 - stdin-fed eval cases whose compared surface remains `stdout`, `stderr`, and `exit_code`
+- direct Option rendering (`some(...)`, `none(...)`) in deterministic final-result output
+- pipeline Option propagation (`some(...)` lift and `none(...)` short-circuit) in deterministic final-result output
 - deterministic eval failures
 
 This directory does not define shared coverage for:

--- a/spec/eval/option-none-render-basic.yaml
+++ b/spec/eval/option-none-render-basic.yaml
@@ -1,0 +1,9 @@
+name: option-none-render-basic
+category: eval
+input:
+  source: |
+    none("missing")
+expected:
+  stdout: "none(\"missing\")\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/option-some-render-basic.yaml
+++ b/spec/eval/option-some-render-basic.yaml
@@ -1,0 +1,9 @@
+name: option-some-render-basic
+category: eval
+input:
+  source: |
+    some(1)
+expected:
+  stdout: "some(1)\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/pipeline-option-none-short-circuit.yaml
+++ b/spec/eval/pipeline-option-none-short-circuit.yaml
@@ -1,0 +1,9 @@
+name: pipeline-option-none-short-circuit
+category: eval
+input:
+  source: |
+    none("blocked") |> ((x) -> x + 1)
+expected:
+  stdout: "none(\"blocked\")\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/pipeline-option-some-lift.yaml
+++ b/spec/eval/pipeline-option-some-lift.yaml
@@ -1,0 +1,9 @@
+name: pipeline-option-some-lift
+category: eval
+input:
+  source: |
+    some(1) |> ((x) -> x + 1)
+expected:
+  stdout: "some(2)\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/flow/README.md
+++ b/spec/flow/README.md
@@ -20,5 +20,6 @@ Current first-wave Flow shared coverage proves only:
 - `step_*` / `rule_*` equivalence (`step-rule-helper-equivalence`)
 - `rules()` identity stage (`rules-identity-stage`)
 - error propagation via invalid-reducer-on-flow diagnostic (`flow-error-propagation-sum-on-flow`)
+- deterministic Option filtering in Flow pipelines via `keep_some(...)` (`flow-keep-some-parse-int`)
 
 This directory does not define full Flow coverage.

--- a/spec/flow/flow-keep-some-parse-int.yaml
+++ b/spec/flow/flow-keep-some-parse-int.yaml
@@ -1,0 +1,13 @@
+name: flow-keep-some-parse-int
+category: flow
+input:
+  source: |
+    stdin |> lines |> map(parse_int) |> keep_some |> collect
+  stdin: |
+    1
+    x
+    2
+expected:
+  stdout: "[1, 2]\n"
+  stderr: ""
+  exit_code: 0

--- a/tests/test_spec_ir_runner_blackbox.py
+++ b/tests/test_spec_ir_runner_blackbox.py
@@ -39,6 +39,10 @@ def test_discover_specs_includes_eval_cases() -> None:
         "output-log",
         "output-print-and-log",
         "pattern-duplicate-binding-false",
+        "option-some-render-basic",
+        "option-none-render-basic",
+        "pipeline-option-some-lift",
+        "pipeline-option-none-short-circuit",
     }.issubset(eval_names)
 
 
@@ -71,6 +75,7 @@ def test_discover_specs_includes_flow_cases() -> None:
         "rules-rule-emit-deterministic",
         "step-rule-helper-equivalence",
         "rules-identity-stage",
+        "flow-keep-some-parse-int",
     }.issubset(flow_names)
 
 
@@ -100,6 +105,10 @@ def test_ir_spec_fixture(fname: str) -> None:
         "output-log.yaml",
         "output-print-and-log.yaml",
         "pattern-duplicate-binding-false.yaml",
+        "option-some-render-basic.yaml",
+        "option-none-render-basic.yaml",
+        "pipeline-option-some-lift.yaml",
+        "pipeline-option-none-short-circuit.yaml",
     ],
 )
 def test_eval_spec_fixture(fname: str) -> None:
@@ -142,6 +151,7 @@ def test_cli_spec_fixture(fname: str) -> None:
         "rules-rule-emit-deterministic.yaml",
         "step-rule-helper-equivalence.yaml",
         "rules-identity-stage.yaml",
+        "flow-keep-some-parse-int.yaml",
     ],
 )
 def test_flow_spec_fixture(fname: str) -> None:

--- a/tools/spec_runner/README.md
+++ b/tools/spec_runner/README.md
@@ -20,6 +20,10 @@ The shared spec runner loads shared spec cases, executes them against the Python
 
 Browser execution is planned to use the Python reference host on a backend service in the current playground direction; this does not add a second implemented host today.
 
+## Dependencies
+
+- `PyYAML` is required to load shared spec `.yaml` files.
+
 ## How to run the spec suite
 
 ```bash


### PR DESCRIPTION
### Motivation

- Add executable shared-spec cases to prove existing Option (`some(...)`/`none(...)`) rendering and pipeline/Flow propagation without changing language/runtime semantics.
- Make the spec runner usable for YAML-based spec files by declaring the `PyYAML` dependency.
- Record design, spec, and audit artifacts for Issue #150 to document scope and verification steps.

### Description

- Added eval shared-spec cases: `spec/eval/option-some-render-basic.yaml`, `spec/eval/option-none-render-basic.yaml`, `spec/eval/pipeline-option-some-lift.yaml`, and `spec/eval/pipeline-option-none-short-circuit.yaml` to assert direct Option rendering and pipeline lift/short-circuit behavior.
- Added a flow shared-spec case: `spec/flow/flow-keep-some-parse-int.yaml` to assert deterministic `keep_some(...)` filtering over `map(parse_int)` in Flow pipelines.
- Updated test discovery `tests/test_spec_ir_runner_blackbox.py` to include the new eval and flow cases in discovery and per-case fixture parametrization.
- Updated truth/docs surfaces: `GENIA_STATE.md`, `README.md`, `spec/eval/README.md`, `spec/flow/README.md`, and `tools/spec_runner/README.md` to reflect the expanded shared-spec coverage and to note the `PyYAML` dependency.
- Added architecture/design/spec/audit docs under `docs/architecture/` for Issue #150 to record design intent and audit results.
- Declared `PyYAML>=6.0` in `pyproject.toml` so the runner/tests can load `.yaml` spec files.

### Testing

- Updated blackbox discovery and fixture tests in `tests/test_spec_ir_runner_blackbox.py` to include the new spec files, but running `pytest tests/test_spec_ir_runner_blackbox.py` in the constrained environment failed at collection due to the missing `PyYAML` runtime dependency. (Failure: cannot import YAML loader without `PyYAML`.)
- The `tools.spec_runner` invocation (`python -m tools.spec_runner`) is documented and expected to exercise the new cases once `PyYAML` is installed; execution was not completed in this environment for the same missing-dependency reason.
- No runtime or language behavior changes were introduced, so existing interpreter tests that do not require spec YAML loading were unaffected by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf53c9fac8329b4aff9af69c1e068)