### PR TITLE
Issue 126 run case contract

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -163,7 +163,8 @@ PYTHON REFERENCE HOST:
 
 **Host implementation location:**
 - The working Python implementation lives in `src/genia/`, `tests/`, and `src/genia/std/prelude/`.
-- `hosts/python/` is a documentation/adaptation scaffold only, not the live runtime source location.
+- `hosts/python/` is the active host adapter layer; it is not the core runtime source location (that remains `src/genia/`).
+- `hosts/python/adapter.py::run_case(spec: LoadedSpec) -> ActualResult` is the canonical adapter entrypoint, wired to the shared spec runner via `tools/spec_runner/executor.py::execute_spec`. All spec categories route through `run_case`.
 
 **Planned/Scaffolded:**
 - Node.js, Java, Rust, Go, C++: planned only, not implemented

--- a/docs/architecture/issue-126-run-case-contract-audit.md
+++ b/docs/architecture/issue-126-run-case-contract-audit.md
@@ -1,0 +1,250 @@
+# === GENIA AUDIT / TRUTH REVIEW ===
+
+CHANGE NAME: Define minimal host adapter contract (`run_case` interface)
+
+---
+
+## 0. BRANCH CHECK
+
+- Branch: `issue-126-run-case-contract` — NOT `main`. ✓
+- Branch name matches change. ✓
+- Scope matches branch intent: adapter contract alignment only. ✓
+- No unrelated changes included. ✓
+
+### Violations: None
+
+---
+
+## 3. AUDIT SUMMARY
+
+Status: **[x] PASS**
+
+Summary: All six pipeline phases completed correctly. `run_case` accepts `LoadedSpec` and returns `ActualResult` with correct per-category normalization. The executor delegates cleanly. Docs are accurate. 1472/1472 pytest, 138/138 shared spec runner.
+
+---
+
+## 4. SPEC ↔ IMPLEMENTATION CHECK
+
+**Input contract (spec §4):**
+
+| Spec requirement | Implementation | Status |
+|-----------------|----------------|--------|
+| Accepts `name`, `category`, `source`, `stdin`, `file`, `command`, `argv`, `debug_stdio` | `run_case(spec: LoadedSpec)` — `LoadedSpec` carries all fields | ✓ |
+| Must not inspect `expected_*` fields | No `expected_*` access in `adapter.py` | ✓ |
+| Must not mutate input | No mutation | ✓ |
+| Unsupported category raises immediately | `raise ValueError(f"Unknown spec case category: {spec.category}")` | ✓ |
+
+**Output contract (spec §5.1):**
+
+| Category | Required fields | Actual return | Status |
+|----------|----------------|---------------|--------|
+| eval, flow, error | `stdout`, `stderr`, `exit_code`, no strip | `ActualResult(stdout=normalize_text(...), ...)` | ✓ |
+| cli | `stdout`, `stderr`, `exit_code`, trailing newlines stripped | `ActualResult(stdout=strip_trailing_newlines(normalize_text(...)), ...)` | ✓ |
+| ir | `ir` field | `ActualResult(ir=result["ir"])` | ✓ |
+| parse | `parse` dict | `ActualResult(parse=result)` | ✓ |
+
+**Normalization rules (spec §5.2):**
+
+| Rule | Implementation | Status |
+|------|----------------|--------|
+| Line-ending normalization all text fields | `normalize_text` in `normalize.py`: `\r\n→\n`, `\r→\n` | ✓ |
+| CLI trailing-newline strip after normalization | `strip_trailing_newlines(normalize_text(...))` — order is correct | ✓ |
+| eval/flow/error must NOT strip trailing newlines | Only `normalize_text`, no strip call | ✓ |
+| IR normalization owned by `exec_ir` | `exec_ir` result passed through as-is | ✓ |
+| Parse normalization owned by parse path | `parse_and_normalize` result passed through as-is | ✓ |
+
+**Error category (spec §5.3):**
+Uses `run_eval_subprocess` (eval path). Returns `stdout`, `stderr`, `exit_code` with line-ending normalization only. ✓
+
+**Invariants (spec §6):**
+
+| # | Invariant | Status |
+|---|-----------|--------|
+| 1 | Adapter does not inspect `expected_*` | ✓ |
+| 2 | Adapter does not mutate input | ✓ |
+| 3 | Unsupported categories raise immediately | ✓ (raises `ValueError`) |
+| 4 | CLI strip occurs after line-ending normalization | ✓ (order verified in code) |
+| 5 | IR/parse shapes compatible with `comparator.py` | ✓ (138/138 spec cases pass) |
+| 6 | eval/flow/error do not strip trailing newlines | ✓ |
+| 7 | Host-specific internals stay internal | ✓ (`SimpleNamespace` for `exec_ir` is internal adapter detail) |
+
+### Mismatches: None
+
+---
+
+## 5. DESIGN ↔ IMPLEMENTATION CHECK
+
+| Design decision | Implementation | Status |
+|----------------|----------------|--------|
+| Strategy: replace scaffold entirely | `SpecCase` and `SpecResult` removed | ✓ |
+| `run_case` accepts `LoadedSpec`, returns `ActualResult` | Signature matches | ✓ |
+| `normalize.py`: remove `normalize_result`, `_normalize_value`; add `normalize_text`, `strip_trailing_newlines` | Done | ✓ |
+| `executor.py`: `execute_spec` delegates to `run_case` via local import | `from hosts.python.adapter import run_case` inside function body | ✓ |
+| `ActualResult` stays in `executor.py` | Still defined there | ✓ |
+| `loader.py`, `comparator.py`, `runner.py` not changed | Confirmed by `git diff` | ✓ |
+| Circular import resolved with local import | Local import inside `execute_spec` body | ✓ |
+
+**Behavior change vs old executor.py:** The old `executor.py` had an implicit fallthrough — unknown categories silently ran as eval. The new `adapter.py` raises `ValueError` for unknown categories. This is the correct change per spec invariant §6.3 and matches the loader's own category validation.
+
+### Mismatches: None
+
+---
+
+## 6. TEST VALIDITY
+
+**Coverage against spec §9 ("For the test phase"):**
+
+| Spec-required test | Test in `test_adapter_contract.py` | Status |
+|--------------------|-----------------------------------|--------|
+| eval returns stdout/stderr/exit_code, no strip | `test_run_case_eval_no_trailing_newline_strip`, `test_run_case_eval_fields` | ✓ |
+| cli strips trailing newlines | `test_run_case_cli_strips_trailing_newlines` | ✓ |
+| ir returns ir field | `test_run_case_ir_provides_ir_field` | ✓ |
+| parse returns parse field (kind: ok) | `test_run_case_parse_ok_provides_parse_field` | ✓ |
+| parse returns parse field (kind: error) | `test_run_case_parse_error_provides_parse_field` | ✓ |
+| error uses eval path, returns stdout/stderr/exit_code | `test_run_case_error_uses_eval_path_no_strip` | ✓ |
+| flow returns stdout/stderr/exit_code, no strip | `test_run_case_flow_no_trailing_newline_strip` | ✓ |
+| unsupported category raises | `test_run_case_unsupported_category_raises` | ✓ |
+| cli CRLF normalized before stripping | `test_run_case_cli_crlf_normalized_then_stripped` | ✓ |
+
+**Return-type tests (ActualResult, not dict):**  Each category has a `test_run_case_<cat>_returns_actual_result` test. ✓
+
+**Spec observable cases (spec §7) coverage:**
+
+All 9 observable cases from the spec have corresponding test coverage. ✓
+
+**Regression coverage:**  
+Existing 138 shared spec cases (eval/ir/cli/flow/error/parse) all pass through `execute_spec → run_case`. ✓
+
+**Mock target correctness:**  
+Tests patch at `hosts.python.adapter.<function>` — correct for post-implementation. Before implementation, these patches raised `AttributeError` (confirming the tests were genuinely failing). ✓
+
+### Missing / weak tests: None blocking.
+
+### False confidence risks: None. Mocks return realistic shapes; `isinstance(result, ActualResult)` checks prevent dict false-positives.
+
+---
+
+## 7. TRUTHFULNESS REVIEW
+
+**`HOST_INTEROP.md`:**
+- No longer claims `run_case(case: SpecCase) -> SpecResult`. ✓
+- Documents correct input fields, per-category output fields, normalization rules. ✓
+- CLI trailing-newline rule explicitly called out. ✓
+- "Unsupported categories raise an error immediately" documented. ✓
+
+**`GENIA_STATE.md`:**
+- `hosts/python/` no longer described as "documentation/adaptation scaffold only". ✓
+- `run_case` named as canonical wired entrypoint. ✓
+- Does not imply multi-host support. ✓
+
+**`tools/spec_runner/README.md`:**
+- Notes `execute_spec` delegates to `adapter.py::run_case`. ✓
+
+**Remaining `SpecCase`/`SpecResult` references in repo:**
+- `docs/architecture/issue-126-run-case-contract-spec.md` — historical "Scaffold path" description. Correct context, not authoritative. ✓
+- `docs/architecture/issue-126-run-case-contract-design.md` — lists what was removed. Correct. ✓
+- `docs/architecture/issue-126-run-case-contract-preflight.md` — historical scaffold note. ✓
+- `docs/architecture/issue-152-spec-system-doc-sync-design.md` — frozen past design doc quoting old `HOST_INTEROP.md` text. Stale but non-authoritative. Does not affect runtime or tests. ✓
+
+No authoritative doc (`GENIA_STATE.md`, `GENIA_RULES.md`, `README.md`, `GENIA_REPL_README.md`, `HOST_INTEROP.md`) contains stale `SpecCase`/`SpecResult` claims. ✓
+
+### Violations: None
+
+---
+
+## 8. CROSS-FILE CONSISTENCY
+
+| Source | Claim | Aligned | Notes |
+|--------|-------|---------|-------|
+| `HOST_INTEROP.md` | `run_case(spec: LoadedSpec) -> ActualResult` | ✓ | Matches implementation |
+| `HOST_INTEROP.md` | CLI strips trailing newlines; eval/flow/error do not | ✓ | Matches `adapter.py` |
+| `GENIA_STATE.md` | `hosts/python/adapter.py::run_case` is canonical entrypoint | ✓ | Matches implementation |
+| `GENIA_STATE.md` | No generic multi-host runner | ✓ | Unchanged, still true |
+| `spec_runner/README.md` | `execute_spec` delegates to `adapter.py::run_case` | ✓ | Matches `executor.py` |
+| `GENIA_RULES.md` | No changes needed | ✓ | No adapter contract rules in rules doc |
+| `README.md` | No changes needed | ✓ | No `SpecCase`/`SpecResult` references |
+
+### Drift detected: None
+
+Risk level: **[x] Low**
+
+---
+
+## 9. PHILOSOPHY CHECK
+
+- Preserve minimalism? **YES** — thin wrapper in `executor.py`; dispatch logic consolidated in one place.
+- Avoid hidden behavior? **YES** — normalization rules explicit; unknown categories raise immediately.
+- Keep semantics out of host? **YES** — adapter normalizes and dispatches; does not define language semantics.
+- Align with pattern-matching-first? **YES (N/A)** — not a language behavior change.
+
+### Violations: None
+
+---
+
+## 10. COMPLEXITY AUDIT
+
+**[x] Minimal and necessary**
+
+### Justification:
+- `adapter.py` is now 52 lines vs 69 before. Simpler.
+- `normalize.py` is 11 lines vs 30 before. Simpler.
+- `executor.py` is 19 lines vs 62 before. Simpler.
+- No new abstractions. No feature creep. Scope held exactly.
+
+### Anything removable: Nothing.
+
+---
+
+## 11. ISSUE LIST
+
+No critical, major, or blocking issues found.
+
+**Minor (non-blocking):**
+- `docs/architecture/issue-152-spec-system-doc-sync-design.md` contains a frozen historical quote of the old `HOST_INTEROP.md` `run_case(case: SpecCase) -> SpecResult` text. This is a past-issue pipeline artifact, frozen in time. Not authoritative, not read by tests, does not affect runtime. No fix required.
+
+---
+
+## 12. RECOMMENDED FIXES (ORDERED)
+
+None required. All issues are non-blocking.
+
+---
+
+## 14. VALIDATION
+
+**Tests executed:**
+```
+pytest: 1472 passed in 125.97s
+```
+
+**Spec runner:**
+```
+Summary: total=138 passed=138 failed=0 invalid=0
+```
+
+**Import chain verified:**
+```
+imports OK
+run_case params: ['spec']
+run_case return annotation: <class 'tools.spec_runner.executor.ActualResult'>
+```
+
+**Unknown category raises:**
+```
+OK: raises ValueError: Unknown spec case category: unknown
+```
+
+**Stale symbol scan:**  
+No `SpecCase`, `SpecResult`, or `normalize_result` references in any authoritative doc or active source file.
+
+---
+
+## FINAL VERDICT
+
+**Ready to merge? YES**
+
+- No blocking issues.
+- All tests pass.
+- All spec cases pass.
+- Docs aligned with implementation.
+- Scope held exactly.

