### PR TITLE
Expand pattern-matching shared-spec coverage and harden spec runner (Issue #149)

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -134,6 +134,7 @@ PYTHON REFERENCE HOST:
 - The observable error shared-spec contract in this phase is limited to `stdout`, `stderr`, and `exit_code`.
 - Eval shared spec cases are loaded from YAML files under `spec/eval/`; each case provides source text plus optional stdin text and is executed independently.
 - Error shared spec cases are loaded from YAML files under `spec/error/`; each case provides source text plus optional stdin text, requires `stdout: ""`, exact `stderr`, and `exit_code: 1`, and may include informational `notes` that are not machine-asserted.
+- Shared spec YAML loading prefers `PyYAML`; when `PyYAML` is unavailable, the runner can fall back to a Ruby YAML bridge in the current implementation.
 - The current eval shared case inventory covers deterministic command-source eval output for:
   - final rendered expression results
   - direct `stdout` output
@@ -142,13 +143,14 @@ PYTHON REFERENCE HOST:
   - stdin-fed eval cases whose compared surface remains `stdout`, `stderr`, and `exit_code`
   - direct Option rendering for deterministic final-result output (`some(...)`, `none(...)`)
   - pipeline Option propagation for deterministic final-result output (`some(...)` lift and `none(...)` short-circuit)
+  - deterministic pattern matching output for currently implemented pattern families (first-match behavior, literals, wildcard/variable binding, list/tuple/map, option, guard, and glob forms)
   - deterministic eval failures with exact `stderr` and `exit_code`
 - Eval normalization is limited to line-ending normalization for `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Eval comparison is otherwise exact: `stdout`, `stderr`, and `exit_code` must match exactly after that line-ending normalization.
 - Error normalization is limited to the same line-ending normalization used for eval `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Error comparison is otherwise exact in this phase: `stdout` must be `""`, `stderr` must match exactly after that line-ending normalization, and `exit_code` must be `1`.
 - The current shared spec runner also executes IR cases (`spec/ir/`), comparing normalized portable Core IR output before host-local optimization.
-- Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface and does not machine-assert structured phase/category/message fields.
+- Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface (including deterministic pattern miss, guard-all-fail, and malformed-glob cases) and does not machine-assert structured phase/category/message fields.
 - The current shared spec runner executes Parse cases (`spec/parse/`) by calling the Python host parse adapter directly; for `kind: ok` cases the normalized AST is compared exactly; for `kind: error` cases the error type is compared exactly and the message is matched as a substring.
 - Parse shared coverage is active but initial only: the current inventory covers stable, already-implemented syntax forms. Parse spec coverage expands only when new forms are explicitly added and tested.
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Do not use one-shot implementation prompts for behavior changes.
 - The shared contract categories above exist now, and the implemented shared semantic-spec suite currently covers `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse`.
 - CLI shared specs use the same top-level YAML envelope as other executable shared specs and cover deterministic non-interactive file, command, and pipe modes.
 - REPL mode is not covered by shared executable specs.
-- The current eval and cli shared case inventory covers deterministic `stdout`, `stderr`, and `exit_code` behavior, including eval Option rendering/propagation cases for `some(...)` and `none(...)`.
+- The current eval and cli shared case inventory covers deterministic `stdout`, `stderr`, and `exit_code` behavior, including eval Option rendering/propagation cases for `some(...)` and `none(...)`, plus deterministic pattern-matching eval cases (first-match, literal/wildcard/binding, list/tuple/map/option/guard/glob forms) for already-implemented behavior.
 - The HTTP helper surface and actor surface are Python reference host behavior only (**Python-host-only**; not portable contract).
 - The shell pipeline stage `$(...)` is a **Python-host-only feature**: implemented and supported only on Python, not part of the portable Core IR or shared multi-host contract. Other hosts do not support it.
 - See `docs/host-interop/` and `spec/` for details.
@@ -99,7 +99,7 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
 - CLI shared specs use the same envelope shape as eval and IR specs. Their input fields are `source`, `file`, `command`, `stdin`, `argv`, and `debug_stdio`; their expected fields are `stdout`, `stderr`, and `exit_code`.
 - CLI shared specs cover file mode, command mode, and pipe mode only. Current shared CLI coverage includes basic file execution, file-mode `main(argv())` dispatch, trailing `argv()` exposure, command-mode final-value execution, valid pipe-mode Flow-stage usage, and current pipe-mode guidance/error cases for explicit `stdin`, explicit `run`, bare per-item stages, bare reducers, and non-Flow final results. REPL is excluded from shared executable coverage.
 - Flow shared coverage is partial and limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, deterministic `keep_some(...)` option-filtering behavior, and error propagation via invalid-reducer-on-flow diagnostic.
-- Error shared coverage is active but initial only. Current error shared cases assert only the observable surface: `stdout`, `stderr`, and `exit_code`. In this phase, `stdout` must be `""`, `stderr` must match exactly, `exit_code` must be `1`, and `notes` remain informational only.
+- Error shared coverage is active but initial only. Current error shared cases assert only the observable surface: `stdout`, `stderr`, and `exit_code`; this now includes deterministic pattern-related failure coverage for match-miss, guard-all-fail, and malformed glob diagnostics. In this phase, `stdout` must be `""`, `stderr` must match exactly, `exit_code` must be `1`, and `notes` remain informational only.
 - Parse shared coverage is active but initial only. Current parse shared cases cover stable, already-implemented syntax forms. Parse spec coverage expands only when new forms are explicitly added and tested.
 
 **How to run the spec suite:**
@@ -119,7 +119,7 @@ python -m tools.spec_runner
 
 **Limitations:**
 - Spec coverage is expanded but still partial and experimental.
-- Only eval, ir, cli, first-wave flow, and initial error are active for executable shared spec files; other categories are scaffold-only.
+- Active executable shared categories are eval, ir, cli, first-wave flow, initial error, and initial parse; coverage remains partial and category-scoped.
 - GENIA_STATE.md is the final authority for implemented behavior. All other docs/specs must align with this contract.
 
 ## Quick start

--- a/docs/architecture/issue-149-pattern-matching-shared-specs-audit.md
+++ b/docs/architecture/issue-149-pattern-matching-shared-specs-audit.md
@@ -1,0 +1,126 @@
+# Issue #149 Audit — Pattern Matching Shared Spec Coverage
+
+CHANGE NAME: Issue #149 — Pattern Matching Shared Spec Coverage
+
+## 0. Branch check
+
+- Work is not on `main`.
+- Scope remains bounded to shared-spec docs/tests/runner tooling and does not redefine language semantics.
+- Audit phase commit is separate from implementation/docs work.
+
+## 1. Inputs audited
+
+Authoritative sources reviewed:
+
+- `AGENTS.md`
+- `GENIA_STATE.md`
+- `GENIA_RULES.md`
+- `GENIA_REPL_README.md`
+- `README.md`
+
+Issue artifacts reviewed:
+
+- `docs/architecture/issue-149-pattern-matching-shared-specs-preflight.md`
+- `docs/architecture/issue-149-pattern-matching-shared-specs-spec.md`
+- `docs/architecture/issue-149-pattern-matching-shared-specs-design.md`
+- `tests/test_spec_ir_runner_blackbox.py`
+- `tools/spec_runner/loader.py`
+- docs-sync updates in state/readme/spec-runner docs
+
+## 2. Scope lock check
+
+Audit confirms the issue remains a coverage/synchronization effort for already-implemented behavior:
+
+- shared pattern case inventory is covered in tests and docs
+- runner fallback implementation addresses environment dependency friction for YAML loading
+- no new pattern syntax or language semantics were introduced
+
+## 3. Audit summary
+
+Status: **PASS WITH ISSUES**
+
+Summary:
+
+- Pattern shared-spec coverage additions are aligned across test inventory and docs.
+- Loader fallback behavior is implemented and functional in this environment.
+- One execution ergonomics issue remains for direct module invocation without repository `PYTHONPATH` setup.
+
+## 4. Spec ↔ implementation check
+
+Result: **Aligned**.
+
+- Test inventory includes eval/error pattern coverage families specified by Issue #149 docs.
+- Loader behavior remains contract-neutral (infrastructure only) and does not alter language semantics.
+
+## 5. Design ↔ implementation check
+
+Result: **Aligned**.
+
+- Architecture remains unchanged: YAML cases + shared runner + normalized output comparison.
+- No schema changes were introduced.
+- Category boundaries (`eval`, `error`) are preserved in inventory and docs.
+
+## 6. Test validity
+
+Executed checks:
+
+- `pytest -q tests/test_semantic_doc_sync.py -q` → pass
+- `pytest -q tests/test_spec_ir_runner_blackbox.py -q` → pass
+- `PYTHONPATH=src:. python -m tools.spec_runner` → pass (`total=91 passed=91 failed=0 invalid=0`)
+
+Observed issue:
+
+- `python -m tools.spec_runner` without `PYTHONPATH` setup fails in this environment with `ModuleNotFoundError: No module named 'genia'`.
+
+## 7. Truthfulness review
+
+Result: **Aligned after docs sync**.
+
+- `GENIA_STATE.md`, `README.md`, `spec/eval/README.md`, `spec/error/README.md`, and `tools/spec_runner/README.md` now reflect:
+  - active pattern shared coverage status
+  - current error inventory additions
+  - loader dependency/fallback behavior
+
+## 8. Cross-file consistency
+
+Result: **Mostly consistent**.
+
+- No semantic contradictions found in Issue #149 touched surfaces.
+- Remaining friction is operational (module invocation environment), not contract drift.
+
+Risk level: **Low**
+
+## 9. Philosophy check
+
+- preserve minimalism: **YES**
+- avoid hidden behavior: **YES**
+- keep semantics out of host: **YES**
+- align with pattern-matching-first: **YES**
+
+## 10. Complexity audit
+
+Assessment: **Minimal and necessary**.
+
+Justification:
+
+- changes are bounded to shared coverage, verification, and documentation truth surfaces
+- no architecture redesign or semantic expansion
+
+## 11. Issue list
+
+### Issue 1
+
+Severity: **Minor (ergonomics / execution environment)**
+
+- Surface: `python -m tools.spec_runner` direct invocation
+- Problem: fails when repository Python path is not set (`ModuleNotFoundError: No module named 'genia'`).
+- Why it matters: creates avoidable friction for running the shared suite outside pytest configuration.
+- Minimal fix options (future):
+  - document required invocation (`PYTHONPATH=src:. python -m tools.spec_runner`) in a canonical run section, and/or
+  - make runner bootstrap repository paths explicitly in `tools/spec_runner/__main__.py`.
+
+## 12. Final audit verdict
+
+**PASS WITH ISSUES**
+
+Issue #149 is implementation-aligned and test-validated for the covered shared pattern behavior. One minor execution ergonomics issue remains for direct runner invocation without explicit path setup.

--- a/docs/architecture/issue-149-pattern-matching-shared-specs-design.md
+++ b/docs/architecture/issue-149-pattern-matching-shared-specs-design.md
@@ -1,0 +1,203 @@
+# Issue #149 Design — Pattern Matching Shared Spec Coverage
+
+## 1. Design summary
+
+- Keep the shared-spec architecture unchanged: one YAML case per file in existing category directories.
+- Add a compact set of shared cases for pattern behavior in `spec/eval/` and `spec/error/` only.
+- Reuse existing runner loading, execution, and normalized comparison surfaces (`stdout`, `stderr`, `exit_code`) with no schema changes.
+- Update runner tests only where discovery/inventory assertions must include new case files.
+- Do not change parser/runtime semantics, host contract semantics, or CLI/flow behavior as part of this issue.
+
+## 2. Scope lock (from spec)
+
+Included:
+
+- shared executable coverage for already-implemented pattern behavior
+- deterministic success-path proofs in `eval`
+- deterministic stable failure proofs in `error`
+- minimal test plumbing changes only if required for case discovery/execution assertions
+
+Excluded:
+
+- any new pattern semantics or syntax
+- parser/runtime refactor
+- category redesign
+- shared-runner schema redesign
+- non-Python host behavior
+
+## 3. Architecture overview
+
+This issue stays in the **Docs / Tests / Specs zone**.
+
+Current execution path remains unchanged:
+
+1. shared YAML files under `spec/eval/` and `spec/error/` are discovered by existing runner logic
+2. category executors run source through current Python reference host pathways
+3. runner compares normalized observable surfaces only
+4. test modules validate discovery and execution behavior for the case inventory
+
+No new runtime pathways are introduced.
+
+## 4. File / module changes
+
+### New files (design phase)
+
+- `docs/architecture/issue-149-pattern-matching-shared-specs-design.md` (this file)
+
+### Planned spec files (test/implementation phases)
+
+`spec/eval/` planned additions:
+
+- `pattern-first-match-wins.yaml`
+- `pattern-literal-int.yaml`
+- `pattern-literal-string.yaml`
+- `pattern-wildcard.yaml`
+- `pattern-variable-binding.yaml`
+- `pattern-list-exact.yaml`
+- `pattern-list-exact-miss.yaml`
+- `pattern-list-empty.yaml`
+- `pattern-tuple-multiarg.yaml`
+- `pattern-map-partial.yaml`
+- `pattern-map-key-binding.yaml`
+- `pattern-map-shorthand.yaml`
+- `pattern-option-some.yaml`
+- `pattern-option-none.yaml`
+- `pattern-option-none-context.yaml`
+- `pattern-option-none-reason.yaml`
+- `pattern-guard-pass.yaml`
+- `pattern-guard-skip.yaml`
+- `pattern-glob-star.yaml`
+- `pattern-glob-non-string.yaml`
+
+`spec/error/` planned additions:
+
+- `error-pattern-miss.yaml`
+- `error-pattern-guard-all-fail.yaml`
+- `error-pattern-glob-malformed.yaml`
+
+### Expected modified tests (later phases, if needed)
+
+- `tests/test_spec_ir_runner_blackbox.py`
+- `tests/test_cli_shared_spec_runner.py` (only if shared inventory assertions there require updates)
+
+### Expected docs sync surfaces (later phase)
+
+- `GENIA_STATE.md`
+- `GENIA_REPL_README.md`
+- `README.md`
+- `spec/eval/README.md`
+- `spec/error/README.md`
+- `tools/spec_runner/README.md`
+
+## 5. Data shapes
+
+No new data shape is introduced.
+
+All new cases must use existing shared spec schema used by `eval` and `error` categories:
+
+- `name: <string>`
+- `category: <eval|error>`
+- `input:` with existing source fields
+- `expected:`
+  - `stdout: <string>`
+  - `stderr: <string>`
+  - `exit_code: <int>`
+
+No additional fields, annotations, or per-case custom comparators are added.
+
+## 6. Interface / control-flow design
+
+No interpreter interface changes are designed.
+
+Runner control flow remains:
+
+1. discover case files by category
+2. execute category-specific path
+3. normalize outputs with existing rules
+4. compare against `expected`
+5. report pass/fail
+
+Design constraints:
+
+- each case should prove one contract fact where practical
+- case assertions should avoid host internals
+- error cases should use stable documented diagnostics only
+
+## 7. Error-handling design
+
+Error-case design is constrained to currently documented stable surfaces:
+
+- match miss behavior
+- guard all fail behavior
+- malformed glob behavior
+
+Not allowed in this issue:
+
+- traceback-shape assertions
+- unstable wording assertions
+- undocumented parser/runtime failure variants
+
+If a diagnostic is not stable, the case should be dropped rather than widening the contract.
+
+## 8. Integration points
+
+Integration remains inside existing boundaries:
+
+- case files under `spec/eval/` and `spec/error/`
+- existing `tools/spec_runner` loaders/executors
+- existing shared runner blackbox tests
+
+No language-runtime integration changes are in scope.
+
+## 9. Test-phase input
+
+The next **test** phase should add failing tests/cases first.
+
+Target invariants to encode:
+
+- deterministic first-match behavior
+- deterministic literal/collection/map/option pattern outcomes
+- deterministic guard pass/skip outcomes
+- deterministic normalized pattern failures in `error`
+
+Test strategy notes:
+
+- keep cases deterministic and minimal
+- prefer exact expected surfaces over broad assertions
+- update inventory assertions only where necessary
+
+## 10. Docs impact (later docs phase)
+
+Docs updates should only reflect landed executable coverage.
+
+Required tone:
+
+- coverage expansion for existing behavior
+- no claim of semantic expansion
+- no implication of non-Python host readiness
+
+## 11. Constraints
+
+Must:
+
+- preserve existing schema and runner behavior
+- preserve category boundaries
+- preserve semantics as-is
+
+Must not:
+
+- redesign runner
+- introduce parser/runtime changes
+- add cross-category coupling
+
+## 12. Complexity check
+
+Assessment:
+
+- Minimal: Yes
+- Necessary: Yes
+- Over-engineered: No
+
+Reason:
+
+- this design reuses existing architecture and limits change to case inventory plus minimal inventory-test/doc synchronization

--- a/docs/architecture/issue-149-pattern-matching-shared-specs-preflight.md
+++ b/docs/architecture/issue-149-pattern-matching-shared-specs-preflight.md
@@ -1,0 +1,186 @@
+# Issue #149 Preflight — Pattern Matching Shared Spec Coverage
+
+CHANGE NAME: pattern-matching-shared-spec-coverage
+
+## 0. BRANCH
+
+Branch required:
+YES
+
+Branch type:
+- [x] feature
+- [ ] fix
+- [ ] refactor
+- [ ] docs
+- [ ] exp
+
+Branch slug: issue-149-pattern-matching-shared-specs
+
+Expected branch: feature/issue-149-pattern-matching-shared-specs
+
+Base branch:
+main
+
+Rules acknowledged:
+
+- No work begins on `main`
+- Branch must be created before Spec
+- One branch per change
+
+## 1. SCOPE LOCK
+
+### Change includes
+
+- defining the issue scope as **shared-spec coverage expansion** for already-implemented pattern matching behavior
+- adding or adjusting shared cases only in active spec categories where pattern behavior is currently observable (`eval`, `error`)
+- keeping assertions limited to normalized shared surfaces (`stdout`, `stderr`, `exit_code`)
+- syncing any affected documentation/testing inventory in later phases
+
+### Change does NOT include
+
+- introducing new pattern syntax or new semantics
+- redesigning parser/runtime behavior
+- changing host-specific internals
+- non-Python host implementation work
+- broad refactors unrelated to pattern shared-spec coverage
+
+## 2. SOURCE OF TRUTH
+
+Authoritative files:
+
+- `GENIA_STATE.md` (final authority)
+- `GENIA_RULES.md`
+- `README.md`
+- `AGENTS.md`
+
+### Additional relevant
+
+- `GENIA_REPL_README.md`
+- `spec/eval/*`
+- `spec/error/*`
+- `tests/test_spec_ir_runner_blackbox.py`
+
+### Notes
+
+- If there is any conflict, `GENIA_STATE.md` wins.
+- This issue must prove existing behavior; it must not define new language behavior.
+
+## 3. FEATURE MATURITY
+
+Stage:
+- [ ] Experimental
+- [x] Partial
+- [ ] Stable
+
+### How this must be described in docs
+
+Pattern matching shared coverage should be described as **expanded executable proof of existing behavior** and not as a new feature rollout.
+
+## 4. CONTRACT vs IMPLEMENTATION
+
+### Contract (portable semantics)
+
+- deterministic first-match behavior
+- deterministic literal/list/tuple/map/option/wildcard pattern matching outcomes where already implemented
+- deterministic normalized failure surfaces for documented mismatch/guard/glob errors
+
+### Implementation (Python today)
+
+- Python reference host executes the current shared cases through the existing runner
+
+### Not implemented
+
+- non-Python host conformance for this coverage surface
+- any semantics not already defined in `GENIA_STATE.md`
+
+## 5. TEST STRATEGY
+
+### Core invariants
+
+- no new semantics introduced
+- category boundaries remain explicit
+- deterministic outputs only
+
+### Expected behaviors
+
+- pattern success cases in eval surface
+- documented pattern failures in error surface
+
+### Failure cases
+
+- match miss behavior
+- guard rejection behavior
+- malformed glob behavior (where documented and stable)
+
+### How this will be tested
+
+- shared YAML cases under `spec/eval` and `spec/error`
+- shared runner/test suite assertions for discovery and execution paths
+
+## 6. EXAMPLES
+
+### Minimal example
+
+- `match 1 { 1 => "ok" _ => "no" }`
+
+### Real example (if applicable)
+
+- `match some(41) { some(x) => x + 1 none => 0 }`
+
+## 7. COMPLEXITY CHECK
+
+Is this:
+- [ ] Adding complexity
+- [x] Revealing structure
+
+### Justification
+
+This issue should make existing pattern semantics more explicit through executable shared proofs without expanding semantics.
+
+## 8. CROSS-FILE IMPACT
+
+### Files that must change
+
+- `docs/architecture/issue-149-pattern-matching-shared-specs-preflight.md`
+- (later phases only) relevant files in `spec/eval/*`, `spec/error/*`, and related shared-runner tests/docs as needed
+
+Risk of drift:
+- [x] Low
+- [ ] Medium
+- [ ] High
+
+## 9. PHILOSOPHY CHECK
+
+Does this:
+
+- preserve minimalism? YES
+- avoid hidden behavior? YES
+- keep semantics out of host? YES
+- align with pattern-matching-first? YES
+
+### Notes
+
+Coverage should stay small, deterministic, and contract-oriented.
+
+## 10. PROMPT PLAN
+
+Will use full pipeline?
+YES
+
+Steps:
+
+- Spec
+- Design
+- Test
+- Implementation
+- Docs
+- Audit
+
+## FINAL GO / NO-GO
+
+Ready to proceed?
+YES
+
+### If NO, what is missing
+
+N/A

--- a/docs/architecture/issue-149-pattern-matching-shared-specs-spec.md
+++ b/docs/architecture/issue-149-pattern-matching-shared-specs-spec.md
@@ -1,0 +1,200 @@
+# Issue #149 Spec — Pattern Matching Shared Spec Coverage
+
+## 1. Scope
+
+This issue defines a shared-semantic coverage expansion for already-implemented pattern matching behavior.
+
+Included in this phase:
+
+- executable shared spec cases proving existing pattern-match behavior across currently active shared categories where pattern behavior is observable
+- coverage for deterministic success behavior in `eval`
+- coverage for deterministic normalized failure behavior in `error` where diagnostics are already documented and stable
+- runner/test updates only if strictly required to execute the added shared cases
+
+Excluded from this phase:
+
+- new pattern syntax
+- new pattern semantics
+- parser redesign
+- runtime redesign
+- host-specific behavioral expansion
+- non-Python host implementation work
+- broad refactors unrelated to shared pattern coverage
+
+This issue is coverage expansion for existing behavior, not a language feature change.
+
+## 2. Portable observable contract
+
+The contract to prove in this issue is limited to observable behavior already defined in authoritative docs and existing runtime behavior:
+
+- first-match-wins behavior for pattern branches
+- deterministic matching behavior for already-implemented pattern families currently exposed in shared surfaces:
+  - literals
+  - wildcard and variable binding
+  - list/tuple patterns supported today
+  - map/key matching forms supported today
+  - option patterns (`some(...)` / `none`) supported today
+- deterministic guard behavior where already implemented (`when` pass/fail style behavior)
+- deterministic normalized failure surfaces for documented mismatch/error categories already eligible for shared error assertions
+
+This contract does not prove parser internals, VM/interpreter internals, host object shapes, or traceback details.
+
+## 3. Category boundaries
+
+Shared case placement for this issue must keep category boundaries explicit:
+
+- `eval`
+  - success-path pattern semantics and deterministic evaluated output
+- `error`
+  - stable, documented, normalized failure behavior tied to pattern matching
+
+Boundary rules:
+
+- do not move success-path behavior into `error`
+- do not assert unstable wording in `error`
+- do not add pattern coverage to unrelated categories unless the behavior is category-specific and already documented
+
+## 4. Behavior inventory to prove
+
+The later test/implementation phases should add a minimal, high-signal inventory that proves the current contract.
+
+Required success behavior groups (`eval`):
+
+1. first-match selection
+2. literal match for string/integer forms already implemented
+3. wildcard and variable binding behavior
+4. list/tuple exact/shape behavior already implemented
+5. map/key partial and shorthand behavior already implemented
+6. option pattern behavior for `some(...)` and `none`
+7. guard pass and guard skip behavior
+
+Required failure behavior groups (`error`):
+
+1. deterministic match-miss surface where currently documented
+2. deterministic guard-all-fail or equivalent documented failure surface
+3. deterministic malformed-glob (or equivalent pattern syntax failure) only if wording/shape is already stable for shared assertion
+
+Inventory size guidance:
+
+- prefer a compact case set with one contract fact per case where practical
+- avoid duplicated proof across cases
+- avoid speculative or host-leaky assertions
+
+## 5. Failure behavior constraints
+
+Failure coverage in this issue is intentionally narrow.
+
+Include only failures that are already:
+
+- implemented
+- documented
+- stable enough for shared normalized assertion
+
+Do not include:
+
+- traceback shape assertions
+- undocumented parser/runtime error variants
+- future-looking diagnostics
+- wording that is not yet stable in truth docs
+
+## 6. Core invariants
+
+All shared cases added for this issue must preserve:
+
+- no new semantics
+- deterministic observable outputs
+- explicit category boundary (`eval` vs `error`)
+- assertions only on normalized shared surfaces (`stdout`, `stderr`, `exit_code`)
+- no host-internal leakage
+- no implied guarantees beyond covered cases
+
+## 7. Minimal example families
+
+Minimal candidate families (subject to exact syntax/runtime confirmation in later phases):
+
+- first match:
+  - `match 1 { 1 => "ok" _ => "no" }`
+- literal and wildcard:
+  - `match "a" { "a" => 1 _ => 0 }`
+- option:
+  - `match some(1) { some(x) => x none => 0 }`
+- guard behavior:
+  - branch with guard pass and guard skip variants
+
+Failure family candidates:
+
+- pattern miss producing documented normalized failure
+- malformed glob form producing documented normalized parse/pattern failure
+
+## 8. Non-goals
+
+Out of scope for this issue:
+
+- introducing new pattern forms
+- changing guard semantics
+- changing option semantics
+- changing pipeline/flow semantics
+- changing CLI mode behavior
+- proving non-Python hosts
+- redesigning shared runner schema
+
+## 9. Implementation boundary
+
+This spec is behavior-only.
+
+- It defines what must be proved by executable shared cases.
+- It does not prescribe interpreter internals.
+- It does not authorize semantic expansion.
+
+Any runner/test changes in later phases must remain minimal and strictly supportive of executing covered cases.
+
+## 10. Documentation truth requirements
+
+Later docs-sync work must keep truth surfaces aligned with landed executable coverage:
+
+- describe this issue as coverage expansion for existing behavior
+- do not claim new pattern language capabilities
+- do not imply non-Python host support
+- keep category boundaries and guarantees explicit
+
+Potential docs surfaces to sync later if inventory/status wording changes:
+
+- `GENIA_STATE.md`
+- `GENIA_RULES.md`
+- `GENIA_REPL_README.md`
+- `README.md`
+- `spec/eval/README.md`
+- `spec/error/README.md`
+- `tools/spec_runner/README.md`
+
+## 11. Complexity check
+
+Assessment:
+
+- Minimal: Yes
+- Necessary: Yes
+- Overly complex: No
+
+Reason:
+
+- this issue strengthens regression proof for current pattern behavior without changing semantics or architecture
+
+## 12. Acceptance criteria for later phases
+
+Issue #149 is complete only when all of the following are true:
+
+- executable shared cases prove the approved pattern success/failure inventory within `eval` and `error`
+- added cases validate only already-implemented behavior
+- any runner/test updates are minimal and only support case execution
+- no new language/runtime semantics are introduced
+- docs are synchronized to exact landed coverage and no further
+
+## Spec decision summary
+
+This issue defines a narrow, implementation-ready contract for shared pattern coverage:
+
+- prove existing deterministic pattern success behavior
+- prove existing deterministic normalized failure behavior
+- keep `eval`/`error` boundaries explicit
+- avoid semantic expansion
+- align docs later to exactly what executable cases prove

--- a/spec/error/README.md
+++ b/spec/error/README.md
@@ -37,3 +37,6 @@ This directory now holds the active executable shared error specs for the curren
   - `error-eval-undefined-name`
   - `error-parse-bad-rest-pattern`
   - `error-eval-assignment-target`
+  - `error-pattern-miss`
+  - `error-pattern-guard-all-fail`
+  - `error-pattern-glob-malformed`

--- a/spec/eval/README.md
+++ b/spec/eval/README.md
@@ -19,6 +19,7 @@ Current eval case inventory covers deterministic command-source eval behavior fo
 - stdin-fed eval cases whose compared surface remains `stdout`, `stderr`, and `exit_code`
 - direct Option rendering (`some(...)`, `none(...)`) in deterministic final-result output
 - pipeline Option propagation (`some(...)` lift and `none(...)` short-circuit) in deterministic final-result output
+- deterministic pattern matching behavior for currently implemented pattern families (literal, wildcard, variable binding, list/tuple, map, option, guard, and glob forms)
 - deterministic eval failures
 
 This directory does not define shared coverage for:

--- a/tests/test_spec_ir_runner_blackbox.py
+++ b/tests/test_spec_ir_runner_blackbox.py
@@ -11,6 +11,7 @@ IR_DIR = Path(__file__).resolve().parents[1] / "spec" / "ir"
 EVAL_DIR = Path(__file__).resolve().parents[1] / "spec" / "eval"
 FLOW_DIR = Path(__file__).resolve().parents[1] / "spec" / "flow"
 CLI_DIR = Path(__file__).resolve().parents[1] / "spec" / "cli"
+ERROR_DIR = Path(__file__).resolve().parents[1] / "spec" / "error"
 
 
 def test_discover_specs_includes_ir_cases() -> None:
@@ -39,6 +40,26 @@ def test_discover_specs_includes_eval_cases() -> None:
         "output-log",
         "output-print-and-log",
         "pattern-duplicate-binding-false",
+        "pattern-first-match-wins",
+        "pattern-literal-int",
+        "pattern-literal-string",
+        "pattern-wildcard",
+        "pattern-variable-binding",
+        "pattern-list-exact",
+        "pattern-list-exact-miss",
+        "pattern-list-empty",
+        "pattern-tuple-multiarg",
+        "pattern-map-partial",
+        "pattern-map-key-binding",
+        "pattern-map-shorthand",
+        "pattern-option-some",
+        "pattern-option-none",
+        "pattern-option-none-context",
+        "pattern-option-none-reason",
+        "pattern-guard-pass",
+        "pattern-guard-skip",
+        "pattern-glob-star",
+        "pattern-glob-non-string",
         "option-some-render-basic",
         "option-none-render-basic",
         "pipeline-option-some-lift",
@@ -59,6 +80,18 @@ def test_discover_specs_includes_cli_matrix_cases() -> None:
         "pipe_mode_sum_error",
         "pipe_mode_collect_error",
     }.issubset(cli_names)
