### PR TITLE
fix(spec-runner): add verbose per-spec timing output

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -152,6 +152,7 @@ PYTHON REFERENCE HOST:
 - The current shared spec runner also executes IR cases (`spec/ir/`), comparing normalized portable Core IR output before host-local optimization.
 - Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface (including deterministic pattern miss, guard-all-fail, and malformed-glob cases) and does not machine-assert structured phase/category/message fields.
 - The current shared spec runner executes Parse cases (`spec/parse/`) by calling the Python host parse adapter directly; for `kind: ok` cases the normalized AST is compared exactly; for `kind: error` cases the error type is compared exactly and the message is matched as a substring.
+- The current shared spec runner accepts `-v` / `--verbose`, printing each spec name before execution starts and then a single timing line (`<name>\t<elapsed>s`) after each spec completes.
 - Parse shared coverage is active but initial only: the current inventory covers stable, already-implemented syntax forms. Parse spec coverage expands only when new forms are explicitly added and tested.
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.
 

--- a/README.md
+++ b/README.md
@@ -108,13 +108,19 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
 python -m tools.spec_runner
 ```
 
+```bash
+python -m tools.spec_runner --verbose
+```
+
+- `--verbose` / `-v` prints each spec name before execution begins, then prints a single elapsed-time line in the format `<spec-name>\t<elapsed>s`.
+
 **What the spec guarantees:**
 - For eval: the runner executes each case independently and compares `stdout`, `stderr`, and `exit_code` with newline normalization.
 - For cli: the runner executes deterministic non-interactive CLI cases and compares `stdout`, `stderr`, and `exit_code` with newline normalization.
 - For ir: the runner executes each case independently and compares normalized portable Core IR output captured before host-local optimization.
 - For flow: the runner executes first-wave command-source Flow cases and compares `stdout`, `stderr`, and `exit_code` with newline normalization.
 - For error: the runner executes initial normalized error cases and compares only `stdout`, `stderr`, and `exit_code`.
-- For other categories: present as scaffolds only; no executable shared spec files yet.
+- For parse: the runner executes parse cases and compares normalized parse output (`kind: ok` exact AST; `kind: error` exact type plus message substring).
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.
 
 **Limitations:**

--- a/tests/test_cli_shared_spec_runner.py
+++ b/tests/test_cli_shared_spec_runner.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import tools.spec_runner.runner as runner_module
 
 from hosts.python import exec_cli as exec_cli_module
 from hosts.python.exec_cli import exec_cli
@@ -350,6 +351,25 @@ def test_spec_runner_integration_includes_cli_without_invalid_specs(capsys) -> N
     assert exit_code == 0
     assert "invalid=0" in captured.out
     assert f"total={len(specs)}" in captured.out
+
+
+def test_spec_runner_verbose_reports_spec_start_and_elapsed(capsys, monkeypatch) -> None:
+    spec = _loaded_cli_spec(name="verbose_case", command="print 1")
+
+    monkeypatch.setattr(runner_module, "discover_specs", lambda: ([spec], []))
+    monkeypatch.setattr(
+        runner_module,
+        "execute_spec",
+        lambda _spec: ActualResult(stdout="", stderr="", exit_code=0),
+    )
+
+    exit_code = runner_module.main(["--verbose"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "verbose_case\n" in captured.out
+    assert "verbose_case\t" in captured.out
+    assert "Summary: total=1 passed=1 failed=0 invalid=0" in captured.out
 
 
 def test_eval_and_ir_specs_still_execute_unchanged() -> None:

--- a/tools/spec_runner/README.md
+++ b/tools/spec_runner/README.md
@@ -31,6 +31,12 @@ Browser execution is planned to use the Python reference host on a backend servi
 python -m tools.spec_runner
 ```
 
+```bash
+python -m tools.spec_runner --verbose
+```
+
+Verbose mode prints each spec name before execution starts, then prints a timing line after execution in the form `<spec-name>\t<elapsed>s`.
+
 ## How it works
 
 - Cases are loaded from `spec/eval/*.yaml`, `spec/cli/*.yaml`, `spec/ir/*.yaml`, `spec/flow/*.yaml`, `spec/error/*.yaml`, and `spec/parse/*.yaml`