--- a/docs/architecture/issue-126-run-case-contract-design.md
+++ b/docs/architecture/issue-126-run-case-contract-design.md
@@ -1,0 +1,192 @@
+# Issue #126 Design — `run_case` Contract Alignment Plan
+
+**Phase:** design
+**Branch:** `issue-126-run-case-contract`
+**Issue:** #126 — Define minimal host adapter contract (`run_case` interface)
+**Spec:** `docs/architecture/issue-126-run-case-contract-spec.md`
+
+---
+
+## 1. Branch Check
+
+Branch: `issue-126-run-case-contract` — not `main`. Proceeding.
+
+---
+
+## 2. Alignment Strategy: Replace Scaffold Entirely
+
+**Chosen: Option (a) — replace the scaffold entirely.**
+
+`SpecCase` and `SpecResult` are removed. `run_case` is rewritten to accept `LoadedSpec` and return
+`ActualResult`.
+
+**Why not option (b) — thin wrapper:**
+- `SpecCase` wraps all CLI fields inside an `input: dict`, requiring a disassembly step that adds
+  noise with no benefit.
+- `SpecResult` lacks the `parse` field entirely, so it cannot carry parse results through the
+  contract without structural changes anyway.
+- `SpecResult.success`, `SpecResult.result`, and `SpecResult.error` are not consumed by the
+  comparator and must not appear in the portable result.
+- A thin wrapper would keep two sets of types in scope and require a conversion layer that solves
+  no problem. `executor.py` already has the right dispatch and normalization shape; moving it into
+  `adapter.py` directly is simpler.
+
+---
+
+## 3. Changes to `hosts/python/adapter.py`
+
+### 3.1 Removed
+
+- `SpecCase` dataclass — replaced by `LoadedSpec` (from `tools.spec_runner.loader`)
+- `SpecResult` dataclass — replaced by `ActualResult` (from `tools.spec_runner.executor`)
+- `from .normalize import normalize_result` — the old normalize function is removed
+
+### 3.2 New signature
+
+```python
+from tools.spec_runner.loader import LoadedSpec
+from tools.spec_runner.executor import ActualResult
+from .normalize import normalize_text, strip_trailing_newlines
+
+def run_case(spec: LoadedSpec) -> ActualResult:
+```
+
+### 3.3 New dispatch body
+
+Dispatch logic is identical to the current `executor.py::execute_spec` body, moved here as the
+canonical implementation:
+
+```
+parse   → parse_and_normalize(spec.source) → ActualResult(parse=result)
+ir      → exec_ir(...)                     → ActualResult(ir=result["ir"])
+cli     → exec_cli(spec)                   → ActualResult(stdout=stripped, stderr=stripped, exit_code=...)
+flow    → exec_flow(spec)                  → ActualResult(stdout=normalized, stderr=normalized, exit_code=...)
+eval    → run_eval_subprocess(...)         → ActualResult(stdout=normalized, stderr=normalized, exit_code=...)
+error   → run_eval_subprocess(...)         → ActualResult(stdout=normalized, stderr=normalized, exit_code=...)
+other   → raise ValueError(f"Unknown spec case category: {spec.category}")
+```
+
+CLI path applies `strip_trailing_newlines(normalize_text(...))` to both `stdout` and `stderr`.
+eval, flow, error paths apply `normalize_text(...)` only — no trailing-newline stripping.
+ir and parse paths return their result objects without text normalization at this boundary.
+
+### 3.4 exec_ir call site
+
+The current `executor.py` passes a `SimpleNamespace` to `exec_ir`. That adapter-internal wrapping
+stays in `adapter.py`. The call becomes:
+
+```python
+result = exec_ir(SimpleNamespace(input={"source": spec.source}, stdin=None))
+```
+
+This is an internal adapter detail — `exec_ir`'s calling convention is host-specific and not part
+of the portable contract.
+
+---
+
+## 4. Changes to `hosts/python/normalize.py`
+
+### 4.1 Removed
+
+- `normalize_result(raw, case)` — this function returns a `SpecResult`-shaped dict which is not
+  the portable result type. It is removed along with `SpecResult`.
+- `_normalize_value(value)` — not consumed at the adapter boundary for any portable contract field.
+  Removed.
+- `_normalize_text(value)` — renamed and made the canonical helper (see below).
+
+### 4.2 Added / renamed
+
+```python
+def normalize_text(text: str) -> str:
+    """Line-ending normalization: \\r\\n → \\n, \\r → \\n."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+def strip_trailing_newlines(text: str) -> str:
+    """Strip trailing newlines. CLI category only."""
+    return text.rstrip("\n")
+```
+
+These replace the private `_normalize_text` and `_strip_trailing_newlines` that are currently
+duplicated in `executor.py`. Both `adapter.py` and `executor.py` import from `normalize.py`.
+
+---
+
+## 5. Changes to `tools/spec_runner/executor.py`
+
+`execute_spec` becomes a thin delegation wrapper:
+
+```python
+from hosts.python.adapter import run_case
+
+def execute_spec(spec: LoadedSpec) -> ActualResult:
+    return run_case(spec)
+```
+
+The local helpers `_normalize_text` and `_strip_trailing_newlines` are removed from `executor.py`
+(they move to `normalize.py`). `ActualResult` remains defined in `executor.py` — it is the
+canonical result type and `comparator.py` imports it from here.
+
+`runner.py` calls `execute_spec`; that call site does not change.
+
+---
+
+## 6. No Changes
+
+- `tools/spec_runner/loader.py` — `LoadedSpec` is the canonical input type. No changes.
+- `tools/spec_runner/comparator.py` — `compare_spec(spec, actual: ActualResult)` is unchanged.
+  The result shape `adapter.py` returns is already `ActualResult`-compatible.
+- `tools/spec_runner/runner.py` — calls `execute_spec`. Not changed.
+
+---
+
+## 7. Integration Boundary
+
+```
+runner.py
+  └─ execute_spec(spec: LoadedSpec) -> ActualResult   [executor.py — thin wrapper]
+       └─ run_case(spec: LoadedSpec) -> ActualResult  [adapter.py — canonical dispatch + normalization]
+            ├─ exec_parse / parse_and_normalize
+            ├─ exec_ir
+            ├─ exec_cli
+            ├─ exec_flow
+            └─ run_eval_subprocess
+```
+
+The execution boundary is `adapter.py::run_case`. `executor.py` exists only to preserve the
+`runner.py` call site without changes.
+
+---
+
+## 8. Docs Phase Changes
+
+In order:
+
+1. **`docs/host-interop/HOST_INTEROP.md`** — update the `run_case` description to document the
+   canonical input/output contract: accepts `LoadedSpec`-compatible fields, returns
+   `ActualResult`-compatible fields. Remove any statement that `run_case` returns `SpecResult`.
+   Document CLI trailing-newline stripping explicitly.
+
+2. **`GENIA_STATE.md`** — update the Python host adapter description to reflect that the adapter
+   entrypoint is wired to the spec runner (no longer bypassed). Do not imply multi-host support.
+
+3. **`tools/spec_runner/README.md`** (if it exists) — note that `execute_spec` now delegates to
+   `hosts/python/adapter.py::run_case`.
+
+4. **`README.md`** and **`GENIA_REPL_README.md`** — no update. This change does not affect
+   user-visible behavior.
+
+---
+
+## 9. Summary of File Touches
+
+| File | Change |
+|------|--------|
+| `hosts/python/adapter.py` | Replace scaffold: remove `SpecCase`/`SpecResult`, rewrite `run_case` to accept `LoadedSpec`, return `ActualResult` |
+| `hosts/python/normalize.py` | Remove `normalize_result`, `_normalize_value`; add public `normalize_text` and `strip_trailing_newlines` |
+| `tools/spec_runner/executor.py` | Replace body of `execute_spec` with `return run_case(spec)`; remove local normalization helpers |
+| `docs/host-interop/HOST_INTEROP.md` | Update `run_case` contract description (docs phase) |
+| `GENIA_STATE.md` | Update Python adapter wiring description (docs phase) |
+| `tools/spec_runner/README.md` | Note delegation change (docs phase, if file exists) |
+| `tools/spec_runner/loader.py` | No change |
+| `tools/spec_runner/comparator.py` | No change |
+| `tools/spec_runner/runner.py` | No change |