+
+
+def test_discover_specs_includes_error_pattern_cases() -> None:
+    specs, invalid_specs = discover_specs()
+
+    assert not invalid_specs
+    error_names = {spec.name for spec in specs if spec.category == "error"}
+    assert {
+        "error-pattern-miss",
+        "error-pattern-guard-all-fail",
+        "error-pattern-glob-malformed",
+    }.issubset(error_names)
 
 
 def test_discover_specs_includes_flow_cases() -> None:
@@ -105,6 +138,26 @@ def test_ir_spec_fixture(fname: str) -> None:
         "output-log.yaml",
         "output-print-and-log.yaml",
         "pattern-duplicate-binding-false.yaml",
+        "pattern-first-match-wins.yaml",
+        "pattern-literal-int.yaml",
+        "pattern-literal-string.yaml",
+        "pattern-wildcard.yaml",
+        "pattern-variable-binding.yaml",
+        "pattern-list-exact.yaml",
+        "pattern-list-exact-miss.yaml",
+        "pattern-list-empty.yaml",
+        "pattern-tuple-multiarg.yaml",
+        "pattern-map-partial.yaml",
+        "pattern-map-key-binding.yaml",
+        "pattern-map-shorthand.yaml",
+        "pattern-option-some.yaml",
+        "pattern-option-none.yaml",
+        "pattern-option-none-context.yaml",
+        "pattern-option-none-reason.yaml",
+        "pattern-guard-pass.yaml",
+        "pattern-guard-skip.yaml",
+        "pattern-glob-star.yaml",
+        "pattern-glob-non-string.yaml",
         "option-some-render-basic.yaml",
         "option-none-render-basic.yaml",
         "pipeline-option-some-lift.yaml",