--- a/tools/spec_runner/__main__.py
+++ b/tools/spec_runner/__main__.py
@@ -19,4 +19,4 @@ _bootstrap_repo_pythonpath()
 from .runner import main  # noqa: E402
 
 
-raise SystemExit(main())
+raise SystemExit(main(sys.argv[1:]))

--- a/tools/spec_runner/reporter.py
+++ b/tools/spec_runner/reporter.py
@@ -21,6 +21,14 @@ def report_invalid(path: str, message: str) -> None:
     print(f"  {message}")
 
 
+def report_spec_started(spec: LoadedSpec) -> None:
+    print(spec.name, flush=True)
+
+
+def report_spec_elapsed(spec: LoadedSpec, elapsed_seconds: float) -> None:
+    print(f"{spec.name}\t{elapsed_seconds:.3f}s")
+
+
 def report_summary(*, total: int, passed: int, failed: int, invalid: int) -> None:
     print(
         f"Summary: total={total} passed={passed} failed={failed} invalid={invalid}"

--- a/tools/spec_runner/runner.py
+++ b/tools/spec_runner/runner.py
@@ -1,12 +1,33 @@
 from __future__ import annotations
 
+import argparse
+from time import perf_counter
+
 from .comparator import compare_spec
 from .executor import execute_spec
 from .loader import discover_specs
-from .reporter import report_failure, report_invalid, report_summary
+from .reporter import (
+    report_failure,
+    report_invalid,
+    report_spec_elapsed,
+    report_spec_started,
+    report_summary,
+)
 
 
-def main() -> int:
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Genia shared specs")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="print per-spec start and elapsed timing",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args([] if argv is None else argv)
     specs, invalid_specs = discover_specs()
 
     total = len(specs)
@@ -18,10 +39,15 @@ def main() -> int:
         report_invalid(str(invalid_spec.path), invalid_spec.message)
 
     for spec in specs:
+        start_time = perf_counter()
+        if args.verbose:
+            report_spec_started(spec)
         try:
             actual = execute_spec(spec)
         except Exception as exc:  # noqa: BLE001
             failed += 1
+            if args.verbose:
+                report_spec_elapsed(spec, perf_counter() - start_time)
             report_failure(
                 spec,
                 [
@@ -39,6 +65,8 @@ def main() -> int:
             continue
 
         failures = compare_spec(spec, actual)
+        if args.verbose:
+            report_spec_elapsed(spec, perf_counter() - start_time)
         if failures:
             failed += 1
             report_failure(spec, failures)


### PR DESCRIPTION
### Motivation
- The spec runner can take significant time and needs a simple verbose mode to surface per-spec progress and timing.
- While adding verbose output an argument-forwarding bug was found that caused `python -m tools.spec_runner --help` to behave incorrectly when invoked under test harnesses.

### Description
- Add a `-v/--verbose` flag to `tools.spec_runner.runner` using `argparse` that prints each spec name before execution and a single post-run timing line in the form `<name>\t<elapsed>s` using `perf_counter` and new reporter helpers `report_spec_started` and `report_spec_elapsed` in `tools/spec_runner/reporter.py`.
- Make the CLI entrypoint forward arguments from `sys.argv[1:]` in `tools/spec_runner/__main__.py` and update `runner.main` to accept an optional `argv` parameter (defaulting to an empty list when `None`) so programmatic and `-m` invocation behave correctly.
- Add an integration test `test_spec_runner_verbose_reports_spec_start_and_elapsed` in `tests/test_cli_shared_spec_runner.py` and update `tools/spec_runner/README.md`, `README.md`, and `GENIA_STATE.md` to document the new `--verbose` behavior.

### Testing
- Ran `pytest tests/test_cli_shared_spec_runner.py -q` and all tests passed (`26 passed`).
- Verified `python -m tools.spec_runner --help` prints the new `-v/--verbose` option and exits successfully.
- Ran `python -m tools.spec_runner --verbose` to exercise verbose output and observed per-spec start lines, per-spec elapsed lines, and final summary (successful run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecbd8a55f4832997430b2144773c82)