--- a/docs/architecture/issue-126-run-case-contract-preflight.md
+++ b/docs/architecture/issue-126-run-case-contract-preflight.md
@@ -1,0 +1,312 @@
+# Issue #126 Preflight: Minimal Host Adapter Contract
+
+=== GENIA PRE-FLIGHT ===
+
+CHANGE NAME:
+Define minimal host adapter contract (`run_case` interface)
+
+Date: 2026-04-27
+
+Parent epic:
+#115 — Minimize Host Porting Surface via Prelude + IR + Capability Boundaries
+
+## 0. Branch
+
+- Starting branch: `main`
+- Working branch: `issue-126-run-case-contract`
+- Branch status: newly created locally from `main`
+- Base observed locally: `1343b03`
+
+## 1. Scope Lock
+
+This preflight includes:
+
+- minimal host adapter contract
+- normalized `run_case` interface
+- relationship to the current shared spec runner
+- Python reference host alignment
+- test harness integration boundaries
+
+This preflight excludes:
+
+- new language behavior
+- new Genia syntax
+- new host implementation
+- broad spec runner rewrite
+- Core IR redesign
+- portability work beyond this contract
+- implementing `run_case`
+- renaming existing `exec_*` functions
+- changing spec behavior
+
+## 2. Source Of Truth
+
+Authoritative sources, in repository order:
+
+1. `GENIA_STATE.md` (final authority)
+2. `GENIA_RULES.md`
+3. `GENIA_REPL_README.md`
+4. `README.md`
+5. `spec/*`
+6. `docs/host-interop/*`
+7. `docs/architecture/*`
+8. implementation (`src/*`, `hosts/*`)
+9. `docs/process/run-change.md`
+
+If these files conflict, `GENIA_STATE.md` wins. In particular, `GENIA_STATE.md` says Python is the only implemented host, active executable shared spec categories are `parse`, `ir`, `eval`, `cli`, `flow`, and `error`, and no generic multi-host runner exists today.
+
+## 3. Current Behavior To Inspect
+
+Current runner and host-adapter files that must shape later phases:
+
+- `tools/spec_runner/executor.py`
+  - Defines `ActualResult`.
+  - Dispatches by category directly to parse, IR, CLI, Flow, or eval execution.
+  - Applies category-local normalization for `stdout`, `stderr`, and CLI trailing-newline stripping.
+  - Does not currently call `hosts/python/adapter.py::run_case`.
+- `tools/spec_runner/loader.py`
+  - Defines `LoadedSpec`.
+  - Defines active categories: `eval`, `cli`, `ir`, `flow`, `error`, `parse`.
+  - Validates one top-level YAML envelope and category-specific `input` / `expected` fields.
+- `tools/spec_runner/comparator.py`
+  - Compares `stdout`, `stderr`, and `exit_code` for eval/CLI/Flow/error.
+  - Compares normalized portable IR for IR cases.
+  - Compares normalized parse output for parse cases.
+- `tools/spec_runner/runner.py`
+  - Discovers specs, executes each independently, compares, and reports failures.
+  - Treats execution exceptions as `runtime_crash`.
+- `hosts/python/exec_cli.py`
+  - Executes the Python interpreter as a subprocess for CLI file, command, and pipe modes.
+  - Returns `stdout`, `stderr`, and `exit_code`.
+- `hosts/python/exec_eval.py`
+  - Executes command-source eval through a subprocess.
+  - Returns `stdout`, `stderr`, and `exit_code`.
+- `hosts/python/exec_flow.py`
+  - Executes Flow specs through command-source eval, not CLI pipe mode.
+  - Returns the same subprocess result shape as eval.
+- `hosts/python/exec_ir.py`
+  - Parses and lowers source, then normalizes portable Core IR.
+  - Returns `{"ir": ...}`.
+- `hosts/python/adapter.py`
+  - Already contains a `run_case(case: SpecCase) -> SpecResult` scaffold.
+  - This scaffold is not the path used by the current shared spec runner.
+  - Later phases must decide whether to align, replace, or preserve this scaffold without claiming unimplemented multi-host behavior.
+- `hosts/python/normalize.py`
+  - Has a generic normalization helper, but current runner normalization is still mostly in `tools/spec_runner/executor.py`.
+
+Spec cases to inspect in later phases:
+
+- parse: `spec/parse/*.yaml`
+- IR: `spec/ir/*.yaml`
+- eval: `spec/eval/*.yaml`
+- CLI: `spec/cli/*.yaml`
+- flow: `spec/flow/*.yaml`
+- error: `spec/error/*.yaml`
+
+The old `spec/_holding/*` and `spec/flows/*` files are not active shared runner categories in the current `loader.py` category list.
+
+## 4. Desired Contract Shape
+
+Candidate interface only:
+
+```text
+run_case(case) -> normalized_result
+```
+
+Candidate `case` contents:
+
+- identity: spec `name` and/or `id`
+- category: one of `parse`, `ir`, `eval`, `cli`, `flow`, `error`
+- input:
+  - `source` for parse, IR, eval, Flow, and error
+  - optional `stdin` for eval, Flow, error, and CLI
+  - `file`, `command`, `argv`, and `debug_stdio` for CLI where applicable
+- path or metadata for reporting only, if needed
+
+Candidate `normalized_result` contents:
+
+- for eval/CLI/Flow/error:
+  - `stdout`
+  - `stderr`
+  - `exit_code`
+- for IR:
+  - normalized portable Core IR output
+- for parse:
+  - normalized parse result:
+    - `kind: ok` plus normalized AST
+    - `kind: error` plus error type and message
+- optional execution-status metadata only if it does not change the compared contract
+
+Errors should be represented without inventing new semantics:
+
+- Current executable error specs assert only `stdout`, `stderr`, and `exit_code`.
+- Current parse error specs assert exact error `type` and message substring.
+- Structured phase/category/source-location fields remain contract concepts, but they are not machine-asserted by current error specs.
+- Later phases must not add structured error assertions unless the spec phase explicitly defines them and aligns `GENIA_STATE.md`.
+
+## 5. Contract vs Implementation
+
+Portable contract:
+
+- Defines the minimum host adapter entrypoint and result shape used by the shared spec harness.
+- Must be category-aware but not category-redefining.
+- Must preserve Core IR as the portability boundary.
+- Must normalize host-native execution into the existing observable contract.
+
+Python reference host today:
+
+- Python is the only implemented host and semantic reference.
+- Working runtime behavior lives mainly in `src/genia/`.
+- `hosts/python/` contains adapter and normalization scaffolding plus category execution modules.
+- The active runner currently dispatches directly through `tools/spec_runner/executor.py`, not through a single portable `run_case` adapter.
+
+Spec runner expectations:
+
+- Loader validates spec shape before execution.
+- Comparator owns expected-vs-actual checks.
+- Execution result must provide the exact fields each category compares today.
+- Any `run_case` integration should be a narrow execution-boundary change, not a runner rewrite.
+
+What must remain host-specific:
+
+- subprocess invocation strategy
+- parser/evaluator internals
+- runtime object representations
+- host capability implementations
+- file layout and package bootstrapping
+- host-local debugging metadata
+
+Host-specific behavior must not redefine Genia language behavior.
+
+## 6. Test Strategy For Later Phases
+
+Later phases must follow failing tests first.
+
+Adapter contract tests:
+
+- prove a host adapter accepts a loaded spec-like case and returns the normalized category surface
+- prove category dispatch does not mutate expected spec data
+- prove unsupported categories fail explicitly
+
+Python reference host tests:
+
+- prove Python `run_case` delegates to the existing parse/IR/eval/CLI/Flow/error execution paths
+- prove normalized stdout/stderr/exit-code behavior matches current runner behavior
+- prove IR and parse result shapes remain compatible with the comparator
+
+Spec runner integration tests:
+
+- prove `tools/spec_runner` can route execution through the adapter contract
+- prove existing active categories still discover, execute, compare, and report correctly
+- prove CLI-specific normalization remains unchanged unless the spec phase explicitly changes it
+
+Regression tests for existing specs:
+
+- parse shared specs
+- IR shared specs
+- eval shared specs
+- CLI shared specs
+- Flow shared specs
+- error shared specs
+
+Do not write those tests during this preflight phase.
+
+## 7. Docs Impact
+
+Likely documentation impact in later docs phase:
+
+- add or update a focused `docs/host-interop/` contract document for the minimal host adapter boundary
+- possibly update `GENIA_STATE.md` if the public/shared contract changes
+- possibly update `spec/manifest.json` if the host-test contract metadata changes
+- possibly update `tools/spec_runner/README.md` if execution routing changes
+- possibly update `README.md` or `GENIA_REPL_README.md` only if user-visible behavior changes
+
+Docs must not over-document future hosts as implemented. Node.js, Java, Rust, Go, C++, browser-native, and other hosts remain planned/scaffolded only unless runnable implementations and tests exist.
+
+## 8. Complexity Check
+
+Classification: revealing structure, if kept narrow.
+
+Justification:
+
+- The current system already has category execution modules and normalized runner results.
+- A minimal `run_case` contract can expose the existing boundary without adding language semantics.
+- Complexity increases if the issue becomes a spec runner rewrite, a generic multi-host orchestration layer, or a structured error model expansion.
+
+Drift risks:
+
+- `hosts/python/adapter.py` already claims a `run_case` shape, but active runner code does not use it.
+- Normalization currently exists in both runner code and host adapter scaffolding.
+- `HOST_INTEROP.md` mentions a single `run_case` entrypoint, while `GENIA_STATE.md` still says no generic multi-host runner exists.
+- CLI normalization differs from eval/Flow/error by stripping trailing newlines before comparison.
+- Parse and IR result surfaces are not `stdout`/`stderr`/`exit_code` surfaces.
+
+## 9. Philosophy Check
+
+- preserve minimalism: YES, if the contract stays one small adapter boundary
+- explicit behavior: YES, if each category's normalized result shape is written down
+- Core IR as portability boundary: YES, IR cases must continue comparing portable Core IR only
+- no host redefining language behavior: YES, adapters normalize and execute; they do not define semantics
+- no hidden behavior: YES, if normalization rules remain visible in docs/spec runner tests
+
+Notes:
+
+- This issue should standardize the harness boundary, not expand the language.
+- Prelude and Core IR remain the intended portability-reduction mechanisms.
+- Host capability differences must stay explicit and labeled.
+
+## 10. Prompt Plan
+
+Use the full required pipeline, one prompt and one commit per phase:
+
+1. preflight
+2. spec
+3. design
+4. failing tests
+5. implementation
+6. docs sync
+7. audit
+
+Do not continue beyond preflight until explicitly prompted.
+
+## 11. Final GO / NO-GO
+
+Decision: GO for spec phase.
+
+Blockers:
+
+- None for spec phase.
+
+Spec-phase cautions:
+
+- Resolve the current `hosts/python/adapter.py` scaffold vs active `tools/spec_runner/executor.py` dispatch split.
+- Define only the minimal shared adapter interface and result shape.
+- Keep structured error expansion out of scope unless a later issue explicitly scopes it.
+- Do not imply future hosts exist.
+
+Recommended branch name:
+
+- `issue-126-run-case-contract`
+
+Recommended next prompt:
+
+- `SPEC for #126`
+
+Files likely touched in later phases:
+
+- `GENIA_STATE.md`
+- `docs/host-interop/HOST_INTEROP.md`
+- possible new `docs/host-interop/HOST_ADAPTER_CONTRACT.md`
+- `tools/spec_runner/README.md`
+- `spec/manifest.json`
+- `tools/spec_runner/executor.py`
+- `tools/spec_runner/loader.py`
+- `tools/spec_runner/comparator.py`
+- `tools/spec_runner/runner.py`
+- `hosts/python/adapter.py`
+- `hosts/python/normalize.py`
+- `hosts/python/exec_cli.py`
+- `hosts/python/exec_eval.py`
+- `hosts/python/exec_flow.py`
+- `hosts/python/exec_ir.py`
+- targeted tests under `tests/`