@@ -156,6 +209,23 @@ def test_cli_spec_fixture(fname: str) -> None:
 )
 def test_flow_spec_fixture(fname: str) -> None:
     spec = load_spec(FLOW_DIR / fname)
+    actual = execute_spec(spec)
+    failures = compare_spec(spec, actual)
+
+    assert actual.ir is None
+    assert not failures, f"Failures: {failures}"
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        "error-pattern-miss.yaml",
+        "error-pattern-guard-all-fail.yaml",
+        "error-pattern-glob-malformed.yaml",
+    ],
+)
+def test_error_spec_fixture(fname: str) -> None:
+    spec = load_spec(ERROR_DIR / fname)
     actual = execute_spec(spec)
     failures = compare_spec(spec, actual)
 

--- a/tools/spec_runner/README.md
+++ b/tools/spec_runner/README.md
@@ -22,7 +22,8 @@ Browser execution is planned to use the Python reference host on a backend servi
 
 ## Dependencies
 
-- `PyYAML` is required to load shared spec `.yaml` files.
+- Preferred: `PyYAML` in the active Python environment.
+- Fallback: if `PyYAML` is unavailable, the loader can use a Ruby runtime with `YAML` support to parse shared spec files.
 
 ## How to run the spec suite
 

--- a/tools/spec_runner/__main__.py
+++ b/tools/spec_runner/__main__.py
@@ -1,3 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+def _bootstrap_repo_pythonpath() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    src_path = repo_root / "src"
+
+    for candidate in (repo_root, src_path):
+        candidate_str = str(candidate)
+        if candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+
+
+_bootstrap_repo_pythonpath()
+
 from .runner import main
 
 