--- a/docs/architecture/issue-126-run-case-contract-spec.md
+++ b/docs/architecture/issue-126-run-case-contract-spec.md
@@ -1,0 +1,401 @@
+# Issue #126 Spec — Minimal Host Adapter Contract (`run_case`)
+
+**Phase:** spec
+**Branch:** `issue-126-run-case-contract`
+**Issue:** #126 — Define minimal host adapter contract (`run_case` interface)
+
+This phase defines expected behavior only.
+It does not add failing tests, implementation, or documentation sync edits.
+
+---
+
+## 1. Source Of Truth
+
+Final authority: `GENIA_STATE.md`
+
+Supporting:
+- `GENIA_RULES.md`
+- `docs/host-interop/HOST_INTEROP.md`
+- `tools/spec_runner/executor.py` (active execution behavior)
+- `tools/spec_runner/loader.py` (canonical input shape — `LoadedSpec`)
+- `tools/spec_runner/comparator.py` (canonical comparison contract — `ActualResult` fields consumed)
+- `hosts/python/adapter.py` (existing scaffold, NOT currently wired to the runner)
+
+Relevant existing truths:
+- Python is the only implemented host and is the reference host.
+- The active shared spec runner routes execution through
+  `tools/spec_runner/executor.py::execute_spec(spec: LoadedSpec) -> ActualResult`.
+- `hosts/python/adapter.py::run_case(case: SpecCase) -> SpecResult` exists as a scaffold but is
+  not called by the current runner.
+- `GENIA_STATE.md` and `HOST_INTEROP.md` both describe `run_case` as the host adapter entrypoint,
+  but today the runner bypasses it.
+- `GENIA_STATE.md` states no generic multi-host runner exists.
+
+---
+
+## 2. Scope Decision
+
+### Included in this spec
+
+- Define the canonical `run_case(case) -> result` interface that the shared spec harness will
+  eventually route through.
+- Define the input type: what fields `run_case` must accept, derived from what `LoadedSpec`
+  carries today.
+- Define the output type per category: exact fields the comparator consumes from `ActualResult`.
+- Define normalization rules per category, including the CLI trailing-newline rule.
+- Identify and resolve the divergence between the scaffold (`adapter.py`) and the active runner
+  (`executor.py`).
+
+### Explicitly excluded from this spec
+
+- New host implementations (Node, Go, Rust, C++, browser-native).
+- Generic multi-host orchestration.
+- Changes to `LoadedSpec`, `comparator.py`, `loader.py`, or `runner.py` beyond the execution-boundary
+  change.
+- Structured error model expansion (phase/category/source-location assertions).
+- Renaming existing `exec_*` functions.
+- Changing spec YAML behavior or spec file format.
+- Implementation, failing tests, or docs sync.
+
+---
+
+## 3. Divergence Resolution
+
+Two execution paths exist today:
+
+**Active path** (`tools/spec_runner/executor.py::execute_spec`):
+- Input: `LoadedSpec` (flat dataclass from the loader).
+- Output: `ActualResult` (frozen dataclass with `stdout`, `stderr`, `exit_code`, `ir`, `parse`).
+- CLI normalization: strips trailing newlines from both `stdout` and `stderr` after line-ending
+  normalization. No other category strips trailing newlines.
+- Flow/eval/error normalization: normalizes line endings (`\r\n` → `\n`, `\r` → `\n`) only.
+- IR: returns normalized portable Core IR directly from `exec_ir`.
+- Parse: returns normalized parse dict (`{kind: ok, ast: ...}` or `{kind: error, type: ..., message: ...}`).
+
+**Scaffold path** (`hosts/python/adapter.py::run_case`):
+- Input: `SpecCase` (adapter-specific dataclass).
+- Output: `SpecResult` (dataclass with `success`, `stdout`, `stderr`, `exit_code`, `result`, `error`, `ir`).
+- Normalization: `hosts/python/normalize.py::normalize_result` — normalizes line endings but does NOT
+  strip trailing newlines for CLI. This diverges from the active runner.
+- `SpecResult.success`, `SpecResult.result`, and `SpecResult.error` are not consumed by the comparator
+  and have no place in the portable contract.
+- `SpecResult` does not have a `parse` field; `parse` category results cannot be returned.
+
+**Resolution:**
+
+The canonical adapter output for later phases is the `ActualResult` shape, not the `SpecResult` shape.
+`SpecResult` must not be used as the portable result type. The adapter must return an `ActualResult`-
+compatible value so that `comparator.py` can consume it without changes.
+
+The scaffold in `adapter.py` must be aligned to accept a `LoadedSpec`-compatible input and return an
+`ActualResult`-compatible output. Whether this is done by replacing the scaffold entirely or by
+retaining `SpecCase`/`SpecResult` as internal adapter types and converting at the boundary is a design
+decision; this spec only mandates the external interface.
+
+---
+
+## 4. Input Contract
+
+### 4.1 What `run_case` must accept
+
+The host adapter entrypoint must accept all fields that `LoadedSpec` carries which are needed for
+execution. The following fields are the mandatory execution surface:
+
+| Field         | Type                   | Present for                         |
+|---------------|------------------------|--------------------------------------|
+| `name`        | `str`                  | all categories (identity/reporting)  |
+| `category`    | `str`                  | all categories                       |
+| `source`      | `str`                  | all categories                       |
+| `stdin`       | `str`                  | eval, flow, error, cli               |
+| `file`        | `str \| None`          | cli (file mode)                      |
+| `command`     | `str \| None`          | cli (command and pipe modes)         |
+| `argv`        | `list[str]`            | cli                                  |
+| `debug_stdio` | `bool`                 | cli                                  |
+
+`spec_id`, `path`, `description`, and `expected_*` fields are metadata only; the host adapter must
+not require them for execution and must not use `expected_*` values to influence the execution result.
+
+### 4.2 Category values
+
+Accepted category values: `"parse"`, `"ir"`, `"eval"`, `"cli"`, `"flow"`, `"error"`.
+
+An unsupported category must raise an error immediately. The adapter must not silently return a
+result for an unknown category.
+
+---
+
+## 5. Output Contract
+
+### 5.1 Fields per category
+
+The host adapter result must provide exactly the fields consumed by `comparator.py::compare_spec`.
+No extra fields (`success`, `result`, `error`) are part of the portable contract.
+
+**eval / flow / error:**
+
+| Field       | Type  | Rule                                   |
+|-------------|-------|----------------------------------------|
+| `stdout`    | `str` | line-ending normalized, no trailing-newline strip |
+| `stderr`    | `str` | line-ending normalized, no trailing-newline strip |
+| `exit_code` | `int` | as returned by the subprocess          |
+
+**cli:**
+
+| Field       | Type  | Rule                                                      |
+|-------------|-------|-----------------------------------------------------------|
+| `stdout`    | `str` | line-ending normalized, then trailing newlines stripped   |
+| `stderr`    | `str` | line-ending normalized, then trailing newlines stripped   |
+| `exit_code` | `int` | as returned by the subprocess                             |
+
+**ir:**
+
+| Field | Type     | Rule                                              |
+|-------|----------|---------------------------------------------------|
+| `ir`  | `object` | normalized portable Core IR (list of IR node dicts) |
+
+**parse:**
+
+| Field   | Type   | Rule                                                          |
+|---------|--------|---------------------------------------------------------------|
+| `parse` | `dict` | `{kind: "ok", ast: <normalized AST>}` or `{kind: "error", type: <str>, message: <str>}` |
+
+### 5.2 Normalization rules
+
+**Line-ending normalization** (all text fields):
+- `\r\n` → `\n`
+- `\r` → `\n`
+
+**Trailing-newline stripping (CLI only)**:
+- After line-ending normalization, strip all trailing `\n` characters from `stdout` and `stderr`.
+- This rule applies only to `cli` category. It must not apply to `eval`, `flow`, `error`, `ir`, or
+  `parse`.
+
+**IR normalization**:
+- The result of `exec_ir` is the normalized portable Core IR. No additional normalization is applied
+  at the adapter boundary; `exec_ir` owns IR normalization.
+
+**Parse normalization**:
+- The result of the parse execution path is the normalized parse dict. The adapter returns it as-is.
+- For `kind: error` parse results, `message` must be a string; comparison is substring-based (this
+  is the comparator's responsibility, not the adapter's).
+
+### 5.3 `error` category
+
+`error` cases use the `eval` execution path. The error normalization (stdout/stderr/exit_code) is
+identical to `eval`. No structured phase/category/source-location fields are added at the adapter
+boundary. The adapter returns `stdout`, `stderr`, `exit_code` exactly as the subprocess provides
+them after line-ending normalization.
+
+---
+
+## 6. Invariants
+
+1. The adapter must not inspect `expected_*` fields from the input.
+2. The adapter must not mutate the input.
+3. Unsupported categories must raise an error, never silently return a result.
+4. CLI trailing-newline stripping must occur after line-ending normalization, not before.
+5. IR and parse result shapes must remain compatible with `comparator.py` without changes to
+   the comparator.
+6. The adapter result for `eval`, `flow`, and `error` must not strip trailing newlines.
+7. Host-specific subprocess strategy, internal runtime objects, and file layout remain
+   host-specific and must not appear in the portable result.
+
+---
+
+## 7. Observable Cases (to become tests in the test phase)
+
+These are not test code. They describe the contract. Tests are written in the test phase.
+
+### Case: adapter-eval-basic
+
+```
+category: eval
+source: print("hello")
+expected:
+  stdout: "hello\n"
+  stderr: ""
+  exit_code: 0
+```
+
+Adapter result must provide `stdout="hello\n"`, `stderr=""`, `exit_code=0`.
+No trailing-newline stripping for eval.
+
+### Case: adapter-cli-trailing-newline
+
+```
+category: cli
+command: print("hello")
+stdin: ""
+argv: []
+expected:
+  stdout: "hello"
+  stderr: ""
+  exit_code: 0
+```
+
+Adapter result must strip trailing newlines from `stdout`. Raw subprocess output `"hello\n"` normalizes
+to `"hello"`.
+
+### Case: adapter-eval-no-strip
+
+```
+category: eval
+source: print("hello")
+```
+
+Adapter result `stdout` is `"hello\n"`. It must NOT be `"hello"`. Trailing-newline stripping is
+CLI-only.
+
+### Case: adapter-ir-basic
+
+```
+category: ir
+source: 1 + 2
+```
+
+Adapter result provides `ir` field with normalized portable Core IR list. No `stdout`/`stderr`/`exit_code`
+fields are required.
+
+### Case: adapter-parse-ok
+
+```
+category: parse
+source: 1 + 2
+```
+
+Adapter result provides `parse` field with `{kind: "ok", ast: <normalized AST>}`.
+
+### Case: adapter-parse-error
+
+```
+category: parse
+source: (
+```
+
+Adapter result provides `parse` field with `{kind: "error", type: <str>, message: <str>}`.
+
+### Case: adapter-unsupported-category
+
+```
+category: unknown_category
+```
+
+Adapter raises an error immediately. No result is returned.
+
+### Case: adapter-cli-crlf
+
+```
+category: cli
+command: <source that produces CRLF output>
+```
+
+Adapter normalizes `\r\n` to `\n` before stripping trailing newlines.
+
+### Case: adapter-error-stdout-stderr
+
+```
+category: error
+source: <source that triggers a runtime error>
+expected:
+  stdout: ""
+  stderr: <error message>
+  exit_code: 1
+```
+
+Adapter uses eval path. Returns `stdout`, `stderr`, `exit_code` with line-ending normalization only.
+
+---
+
+## 8. Cases NOT in scope
+
+- Structured error assertions (phase, category, source-location fields) — not in active spec contracts.
+- Multi-host dispatch — no generic runner exists; Python is the only host.
+- `SpecResult.success`, `SpecResult.result`, `SpecResult.error` — not consumed by the comparator,
+  not part of the portable contract.
+- Nested CLI argv edge cases — already covered by existing CLI spec cases.
+- Changes to how `exec_ir` or `exec_parse` normalize their results internally.
+
+---
+
+## 9. Cross-phase notes
+
+### For the design phase
+
+- The design must choose one of two alignment strategies for `adapter.py`:
+  a. Replace the scaffold entirely: `run_case` accepts a `LoadedSpec` and returns `ActualResult`
+     directly, removing `SpecCase` and `SpecResult`.
+  b. Retain `SpecCase`/`SpecResult` as internal types but add a thin public entry that accepts
+     `LoadedSpec` and converts before delegating to the existing `run_case` body.
+- Either way, the design must confirm that `normalize.py::normalize_result` is updated or replaced
+  so that CLI results strip trailing newlines (matching `executor.py`) and that `parse` results
+  are returned in the `parse` field (not `ir`/`result`).
+- The design must confirm `executor.py::execute_spec` will be thin-wired to call the adapter after
+  this issue, or describe the integration boundary explicitly.
+- No changes to `loader.py`, `comparator.py`, or `runner.py` are expected.
+
+### For the test phase
+
+Write the following failing tests before implementation:
+
+- `tests/test_adapter_contract.py` — unit tests for the adapter contract:
+  - `run_case` with eval input returns `stdout`, `stderr`, `exit_code` (no trailing-newline strip).
+  - `run_case` with cli input strips trailing newlines from stdout and stderr.
+  - `run_case` with ir input returns `ir` field.
+  - `run_case` with parse input returns `parse` field with `kind: ok` or `kind: error`.
+  - `run_case` with error input uses eval path; returns `stdout`, `stderr`, `exit_code`.
+  - `run_case` with flow input returns `stdout`, `stderr`, `exit_code` (no trailing-newline strip).
+  - `run_case` with unsupported category raises an error.
+  - `run_case` with cli input applies line-ending normalization before stripping trailing newlines.
+
+Run them and confirm they fail before any implementation change.
+
+Confirm all existing shared spec cases still pass after implementation:
+- `spec/eval/*.yaml`
+- `spec/ir/*.yaml`
+- `spec/cli/*.yaml`
+- `spec/flow/*.yaml`
+- `spec/error/*.yaml`
+- `spec/parse/*.yaml`
+
+### For the docs phase
+
+In order:
+1. `docs/host-interop/HOST_INTEROP.md` — update the `run_case` description to reflect the
+   canonical input/output contract as defined here. Remove any claim that `run_case` returns
+   `SpecResult`; document the `ActualResult`-compatible surface instead.
+2. `GENIA_STATE.md` — update the Python host adapter description to reflect that the adapter
+   entrypoint is wired to the spec runner. Do not imply multi-host support.
+3. `tools/spec_runner/README.md` (if it exists) — note the execution boundary change if the
+   integration path changes.
+4. `README.md` and `GENIA_REPL_README.md` — no update expected unless user-visible behavior changes.
+
+---
+
+## 10. Recommended next prompt (DESIGN phase)
+
+```
+You are working in the Genia repo on issue #126:
+Define minimal host adapter contract (run_case interface)
+
+Spec is complete. Branch: issue-126-run-case-contract.
+Spec doc: docs/architecture/issue-126-run-case-contract-spec.md
+
+Design phase task:
+1. Confirm current branch is issue-126-run-case-contract.
+   Refuse to modify files on main.
+2. Read the spec doc and the following files before writing anything:
+   - hosts/python/adapter.py
+   - tools/spec_runner/executor.py
+   - tools/spec_runner/comparator.py
+   - hosts/python/normalize.py
+3. Write a design document at docs/architecture/issue-126-run-case-contract-design.md
+   describing exactly:
+   - Which alignment strategy is chosen for adapter.py (replace scaffold vs. thin wrapper)
+   - Exact changes to adapter.py: new input type, new return type, CLI trailing-newline rule
+   - Exact changes to normalize.py: what is added/changed/removed
+   - How executor.py routes through the adapter (or what the integration boundary is)
+   - What docs change in the docs phase and exactly what is updated
+   - Confirmation that loader.py, comparator.py, and runner.py are not changed
+4. Do NOT implement. Do NOT write tests. Do NOT update behavior docs.
+5. Commit with prefix: design(host): run_case contract alignment plan issue #126
+```

--- a/docs/host-interop/HOST_INTEROP.md
+++ b/docs/host-interop/HOST_INTEROP.md
@@ -87,7 +87,38 @@ Notes:
 
 ## Host Adapter and Spec Runner Model
 
-The Python host adapter exposes a single `run_case(case: SpecCase) -> SpecResult` entrypoint. In the current implemented shared semantic-spec system, the shared runner executes `eval`, `ir`, `cli`, `flow`, initial `error`, and initial `parse` cases.
+The Python host adapter exposes a single `run_case(spec: LoadedSpec) -> ActualResult` entrypoint in `hosts/python/adapter.py`. The shared spec runner routes all category execution through this entrypoint via `tools/spec_runner/executor.py::execute_spec`.
+
+**Input contract** — `run_case` accepts a `LoadedSpec`-compatible value with these execution fields:
+
+| Field | Present for |
+|-------|-------------|
+| `category` | all |
+| `source` | all |
+| `stdin` | eval, flow, error, cli |
+| `file` | cli (file mode) |
+| `command` | cli (command and pipe modes) |
+| `argv` | cli |
+| `debug_stdio` | cli |
+
+The adapter must not inspect `expected_*` fields and must not mutate the input.
+
+**Output contract** — `run_case` returns an `ActualResult`-compatible value with fields per category:
+
+| Category | Fields returned |
+|----------|----------------|
+| eval, flow, error | `stdout`, `stderr`, `exit_code` |
+| cli | `stdout`, `stderr`, `exit_code` (trailing newlines stripped) |
+| ir | `ir` (normalized portable Core IR) |
+| parse | `parse` (`{kind: "ok", ast: ...}` or `{kind: "error", type: ..., message: ...}`) |
+
+**Normalization rules:**
+- All text fields: line endings normalized (`\r\n` → `\n`, `\r` → `\n`)
+- CLI only: trailing newlines stripped from `stdout` and `stderr` after line-ending normalization
+- eval, flow, error: trailing newlines are preserved (not stripped)
+- Unsupported categories raise an error immediately; no result is returned
+
+In the current implemented shared semantic-spec system, the shared runner executes `eval`, `ir`, `cli`, `flow`, initial `error`, and initial `parse` cases.
 
 The shared spec runner loads YAML eval, cli, flow, error, IR, and parse cases, executes them against the Python reference host, and compares:
 