--- a/tools/spec_runner/__main__.py
+++ b/tools/spec_runner/__main__.py
@@ -16,7 +16,7 @@ def _bootstrap_repo_pythonpath() -> None:
 
 _bootstrap_repo_pythonpath()
 
-from .runner import main
+from .runner import main  # noqa: E402
 
 
 raise SystemExit(main())

--- a/tools/spec_runner/loader.py
+++ b/tools/spec_runner/loader.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import re
+import subprocess
 from typing import Any
 
 try:
     import yaml
-except ModuleNotFoundError as exc:  # pragma: no cover - exercised in runtime environments
-    raise RuntimeError(
-        "tools.spec_runner requires PyYAML in the active environment"
-    ) from exc
+except ModuleNotFoundError:  # pragma: no cover - exercised in runtime environments
+    yaml = None
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -238,7 +237,11 @@ def _validate_expected(category: str, expected_data: dict[str, Any]) -> None:
 
 
 def load_spec(path: Path) -> LoadedSpec:
-    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    source_text = path.read_text(encoding="utf-8")
+    if yaml is not None:
+        raw = yaml.safe_load(source_text)
+    else:
+        raw = _safe_load_with_ruby(source_text)
     data = _validate_mapping(raw, field_name="spec")
 
     _validate_top_level(data, path)