--- a/hosts/python/adapter.py
+++ b/hosts/python/adapter.py
@@ -1,69 +1,52 @@
 """
 Python Host Adapter for Genia Shared Spec Contract
 
-Implements: run_case(case: SpecCase) -> SpecResult
-
-- Category-specific execution paths
-- Normalization layer
-- Thin bridge to src/genia/interpreter.py
+Implements: run_case(spec: LoadedSpec) -> ActualResult
 """
-from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, Optional, List, Literal, Union
 
-from .exec_parse import exec_parse
-from .exec_ir import exec_ir
-from .exec_eval import exec_eval
-from .exec_cli import exec_cli
-from .exec_flow import exec_flow
-from .normalize import normalize_result
+from hosts.python import parse_and_normalize
+from hosts.python.exec_eval import run_eval_subprocess
+from hosts.python.exec_ir import exec_ir
+from hosts.python.exec_cli import exec_cli
+from hosts.python.exec_flow import exec_flow
+from hosts.python.normalize import normalize_text, strip_trailing_newlines
 
-@dataclass
-class SpecCase:
-    id: str
-    category: Literal["parse", "ir", "eval", "cli", "flow", "error"]
-    input: Union[str, dict]
-    args: Optional[List[str]] = None
-    stdin: Optional[str] = None
-    expected: Optional[dict] = None
-
-@dataclass
-class SpecResult:
-    success: bool
-    stdout: str
-    stderr: str
-    exit_code: int
-    result: Optional[Any] = None
-    error: Optional[dict] = None
-    ir: Optional[dict] = None
+from tools.spec_runner.loader import LoadedSpec
+from tools.spec_runner.executor import ActualResult
 
 
-def run_case(case: SpecCase) -> SpecResult:
-    """
-    Dispatches a spec case to the correct execution path and normalizes the result.
-    """
-    if case.category == "parse":
-        raw = exec_parse(case)
-    elif case.category == "ir":
-        raw = exec_ir(case)
-    elif case.category == "eval":
-        raw = exec_eval(case)
-    elif case.category == "cli":
-        if not isinstance(case.input, dict):
-            raise TypeError("cli case input must be a mapping")
-        raw = exec_cli(
-            SimpleNamespace(
-                file=case.input.get("file"),
-                command=case.input.get("command"),
-                stdin=case.input.get("stdin", ""),
-                argv=case.input.get("argv", []),
-                debug_stdio=case.input.get("debug_stdio", False),
-            )
+def run_case(spec: LoadedSpec) -> ActualResult:
+    if spec.category == "parse":
+        result = parse_and_normalize(spec.source)
+        return ActualResult(parse=result)
+
+    if spec.category == "ir":
+        result = exec_ir(SimpleNamespace(input={"source": spec.source}, stdin=None))
+        return ActualResult(ir=result["ir"])
+
+    if spec.category == "cli":
+        result = exec_cli(spec)
+        return ActualResult(
+            stdout=strip_trailing_newlines(normalize_text(result["stdout"])),
+            stderr=strip_trailing_newlines(normalize_text(result["stderr"])),
+            exit_code=result["exit_code"],
         )
-    elif case.category == "flow":
-        raw = exec_flow(case)
-    elif case.category == "error":
-        raw = exec_eval(case)  # error cases use eval path, expect error normalization
-    else:
-        raise ValueError(f"Unknown spec case category: {case.category}")
-    return normalize_result(raw, case)
+
+    if spec.category == "flow":
+        result = exec_flow(spec)
+        return ActualResult(
+            stdout=normalize_text(result["stdout"]),
+            stderr=normalize_text(result["stderr"]),
+            exit_code=result["exit_code"],
+        )
+
+    if spec.category in ("eval", "error"):
+        result = run_eval_subprocess(spec.source, spec.stdin or None)
+        return ActualResult(
+            stdout=normalize_text(result["stdout"]),
+            stderr=normalize_text(result["stderr"]),
+            exit_code=result["exit_code"],
+        )
+
+    raise ValueError(f"Unknown spec case category: {spec.category}")

--- a/hosts/python/normalize.py
+++ b/hosts/python/normalize.py
@@ -1,30 +1,11 @@
 """
-Normalization layer for Genia Python host adapter.
+Normalization helpers for the Genia Python host adapter.
 """
-from typing import Any
 
-def _normalize_text(value: Any) -> str:
-    text = value if isinstance(value, str) else str(value)
+
+def normalize_text(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
-def _normalize_value(value: Any) -> Any:
-    if value is None or isinstance(value, (bool, int, float, str)):
-        return value
-    if isinstance(value, list):
-        return [_normalize_value(item) for item in value]
-    if isinstance(value, dict):
-        return {str(key): _normalize_value(value[key]) for key in sorted(value, key=str)}
-    return type(value).__name__
-
-
-def normalize_result(raw: dict, case) -> Any:
-    return {
-        "success": int(raw.get("exit_code", 0)) == 0,
-        "stdout": _normalize_text(raw.get("stdout", "")),
-        "stderr": _normalize_text(raw.get("stderr", "")),
-        "exit_code": int(raw.get("exit_code", 0)),
-        "result": _normalize_value(raw.get("result")),
-        "error": _normalize_value(raw.get("error")),
-        "ir": _normalize_value(raw.get("ir")),
-    }
+def strip_trailing_newlines(text: str) -> str:
+    return text.rstrip("\n")

--- a/tests/test_adapter_contract.py
+++ b/tests/test_adapter_contract.py
@@ -1,0 +1,209 @@
+"""
+Failing tests for the run_case adapter contract — issue #126.
+
+Target interface (post-implementation):
+    run_case(spec: LoadedSpec) -> ActualResult
+
+All tests in this file MUST fail before implementation and pass after.
+
+Failure modes before implementation:
+- eval/error tests: AttributeError — hosts.python.adapter.run_eval_subprocess not yet imported
+- parse tests: AttributeError — hosts.python.adapter.parse_and_normalize not yet imported
+- ir/cli/flow return-type tests: isinstance(result, ActualResult) fails — old code returns dict
+- unsupported-category test: passes both before and after (contract already correct)
+"""
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.spec_runner.loader import LoadedSpec
+from tools.spec_runner.executor import ActualResult
+from hosts.python.adapter import run_case
+
+
+def _spec(category, source="x", **kwargs):
+    defaults = dict(
+        name="test",
+        category=category,
+        source=source,
+        stdin="",
+        expected_stdout=None,
+        expected_stderr=None,
+        expected_exit_code=None,
+        expected_ir=None,
+        path=Path("/fake/test.yaml"),
+        command=None,
+        file=None,
+        argv=[],
+        debug_stdio=False,
+    )
+    defaults.update(kwargs)
+    return LoadedSpec(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# eval
+# ---------------------------------------------------------------------------
+
+def test_run_case_eval_returns_actual_result():
+    with patch("hosts.python.adapter.run_eval_subprocess") as m:
+        m.return_value = {"stdout": "hello\n", "stderr": "", "exit_code": 0}
+        result = run_case(_spec("eval", source="print('hello')"))
+    assert isinstance(result, ActualResult)
+
+
+def test_run_case_eval_fields():
+    with patch("hosts.python.adapter.run_eval_subprocess") as m:
+        m.return_value = {"stdout": "hello\n", "stderr": "", "exit_code": 0}
+        result = run_case(_spec("eval", source="print('hello')"))
+    assert result.stdout == "hello\n"
+    assert result.stderr == ""
+    assert result.exit_code == 0
+
+
+def test_run_case_eval_no_trailing_newline_strip():
+    with patch("hosts.python.adapter.run_eval_subprocess") as m:
+        m.return_value = {"stdout": "hello\n", "stderr": "warn\n", "exit_code": 0}
+        result = run_case(_spec("eval", source="print('hello')"))
+    assert result.stdout == "hello\n", "eval must not strip trailing newlines from stdout"
+    assert result.stderr == "warn\n", "eval must not strip trailing newlines from stderr"
+
+
+# ---------------------------------------------------------------------------
+# error (uses eval path)
+# ---------------------------------------------------------------------------
+
+def test_run_case_error_returns_actual_result():
+    with patch("hosts.python.adapter.run_eval_subprocess") as m:
+        m.return_value = {"stdout": "", "stderr": "ZeroDivisionError\n", "exit_code": 1}
+        result = run_case(_spec("error", source="1/0"))
+    assert isinstance(result, ActualResult)
+
+
+def test_run_case_error_uses_eval_path_no_strip():
+    with patch("hosts.python.adapter.run_eval_subprocess") as m:
+        m.return_value = {"stdout": "", "stderr": "err\n", "exit_code": 1}
+        result = run_case(_spec("error", source="1/0"))
+    assert result.stderr == "err\n", "error must not strip trailing newlines from stderr"
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# cli
+# ---------------------------------------------------------------------------
+
+def test_run_case_cli_returns_actual_result():
+    with patch("hosts.python.adapter.exec_cli") as m:
+        m.return_value = {"stdout": "hello\n", "stderr": "", "exit_code": 0}
+        result = run_case(_spec("cli", source="print('hello')", command="print('hello')", stdin="", argv=[]))
+    assert isinstance(result, ActualResult)
+
+
+def test_run_case_cli_strips_trailing_newlines():
+    with patch("hosts.python.adapter.exec_cli") as m:
+        m.return_value = {"stdout": "hello\n\n", "stderr": "\n", "exit_code": 0}
+        result = run_case(_spec("cli", source="print('hello')", command="print('hello')", stdin="", argv=[]))
+    assert result.stdout == "hello", "cli must strip trailing newlines from stdout"
+    assert result.stderr == "", "cli must strip trailing newlines from stderr"
+
+
+def test_run_case_cli_crlf_normalized_then_stripped():
+    with patch("hosts.python.adapter.exec_cli") as m:
+        m.return_value = {"stdout": "hello\r\n", "stderr": "warn\r\n", "exit_code": 0}
+        result = run_case(_spec("cli", source="print('hello')", command="print('hello')", stdin="", argv=[]))
+    assert result.stdout == "hello", "cli must normalize CRLF then strip trailing newlines"
+    assert result.stderr == "warn", "cli must normalize CRLF then strip trailing newlines from stderr"
+
+
+# ---------------------------------------------------------------------------
+# flow
+# ---------------------------------------------------------------------------
+
+def test_run_case_flow_returns_actual_result():
+    with patch("hosts.python.adapter.exec_flow") as m:
+        m.return_value = {"stdout": "line\n", "stderr": "", "exit_code": 0}
+        result = run_case(_spec("flow", source="stdin |> lines |> each(print) |> run"))
+    assert isinstance(result, ActualResult)
+
+
+def test_run_case_flow_no_trailing_newline_strip():
+    with patch("hosts.python.adapter.exec_flow") as m:
+        m.return_value = {"stdout": "line\n", "stderr": "warn\n", "exit_code": 0}
+        result = run_case(_spec("flow", source="stdin |> lines |> each(print) |> run"))
+    assert result.stdout == "line\n", "flow must not strip trailing newlines from stdout"
+    assert result.stderr == "warn\n", "flow must not strip trailing newlines from stderr"
+    assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# ir
+# ---------------------------------------------------------------------------
+
+def test_run_case_ir_returns_actual_result():
+    ir_val = [{"kind": "Int", "value": 1}]
+    with patch("hosts.python.adapter.exec_ir") as m:
+        m.return_value = {"ir": ir_val}
+        result = run_case(_spec("ir", source="1"))
+    assert isinstance(result, ActualResult)
+
+
+def test_run_case_ir_provides_ir_field():
+    ir_val = [{"kind": "Int", "value": 1}]
+    with patch("hosts.python.adapter.exec_ir") as m:
+        m.return_value = {"ir": ir_val}
+        result = run_case(_spec("ir", source="1"))
+    assert result.ir == ir_val
+    assert result.stdout is None
+    assert result.stderr is None
+
+
+# ---------------------------------------------------------------------------
+# parse
+# ---------------------------------------------------------------------------
+
+def test_run_case_parse_ok_returns_actual_result():
+    parse_val = {"kind": "ok", "ast": {"type": "Int", "value": 1}}
+    with patch("hosts.python.adapter.parse_and_normalize") as m:
+        m.return_value = parse_val
+        result = run_case(_spec("parse", source="1"))
+    assert isinstance(result, ActualResult)
+
+
+def test_run_case_parse_ok_provides_parse_field():
+    parse_val = {"kind": "ok", "ast": {"type": "Int", "value": 1}}
+    with patch("hosts.python.adapter.parse_and_normalize") as m:
+        m.return_value = parse_val
+        result = run_case(_spec("parse", source="1"))
+    assert result.parse == parse_val
+    assert result.stdout is None
+
+
+def test_run_case_parse_error_provides_parse_field():
+    parse_val = {"kind": "error", "type": "ParseError", "message": "unexpected EOF"}
+    with patch("hosts.python.adapter.parse_and_normalize") as m:
+        m.return_value = parse_val
+        result = run_case(_spec("parse", source="("))
+    assert isinstance(result, ActualResult)
+    assert result.parse["kind"] == "error"
+    assert result.parse["type"] == "ParseError"
+    assert isinstance(result.parse["message"], str)
+
+
+# ---------------------------------------------------------------------------
+# unsupported category
+# ---------------------------------------------------------------------------
+
+def test_run_case_unsupported_category_raises():
+    with pytest.raises((ValueError, KeyError, TypeError)):
+        run_case(_spec("unknown_category"))
+
+
+# ---------------------------------------------------------------------------
+# adapter must not inspect expected fields
+# ---------------------------------------------------------------------------
+
+def test_run_case_does_not_require_expected_fields():
+    with patch("hosts.python.adapter.run_eval_subprocess") as m:
+        m.return_value = {"stdout": "2\n", "stderr": "", "exit_code": 0}
+        result = run_case(_spec("eval", source="1+1"))
+    assert result.exit_code == 0

--- a/tests/test_cli_shared_spec_runner.py
+++ b/tests/test_cli_shared_spec_runner.py
@@ -274,7 +274,7 @@ def test_execute_spec_normalizes_cli_line_endings_and_trailing_newlines(monkeypa
     def fake_exec_cli(_spec: LoadedSpec) -> dict[str, object]:
         return {"stdout": "a\r\nb\n\n", "stderr": "err\r\n\n", "exit_code": 0}
 
-    monkeypatch.setattr("tools.spec_runner.executor.exec_cli", fake_exec_cli)
+    monkeypatch.setattr("hosts.python.adapter.exec_cli", fake_exec_cli)
     spec = _loaded_cli_spec(command="print 1")
 
     actual = execute_spec(spec)
@@ -286,7 +286,7 @@ def test_execute_spec_preserves_internal_cli_whitespace(monkeypatch) -> None:
     def fake_exec_cli(_spec: LoadedSpec) -> dict[str, object]:
         return {"stdout": "a  b\tc\n", "stderr": "x  y\n", "exit_code": 0}
 
-    monkeypatch.setattr("tools.spec_runner.executor.exec_cli", fake_exec_cli)
+    monkeypatch.setattr("hosts.python.adapter.exec_cli", fake_exec_cli)
     spec = _loaded_cli_spec(command="print 1")
 
     actual = execute_spec(spec)

--- a/tests/test_flow_shared_spec_runner.py
+++ b/tests/test_flow_shared_spec_runner.py
@@ -58,7 +58,7 @@ def test_execute_spec_normalizes_flow_line_endings_like_eval(monkeypatch) -> Non
     def fake_exec_flow(_spec: LoadedSpec) -> dict[str, object]:
         return {"stdout": "a\r\nb\n", "stderr": "err\r\n", "exit_code": 0}
 
-    monkeypatch.setattr("tools.spec_runner.executor.exec_flow", fake_exec_flow)
+    monkeypatch.setattr("hosts.python.adapter.exec_flow", fake_exec_flow)
     spec = load_spec(FLOW_DIR / "stdin-lines-collect-basic.yaml")
 
     actual = execute_spec(spec)

--- a/tests/test_python_host_adapter.py
+++ b/tests/test_python_host_adapter.py
@@ -1,83 +1,12 @@
 """
-Comprehensive tests for Genia Python host adapter contract.
-Covers: all contract categories, normalization, comparator, drift detection.
+Tests for Genia Python host adapter — comparator and drift-detection coverage.
+Category-contract tests live in tests/test_adapter_contract.py (issue #126).
 """
 import pytest
-from hosts.python.adapter import run_case, SpecCase
-from hosts.python.normalize import normalize_result
 
-# --- Category Coverage ---
-@pytest.mark.parametrize("category,input_data", [
-    ("parse", "x = 1"),
-    ("ir", "x = 1"),
-    ("eval", "1 + 2"),
-    (
-        "cli",
-        {
-            "source": "1+2",
-            "file": None,
-            "command": "1+2",
-            "stdin": "",
-            "argv": [],
-            "debug_stdio": False,
-        },
-    ),
-    ("flow", "stdin |> lines |> each(print) |> run"),
-    ("error", "1 / 0"),
-])
-def test_run_case_contract_categories(category, input_data):
-    case = SpecCase(
-        id=f"contract-{category}",
-        category=category,
-        input=input_data,
-        args=None,
-        stdin=None,
-        expected=None,
-    )
-    result = run_case(case)
-    # All contract results must have these fields
-    for key in ["stdout", "stderr", "exit_code", "success"]:
-        assert key in result, f"Missing {key} in {category} result"
-
-# --- Normalization Layer ---
-def test_normalization_no_python_leak():
-    # Simulate a raw result with Python artifacts
-    raw = {"stdout": "", "stderr": "", "exit_code": 0, "result": {"a": object()}}
-    norm = normalize_result(raw, SpecCase(id="noleak", category="eval", input="1", args=None, stdin=None, expected=None))
-    # Should not leak Python reprs
-    def no_leak(val):
-        if isinstance(val, dict):
-            for k, v in val.items():
-                assert "<class" not in str(k) and "<class" not in str(v)
-                no_leak(v)
-        elif isinstance(val, list):
-            for v in val:
-                no_leak(v)
-        elif isinstance(val, str):
-            assert not val.startswith("<class")
-    no_leak(norm)
-
-def test_normalization_canonical_types():
-    # Canonicalize numbers, strings, bools, lists, dicts, options
-    canonical = [42, 3.14, "foo", True, False, [], {}, {"some": 1}, {"none": None}]
-    for val in canonical:
-        raw = {"stdout": "", "stderr": "", "exit_code": 0, "result": val}
-        norm = normalize_result(raw, SpecCase(id="canon", category="eval", input="1", args=None, stdin=None, expected=None))
-        # Should round-trip
-        assert norm["result"] == val
-
-def test_normalization_newline_and_ordering():
-    # Newlines normalized, dict ordering canonical
-    raw1 = {"stdout": "foo\n", "stderr": "", "exit_code": 0, "result": {"a": 1, "b": 2}}
-    raw2 = {"stdout": "foo\r\n", "stderr": "", "exit_code": 0, "result": {"b": 2, "a": 1}}
-    norm1 = normalize_result(raw1, SpecCase(id="nl", category="eval", input="1", args=None, stdin=None, expected=None))
-    norm2 = normalize_result(raw2, SpecCase(id="nl", category="eval", input="1", args=None, stdin=None, expected=None))
-    # Newlines should be normalized (simulate)
-    assert norm1["stdout"].replace("\r\n", "\n") == norm2["stdout"].replace("\r\n", "\n")
-    # Dict ordering should not affect equality
-    assert sorted(norm1["result"].items()) == sorted(norm2["result"].items())
 
 # --- Comparator Strictness ---
+
 def compare_results(a, b):
     assert set(a.keys()) == set(b.keys()), f"Field mismatch: {a.keys()} vs {b.keys()}"
     for k in a:
@@ -101,24 +30,24 @@ def test_comparator_partial_match_fails():
     with pytest.raises(AssertionError):
         compare_results(a, d)
 
+
 # --- Drift Detection ---
+
 def test_normalization_drift_detection():
-    # Simulate normalization drift (newlines)
     a = {"result": 1, "stdout": "foo\n"}
     b = {"result": 1, "stdout": "foo\r\n"}
     with pytest.raises(AssertionError):
         assert a["stdout"] == b["stdout"], "Normalization drift: newlines differ"
 
 def test_ordering_drift_detection():
-    # Simulate ordering drift
     a = {"result": {"a": 1, "b": 2}}
     b = {"result": {"b": 2, "a": 1}}
-    # Canonicalize for comparison
     assert sorted(a["result"].items()) == sorted(b["result"].items())
 
-# --- Doc/Test Sync Minimal Assertion ---
+
+# --- Doc/Test Sync ---
+
 def test_doc_sync_mentions_genia_state_and_rules():
-    # Ensure GENIA_STATE.md and GENIA_RULES.md are referenced in AGENTS.md
     with open("AGENTS.md", encoding="utf-8") as f:
         text = f.read()
     assert "GENIA_STATE.md" in text

--- a/tools/spec_runner/README.md
+++ b/tools/spec_runner/README.md
@@ -40,7 +40,7 @@ Verbose mode prints each spec name before execution starts, then prints a timing
 ## How it works
 
 - Cases are loaded from `spec/eval/*.yaml`, `spec/cli/*.yaml`, `spec/ir/*.yaml`, `spec/flow/*.yaml`, `spec/error/*.yaml`, and `spec/parse/*.yaml`
-- Each case is executed independently against the Python reference host
+- Each case is executed independently against the Python reference host via `execute_spec` in `tools/spec_runner/executor.py`, which delegates to `hosts/python/adapter.py::run_case`
 - CLI cases are executed through the Python host adapter
 - Flow cases are executed through command-source execution in the Python host adapter; the runner does not route Flow cases through CLI pipe mode
 - Error cases reuse the eval execution path; there is no separate error subprocess or error-specific execution path

--- a/tools/spec_runner/executor.py
+++ b/tools/spec_runner/executor.py
@@ -1,13 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from types import SimpleNamespace
-
-from hosts.python import parse_and_normalize
-from hosts.python.exec_cli import exec_cli
-from hosts.python.exec_eval import run_eval_subprocess
-from hosts.python.exec_flow import exec_flow
-from hosts.python.exec_ir import exec_ir
 
 from .loader import LoadedSpec
 
@@ -21,42 +14,6 @@ class ActualResult:
     parse: object | None = None
 
 
-def _normalize_text(text: str) -> str:
-    return text.replace("\r\n", "\n").replace("\r", "\n")
-
-
-def _strip_trailing_newlines(text: str) -> str:
-    return text.rstrip("\n")
-
-
 def execute_spec(spec: LoadedSpec) -> ActualResult:
-    if spec.category == "parse":
-        result = parse_and_normalize(spec.source)
-        return ActualResult(parse=result)
-
-    if spec.category == "ir":
-        result = exec_ir(SimpleNamespace(input={"source": spec.source}, stdin=None))
-        return ActualResult(ir=result["ir"])
-
-    if spec.category == "cli":
-        result = exec_cli(spec)
-        return ActualResult(
-            stdout=_strip_trailing_newlines(_normalize_text(result["stdout"])),
-            stderr=_strip_trailing_newlines(_normalize_text(result["stderr"])),
-            exit_code=result["exit_code"],
-        )
-
-    if spec.category == "flow":
-        result = exec_flow(spec)
-        return ActualResult(
-            stdout=_normalize_text(result["stdout"]),
-            stderr=_normalize_text(result["stderr"]),
-            exit_code=result["exit_code"],
-        )
-
-    result = run_eval_subprocess(spec.source, spec.stdin or None)
-    return ActualResult(
-        stdout=_normalize_text(result["stdout"]),
-        stderr=_normalize_text(result["stderr"]),
-        exit_code=result["exit_code"],
-    )
+    from hosts.python.adapter import run_case
+    return run_case(spec)


### PR DESCRIPTION
#126 

This pull request finalizes the alignment of the Python host adapter contract by replacing the old scaffold with a minimal, spec-compliant `run_case` interface. The implementation, documentation, and tests are thoroughly audited to ensure the adapter now accepts a `LoadedSpec` and returns an `ActualResult`, with correct normalization and category handling. All references to the deprecated `SpecCase` and `SpecResult` are removed from both code and authoritative documentation.

**Key changes by theme:**

#### Adapter Contract Redesign
* The Python host adapter (`hosts/python/adapter.py`) now exposes `run_case(spec: LoadedSpec) -> ActualResult` as the canonical entrypoint, with all dispatch and normalization logic consolidated here. Deprecated types (`SpecCase`, `SpecResult`) and the old normalization function are removed. Category dispatch raises immediately for unknown categories, per spec. [[1]](diffhunk://#diff-1885f503d03e9ab3bf56f0fd48e299a2da34aad58c439b049ba01fca0d663fadR1-R192) [[2]](diffhunk://#diff-041d81bfc19399164c88da8ea6d112d639a3ca461af51046174474f0147e6a24R1-R250)

#### Codebase Simplification & Refactoring
* The normalization helpers are refactored: `normalize_text` and `strip_trailing_newlines` are now public helpers in `hosts/python/normalize.py`, replacing prior private or duplicated implementations. The adapter and executor import these helpers.
* The spec runner's `execute_spec` function (`tools/spec_runner/executor.py`) is simplified to a thin wrapper that delegates directly to `run_case`. Local normalization helpers are removed, and `ActualResult` remains the canonical result type.

#### Documentation & Audit
* All relevant documentation (`GENIA_STATE.md`, `HOST_INTEROP.md`, and `tools/spec_runner/README.md`) is updated to reflect the new adapter contract, entrypoint, and normalization details. No authoritative doc contains stale references to old types or behavior. [[1]](diffhunk://#diff-865cff63a4bb7e67f17086ab8b6cb9e9559a7508e0daf95234604eb450418abcL166-R167) [[2]](diffhunk://#diff-1885f503d03e9ab3bf56f0fd48e299a2da34aad58c439b049ba01fca0d663fadR1-R192) [[3]](diffhunk://#diff-041d81bfc19399164c88da8ea6d112d639a3ca461af51046174474f0147e6a24R1-R250)
* An extensive audit document (`docs/architecture/issue-126-run-case-contract-audit.md`) verifies implementation, design, tests, and documentation are all aligned and spec-compliant. All tests and shared spec cases pass.

#### Design Documentation
* A design document (`docs/architecture/issue-126-run-case-contract-design.md`) records the rationale for the approach, the removal of scaffolding, and the resulting integration boundaries and file changes.

All changes are minimal, necessary, and thoroughly validated. No blocking issues remain.