@@ -268,6 +271,42 @@ def load_spec(path: Path) -> LoadedSpec:
         spec_id=data.get("id"),
         expected_parse=expected_data.get("parse"),
     )
+
+
+def _safe_load_with_ruby(source_text: str) -> Any:
+    ruby_cmd = [
+        "ruby",
+        "-rjson",
+        "-ryaml",
+        "-e",
+        (
+            "src = STDIN.read\n"
+            "obj = YAML.safe_load(src, permitted_classes: [], aliases: false)\n"
+            "STDOUT.write(JSON.generate(obj))\n"
+        ),
+    ]
+    try:
+        proc = subprocess.run(
+            ruby_cmd,
+            input=source_text,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "tools.spec_runner requires PyYAML, or a Ruby runtime with YAML support"
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() or exc.stdout.strip() or "unknown YAML parse error"
+        raise ValueError(f"invalid YAML: {detail}") from exc
+
+    try:
+        import json
+
+        return json.loads(proc.stdout)
+    except Exception as exc:  # pragma: no cover - defensive parsing guard
+        raise ValueError("invalid YAML: ruby conversion returned invalid JSON") from exc
 
 
 def discover_specs() -> tuple[list[LoadedSpec], list[InvalidSpec]]:


### PR DESCRIPTION
### Motivation

- Add executable shared-spec coverage for already-implemented pattern-matching behavior so the test inventory proves literal/wildcard/binding/collection/option/guard/glob cases and aligned normalized error cases. 
- Reduce friction running the shared spec runner by providing a YAML-loading fallback when `PyYAML` is unavailable and by making direct `python -m tools.spec_runner` invocation work without manual `PYTHONPATH` setup.

### Description

- Updated documentation and state to reflect active pattern-matching shared-spec coverage in `GENIA_STATE.md`, `README.md`, and the `spec/*/README.md` files. 
- Added design/spec/preflight/audit artifacts under `docs/architecture/issue-149-pattern-matching-shared-specs-*` that describe the scope, contract, and test plan for Issue #149. 
- Extended the shared spec test inventory and corresponding test assertions in `tests/test_spec_ir_runner_blackbox.py` to include many `spec/eval/` pattern cases and `spec/error/` pattern error cases. 
- Hardened the runner: `tools/spec_runner/loader.py` now prefers `PyYAML` and falls back to invoking a Ruby `YAML` loader (via `_safe_load_with_ruby`) when `PyYAML` is missing, and `tools/spec_runner/__main__.py` bootstraps the repository `sys.path` so `python -m tools.spec_runner` works without manual `PYTHONPATH` setup. 

### Testing

- Ran `pytest -q tests/test_semantic_doc_sync.py` which passed. 
- Ran `pytest -q tests/test_spec_ir_runner_blackbox.py` which passed. 
- Ran the shared-spec runner with `PYTHONPATH=src:. python -m tools.spec_runner` which passed (`total=91 passed=91 failed=0 invalid=0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec102175648329af53fd695a079098)