### PR TITLE
Docs/host capability registry contract

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -42,6 +42,7 @@ Implemented today:
   - `spec/`
   - `tools/spec_runner/README.md`
   - `hosts/`
+- A formal host capability registry contract is documented at `docs/host-interop/capabilities.md`. It is the authoritative reference for capability names, Genia surface, input/output shapes, normalized error behavior, and portability status for each host capability.
 
 Scaffolded or planned, not implemented as hosts:
 

--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ Truthful status:
 
 Related shared portability docs:
 
+- docs/host-interop/capabilities.md
 - docs/host-interop/HOST_INTEROP.md
 - docs/host-interop/HOST_PORTING_GUIDE.md
 - docs/host-interop/HOST_CAPABILITY_MATRIX.md

--- a/docs/host-interop/HOST_CAPABILITY_MATRIX.md
+++ b/docs/host-interop/HOST_CAPABILITY_MATRIX.md
@@ -11,6 +11,8 @@ Python is the only implemented host today.
 All other hosts below are placeholders for planned work.
 `hosts/python/` is also a placeholder directory for the future monorepo layout; the live Python implementation remains in `src/genia/`.
 
+For the formal per-capability contract (name, Genia surface, input/output shapes, normalized error behavior, and portability status), see `capabilities.md`.
+
 Browser playground adapter note:
 
 - documentation scaffold exists under `docs/browser/`

--- a/docs/host-interop/README.md
+++ b/docs/host-interop/README.md
@@ -10,6 +10,7 @@ Current status in this phase:
 
 Start here:
 
+- `capabilities.md` for the formal per-capability contract (name, Genia surface, input, output, errors, portability status)
 - `HOST_INTEROP.md` for the cross-host semantic contract
 - `HOST_PORTING_GUIDE.md` for the practical checklist when adding a host
 - `HOST_CAPABILITY_MATRIX.md` for current/planned host capability status

--- a/docs/host-interop/capabilities.md
+++ b/docs/host-interop/capabilities.md
@@ -42,7 +42,7 @@ Capabilities connecting Genia programs to the host I/O streams. These are `langu
 - **input:** any display-formattable Genia value
 - **output:** `none("nil")` (side effect: text written to host stderr stream)
 - **errors:**
-  - broken pipe on stderr is handled best-effort without recursive noisy failures
+  - none raised — broken pipe on stderr is absorbed best-effort without recursive noisy failures
 - **portability:** `language contract`
 - **notes:** `log(value)` writes display-formatted output plus a trailing newline to stderr. REPL diagnostics and command/file diagnostics go to stderr.
 

--- a/docs/host-interop/capabilities.md
+++ b/docs/host-interop/capabilities.md
@@ -1,0 +1,366 @@
+# Host Capability Registry Contract
+
+**Status:** Partial — Python is the reference host. Future hosts are planned or scaffolded only. This registry documents capabilities that are implemented in the Python reference host. No other host is implemented in the current phase.
+
+This document is the authoritative reference for host capability names, Genia surface, input/output shapes, normalized error behavior, and portability status for each host capability.
+
+A host capability is a named, host-backed service exposed to Genia programs through the runtime substrate — not through language semantics or Core IR. Adding, removing, or renaming a capability requires updating this document, `HOST_CAPABILITY_MATRIX.md`, `GENIA_STATE.md`, and relevant tests.
+
+---
+
+## Portability Status Terms
+
+| Term | Meaning |
+|---|---|
+| `language contract` | All hosts must implement this capability. It is part of the shared portable contract. |
+| `Python-host-only` | Implemented in the Python reference host only. Not part of the shared portable contract. Future hosts may implement it. |
+| `not implemented` | Not implemented in any host in the current phase. |
+
+---
+
+## Capability Groups
+
+### Group: I/O Substrate
+
+Capabilities connecting Genia programs to the host I/O streams. These are `language contract` capabilities — all hosts must provide them.
+
+#### `io.stdout`
+
+- **name:** `io.stdout`
+- **genia_surface:** `stdout` (runtime value), `print(value)`, `write(stdout, value)`, `writeln(stdout, value)`, `flush(stdout)`
+- **input:** any display-formattable Genia value
+- **output:** `none("nil")` (side effect: text written to host stdout stream)
+- **errors:**
+  - `RuntimeError` — broken pipe in file/command/pipe execution mode; treated as normal downstream termination, not surfaced as a traceback
+- **portability:** `language contract`
+- **notes:** `stdout` is a first-class runtime capability value, not a string. `print(value)` writes display-formatted output plus a trailing newline. Flow-driven stdout writes use the same quiet broken-pipe path.
+
+#### `io.stderr`
+
+- **name:** `io.stderr`
+- **genia_surface:** `stderr` (runtime value), `log(value)`, `write(stderr, value)`, `writeln(stderr, value)`, `flush(stderr)`
+- **input:** any display-formattable Genia value
+- **output:** `none("nil")` (side effect: text written to host stderr stream)
+- **errors:**
+  - broken pipe on stderr is handled best-effort without recursive noisy failures
+- **portability:** `language contract`
+- **notes:** `log(value)` writes display-formatted output plus a trailing newline to stderr. REPL diagnostics and command/file diagnostics go to stderr.
+
+#### `io.stdin`
+
+- **name:** `io.stdin`
+- **genia_surface:** `stdin` (runtime value), used as a Flow source via `stdin |> lines`
+- **input:** none (stdin is a source, not a sink)
+- **output:** `Flow` — lazy, pull-based, single-use sequence of string lines when used via `stdin |> lines`
+- **errors:**
+  - `RuntimeError("Flow has already been consumed")` — on second consumption of the same stdin flow
+- **portability:** `language contract`
+- **notes:** Binding `stdin` into a flow must not force a full stdin read up front. `stdin()` (call form) returns a cached list of full stdin lines and is a separate compatibility surface. The primary source behavior is `stdin |> lines`.
+
+---
+
+### Group: Time / Sleep
+
+#### `time.sleep`
+
+- **name:** `time.sleep`
+- **genia_surface:** `sleep(ms)`
+- **input:** `ms` — Number (non-negative)
+- **output:** `none("nil")` (side effect: host thread blocks for `ms` milliseconds)
+- **errors:**
+  - `TypeError` — when `ms` is not numeric
+  - `ValueError` — when `ms < 0`
+- **portability:** `Python-host-only`
+- **notes:** Blocking primitive only. Does not introduce a scheduler, async/await surface, or event loop.
+
+---
+
+### Group: Randomness
+
+Explicit seeded randomness is state-threaded and deterministic; the same seed yields the same sequence on the Python reference host. Convenience forms use the host RNG and are not deterministic.
+
+#### `random.rng`
+
+- **name:** `random.rng`
+- **genia_surface:** `rng(seed)`
+- **input:** `seed` — Number (non-negative integer)
+- **output:** opaque RNG state value
+- **errors:**
+  - `TypeError` — when `seed` is not an integer
+  - `ValueError` — when `seed < 0`
+- **portability:** `Python-host-only`
+- **notes:** The same seed must yield the same sequence. The Python reference host uses a fixed 32-bit LCG. The opaque RNG state value is not a plain Genia data type and must not be inspected directly.
+
+#### `random.rand`
+
+- **name:** `random.rand`
+- **genia_surface:** `rand()`
+- **input:** none
+- **output:** Number (float in `[0, 1)`)
+- **errors:** none defined
+- **portability:** `Python-host-only`
+- **notes:** Uses host RNG; sequence is not deterministic. Convenience form only.
+
+#### `random.rand-int`
+
+- **name:** `random.rand-int`
+- **genia_surface:** `rand_int(n)`
+- **input:** `n` — Number (positive integer)
+- **output:** Number (integer in `[0, n)`)
+- **errors:**
+  - `TypeError` — when `n` is not an integer
+  - `ValueError` — when `n <= 0`
+- **portability:** `Python-host-only`
+- **notes:** Uses host RNG; sequence is not deterministic. Convenience form only.
+
+#### `random.rand-seeded`
+
+- **name:** `random.rand-seeded`
+- **genia_surface:** `rand(rng_state)`
+- **input:** `rng_state` — opaque RNG state value (from `rng(seed)` or a prior `rand(rng_state)` call)
+- **output:** List — `[next_rng_state, float]` where float is in `[0, 1)`
+- **errors:**
+  - `TypeError` — when `rng_state` is not a valid RNG state value
+- **portability:** `Python-host-only`
+- **notes:** Deterministic and state-threaded. The same state must always produce the same next state and the same float value.
+
+#### `random.rand-int-seeded`
+
+- **name:** `random.rand-int-seeded`
+- **genia_surface:** `rand_int(rng_state, n)`
+- **input:** `rng_state` — opaque RNG state value; `n` — Number (positive integer)
+- **output:** List — `[next_rng_state, int]` where int is in `[0, n)`
+- **errors:**
+  - `TypeError` — when `rng_state` is not a valid RNG state value
+  - `TypeError` — when `n` is not an integer
+  - `ValueError` — when `n <= 0`
+- **portability:** `Python-host-only`
+- **notes:** Deterministic and state-threaded. Uses the same LCG sequence as `random.rand-seeded`.
+
+---
+
+### Group: HTTP Serving
+
+#### `http.serve`
+
+- **name:** `http.serve`
+- **genia_surface:** `import web` then `web/serve_http(config, handler)`
+- **input:** `config` — Map; `handler` — Function with shape `(request_map) -> response_map`
+- **output:** none (blocking; does not return while server is running)
+- **errors:**
+  - invalid handler return value is normalized to a `500 internal server error` response (not a language-level error)
+- **portability:** `Python-host-only`
+- **notes:** Synchronous and blocking only. Request map fields: `method`, `path`, `query`, `headers`, `body`, `raw_body`, `client`. Response map fields: `status`, `headers`, `body`. Current limitations: exact-path routing only, no middleware, no path params, no streaming request/response bodies, no websockets, no async support. Higher-level routing helpers (`get`, `post`, `route_request`, `ok_text`, `json`) are prelude-backed wrappers.
+
+---
+
+### Group: Process / Mailbox
+
+Host-backed concurrency substrate. Processes are fail-stop: handler exceptions cache an error string, exit the worker, and cause future `send` calls to raise.
+
+#### `process.spawn`
+
+- **name:** `process.spawn`
+- **genia_surface:** `spawn(handler)`
+- **input:** `handler` — Function (receives messages sent to the process)
+- **output:** opaque Process handle value
+- **errors:**
+  - `TypeError` — when `handler` is not callable
+- **portability:** `Python-host-only`
+- **notes:** Creates a host-thread worker with a FIFO mailbox. One handler invocation runs at a time per process.
+
+#### `process.send`
+
+- **name:** `process.send`
+- **genia_surface:** `send(process, message)`
+- **input:** `process` — Process handle value; `message` — any Genia value
+- **output:** `none("nil")` (side effect: message enqueued in process mailbox)
+- **errors:**
+  - `RuntimeError` — when the target process has already failed
+- **portability:** `Python-host-only`
+- **notes:** Mailbox is FIFO per process. Messages are delivered in the order sent.
+
+#### `process.alive`
+
+- **name:** `process.alive`
+- **genia_surface:** `process_alive?(process)`
+- **input:** `process` — Process handle value
+- **output:** Boolean
+- **errors:** none defined
+- **portability:** `Python-host-only`
+
+#### `process.failed`
+
+- **name:** `process.failed`
+- **genia_surface:** `process_failed?(process)`
+- **input:** `process` — Process handle value
+- **output:** Boolean
+- **errors:** none defined
+- **portability:** `Python-host-only`
+
+#### `process.error`
+
+- **name:** `process.error`
+- **genia_surface:** `process_error(process)`
+- **input:** `process` — Process handle value
+- **output:** `some(error_string)` when the process has failed; `none("nil")` otherwise
+- **errors:** none defined
+- **portability:** `Python-host-only`
+
+---
+
+### Group: Refs / Cells
+
+Host-backed synchronized state substrate.
+
+#### `ref.create`
+
+- **name:** `ref.create`
+- **genia_surface:** `ref(initial_value)`
+- **input:** `initial_value` — any Genia value
+- **output:** opaque Ref value
+- **errors:** none defined
+- **portability:** `Python-host-only`
+- **notes:** Refs are synchronized host objects. The opaque Ref value is not a plain Genia data type.
+
+#### `ref.get`
+
+- **name:** `ref.get`
+- **genia_surface:** `ref_get(ref_value)`
+- **input:** `ref_value` — Ref value
+- **output:** the current stored Genia value
+- **errors:**
+  - `TypeError` — when the argument is not a Ref value
+- **portability:** `Python-host-only`
+
+#### `ref.set`
+
+- **name:** `ref.set`
+- **genia_surface:** `ref_set(ref_value, new_value)`
+- **input:** `ref_value` — Ref value; `new_value` — any Genia value
+- **output:** `none("nil")` (side effect: stored value updated)
+- **errors:**
+  - `TypeError` — when the first argument is not a Ref value
+- **portability:** `Python-host-only`
+
+#### `ref.update`
+
+- **name:** `ref.update`
+- **genia_surface:** `ref_update(ref_value, f)`
+- **input:** `ref_value` — Ref value; `f` — Function with shape `(current_value) -> new_value`
+- **output:** `none("nil")` (side effect: stored value replaced by `f(current_value)`)
+- **errors:**
+  - `TypeError` — when the first argument is not a Ref value
+  - `TypeError` — when `f` is not callable
+- **portability:** `Python-host-only`
+
+#### `cell.create`
+
+- **name:** `cell.create`
+- **genia_surface:** `cell(initial_state)`, `cell_with_state(ref_value)`
+- **input:** `initial_state` — any Genia value (for `cell`); `ref_value` — Ref value (for `cell_with_state`)
+- **output:** opaque Cell value
+- **errors:** none defined
+- **portability:** `Python-host-only`
+- **notes:** Cells queue asynchronous updates serialized one at a time. Cells are fail-stop: failed updates preserve the last successful state, cache an error string, and mark the cell failed.
+
+#### `cell.send`
+
+- **name:** `cell.send`
+- **genia_surface:** `cell_send(cell, update_fn)`
+- **input:** `cell` — Cell value; `update_fn` — Function with shape `(current_state) -> next_state`
+- **output:** `none("nil")` (update is asynchronous; side effect: update enqueued)
+- **errors:**
+  - `RuntimeError` — when the cell has already failed
+- **portability:** `Python-host-only`
+- **notes:** Failed updates preserve the last successful state. Nested `cell_send` calls issued during an update are staged and committed only if that update succeeds.
+
+#### `cell.get`
+
+- **name:** `cell.get`
+- **genia_surface:** `cell_get(cell)`, `cell_state(cell)`
+- **input:** `cell` — Cell value
+- **output:** the last successful state Genia value
+- **errors:**
+  - `RuntimeError` — when the cell has already failed
+- **portability:** `Python-host-only`
+
+#### `cell.restart`
+
+- **name:** `cell.restart`
+- **genia_surface:** `restart_cell(cell, new_state)`
+- **input:** `cell` — Cell value; `new_state` — any Genia value
+- **output:** `none("nil")` (side effect: failure cleared, state replaced, queued pre-restart updates discarded)
+- **errors:** none defined
+- **portability:** `Python-host-only`
+
+---
+
+### Group: Bytes / JSON / ZIP Bridge
+
+Host-backed bridge for binary data, JSON serialization, and ZIP archive access.
+
+#### `bytes.utf8-encode`
+
+- **name:** `bytes.utf8-encode`
+- **genia_surface:** `utf8_encode(string)`
+- **input:** String
+- **output:** opaque Bytes wrapper value
+- **errors:**
+  - `TypeError` — when the argument is not a String
+- **portability:** `Python-host-only`
+- **notes:** The opaque Bytes wrapper value is not a plain Genia data type (not a list or string).
+
+#### `bytes.utf8-decode`
+
+- **name:** `bytes.utf8-decode`
+- **genia_surface:** `utf8_decode(bytes)`
+- **input:** opaque Bytes wrapper value
+- **output:** String
+- **errors:**
+  - `ValueError` — for invalid UTF-8 byte sequences
+  - `TypeError` — when the argument is not a Bytes wrapper value
+- **portability:** `Python-host-only`
+
+#### `json.parse`
+
+- **name:** `json.parse`
+- **genia_surface:** `json_parse(string)`
+- **input:** String
+- **output:** parsed Genia value on success; `none("json-parse-error", context)` on failure (structured absence — not a raised exception)
+- **errors:** none raised — parse failures return `none("json-parse-error", context)` as structured absence
+- **portability:** `Python-host-only`
+- **notes:** JSON objects become runtime Map values (same family as `map_new`/`map_put`). Failures are returned as structured absence, not exceptions.
+
+#### `json.stringify`
+
+- **name:** `json.stringify`
+- **genia_surface:** `json_stringify(value)`, `json_pretty(value)` (compatibility alias)
+- **input:** any Genia value representable as JSON (Number, String, Boolean, List, Map, `none("nil")`)
+- **output:** String on success; `none("json-stringify-error", context)` on failure (structured absence — not a raised exception)
+- **errors:** none raised — stringify failures return `none("json-stringify-error", context)` as structured absence
+- **portability:** `Python-host-only`
+- **notes:** Current output format uses 2-space indentation and sorted keys. `json_pretty` is a compatibility alias for `json_stringify`.
+
+#### `zip.entries`
+
+- **name:** `zip.entries`
+- **genia_surface:** `zip_entries(path)`
+- **input:** String (file path)
+- **output:** List of opaque Zip entry wrapper values (in archive order; eager list, not a lazy Flow)
+- **errors:**
+  - `FileNotFoundError` — when `path` does not exist or is not accessible
+- **portability:** `Python-host-only`
+- **notes:** Each entry is an opaque Zip entry wrapper value. Entry accessors: `entry_name`, `entry_bytes`, `set_entry_bytes`, `update_entry_bytes`, `entry_json`. Returns an eager list in the current phase.
+
+#### `zip.write`
+
+- **name:** `zip.write`
+- **genia_surface:** `zip_write(entries, path)`, `zip_write(path, entries)` (pipeline-friendly form)
+- **input:** List of opaque Zip entry wrapper values; String (output file path)
+- **output:** String (the output path written)
+- **errors:**
+  - `TypeError` — when entries is not a list of Zip entry wrapper values
+  - `RuntimeError` — on write failure (e.g., permission denied or disk error)
+- **portability:** `Python-host-only`
+- **notes:** Preserves entry order. Accepts both argument orderings for pipeline compatibility with `|>`.

--- a/docs/host-interop/capability-registry-design.md
+++ b/docs/host-interop/capability-registry-design.md
@@ -1,0 +1,295 @@
+# Design: Host Capability Registry Contract
+# Issue #118 — Design Phase
+
+**Branch:** docs/host-capability-registry-contract
+**Spec:** docs/host-interop/capability-registry-spec.md
+**Authority:** GENIA_STATE.md is the final authority for all behavioral claims.
+
+No code here. No implementation. No scope expansion.
+
+---
+
+## 1. PURPOSE
+
+Translate the capability registry spec into a concrete file layout, document format, test additions, and implementation order. The design answers two deferred questions from the spec: document format and validation layer.
+
+---
+
+## 2. SCOPE LOCK
+
+Follows spec exactly. No new behavior added.
+
+**Design resolves two spec-deferred decisions:**
+
+| Decision | Resolution | Rationale |
+|---|---|---|
+| Document format | Markdown with per-capability bullet-list template | Consistent with existing host-interop docs; human-readable; machine-checkable by string matching |
+| Validation layer | Lightweight string-based doc-sync tests added to `tests/test_semantic_doc_sync.py` | Matches existing test pattern; no schema format needed; minimal scope |
+
+No YAML schema file, no Python validation registry, no new test framework. Those are deferred.
+
+---
+
+## 3. ARCHITECTURE OVERVIEW
+
+This change is entirely in the **Docs / Tests** zone (AGENTS.md four-zone model). It does not cross into Language Contract, Core IR, or Host Adapters.
+
+```
+docs/host-interop/capabilities.md        ← new: primary deliverable
+tests/test_semantic_doc_sync.py          ← modified: adds invariant checks
+docs/host-interop/HOST_CAPABILITY_MATRIX.md  ← modified: adds reference
+docs/host-interop/README.md              ← modified: adds to start-here list
+GENIA_STATE.md §0                        ← modified: records registry exists
+```
+
+No files in `src/genia/`, `hosts/python/`, or `spec/` change.
+
+---
+
+## 4. FILE / MODULE CHANGES
+
+### New files
+
+**`docs/host-interop/capabilities.md`**
+- The primary deliverable.
+- Contains the maturity notice, portability vocabulary table, and all 29 capability entries across 7 groups.
+- Authoritative reference for capability names, input/output shapes, error behavior, and portability status.
+
+### Modified files
+
+**`tests/test_semantic_doc_sync.py`**
+- Add one new test function: `test_capability_registry_invariants`.
+- Checks all 12 spec invariants by string matching against `docs/host-interop/capabilities.md`.
+- Follows the existing pattern: `read_text(relpath)` + `assert "..." in text`.
+
+**`docs/host-interop/HOST_CAPABILITY_MATRIX.md`**
+- Add one sentence in the opening section referencing `capabilities.md` as the per-capability contract source.
+- No row changes in this phase; the matrix rows already reflect the correct status.
+
+**`docs/host-interop/README.md`**
+- Add `capabilities.md` as the first entry in the "Start here" list with description: "formal per-capability contract reference (name, input, output, errors, portability status)".
+
+**`GENIA_STATE.md` §0**
+- Add one bullet point under "Implemented today": formal capability registry contract documented at `docs/host-interop/capabilities.md`.
+- Must be in the multi-host status section because that is where Python-host-only vs language contract status is tracked.
+
+### Removed files
+
+None.
+
+---
+
+## 5. DATA SHAPES
+
+### Capability entry template (markdown)
+
+Each capability entry in `capabilities.md` uses this exact layout:
+
+```
+#### `<name>`
+
+- **name:** `<dotted-name>`
+- **genia_surface:** `<surface>` [, `<surface>`, ...]
+- **input:** <Genia type description — no Python types>
+- **output:** <Genia type description — no Python types>
+- **errors:**
+  - `<ErrorCategory>` — <trigger condition and normalized message prefix>
+  - (or: none defined)
+- **portability:** `<language contract | Python-host-only | not implemented>`
+- **notes:** <optional short clarification> (omit line if empty)
+```
+
+Rules enforced by this template:
+- `name` always uses backtick quoting
+- `portability` always uses one of the three spec-defined terms in backticks
+- `errors` section always present, even if value is "none defined"
+- `notes` line omitted entirely when there is nothing to say (not written as empty or "N/A")
+
+### Document structure
+
+```
+# Host Capability Registry Contract
+
+<maturity notice>
+
+## Portability Status Terms
+
+<vocabulary table>
+
+## Capability Groups
+
+### Group: I/O Substrate
+
+#### `io.stdout`
+...
+
+#### `io.stderr`
+...
+
+#### `io.stdin`
+...
+
+### Group: Time / Sleep
+
+#### `time.sleep`
+...
+
+### Group: Randomness
+
+#### `random.rng`
+...
+
+[remaining groups in §5 of spec order]
+```
+
+Section heading format for groups: `### Group: <Group Name>`
+Section heading format for entries: `#### \`<name>\``
+
+This structure lets the doc-sync test verify capability presence with simple `assert "\`io.stdout\`" in text`.
+
+---
+
+## 6. TEST DESIGN (for test phase)
+
+### Function: `test_capability_registry_invariants`
+
+Location: `tests/test_semantic_doc_sync.py`
+
+The test reads `docs/host-interop/capabilities.md` once and asserts all 12 invariants from the spec.
+
+**Invariant checks mapped to assertions:**
+
+| Invariant | Assertion type |
+|---|---|
+| 1. All 29 capability names present | `assert "\`<name>\`" in text` for each name |
+| 2. All entries have required fields | `assert "- **portability:**" in text` (count ≥ 29); similar for other required fields |
+| 3. Portability values are only the three allowed terms | `assert "portability: \`language contract\`" or "portability: \`Python-host-only\`" or "portability: \`not implemented\`" — no other portability value appears |
+| 4. No Python class names | `assert "src/genia/" not in text`; `assert "interpreter.py" not in text` |
+| 5. No unimplemented behaviors described as current | checked via prohibited phrasings |
+| 6. No non-Python host claims implementation | `assert "Node.js: Implemented" not in text` (etc.) — this is weaker; primary guard is Invariant 3 + status terms |
+| 7. language contract entries in HOST_CAPABILITY_MATRIX as Implemented | separate assertion on HOST_CAPABILITY_MATRIX.md |
+| 8. Python-host-only entries in HOST_CAPABILITY_MATRIX as Python-host-only | separate assertion on HOST_CAPABILITY_MATRIX.md |
+| 9. No prohibited phrasings | `assert "will be implemented" not in text`, etc. |
+| 10. No future-tense phrases in contracts | `assert "coming soon" not in text`; "planned" not in contract field lines |
+| 11. Structured absence distinguished from error raises | presence of `none("json-parse-error"` in json.parse entry and absence of "raises" in the same entry |
+| 12. No language semantics in doc | `assert "Core IR" not in text`; `assert "IrPipeline" not in text` |
+
+**Failing state before implementation phase:** The test will fail immediately at the file read because `docs/host-interop/capabilities.md` does not exist yet.
+
+### Existing tests: no regression expected
+
+No existing test assertions change. The new function is additive.
+
+---
+
+## 7. IMPLEMENTATION ORDER (TDD)
+
+Phase ordering matters. The test phase must produce failing tests before the implementation phase writes the document.
+
+**Test phase commit (tests fail — capabilities.md does not exist):**
+1. Add `test_capability_registry_invariants` to `tests/test_semantic_doc_sync.py`.
+
+**Implementation phase commits (tests pass):**
+1. Write `docs/host-interop/capabilities.md` (all 29 capability entries).
+2. Update `docs/host-interop/README.md` (add capabilities.md to start-here list).
+3. Update `docs/host-interop/HOST_CAPABILITY_MATRIX.md` (add cross-reference).
+4. Update `GENIA_STATE.md` §0 (add registry bullet point).
+
+All four implementation changes may land in one commit because they are jointly required to satisfy all 12 invariants. If the test phase verifies invariants 7 and 8 against HOST_CAPABILITY_MATRIX.md, that file must also be in place before the test can pass.
+
+---
+
+## 8. ERROR HANDLING DESIGN
+
+No runtime error handling is introduced. This is a docs-only change.
+
+For the doc-sync test:
+- If `capabilities.md` is missing → `FileNotFoundError` from `Path.read_text` → test fails with clear path message.
+- If an invariant string is absent → `AssertionError` with the failing assertion visible in pytest output.
+- No try/except needed; pytest handles both.
+
+---
+
+## 9. INTEGRATION POINTS
+
+| System | Interaction |
+|---|---|
+| `tests/test_semantic_doc_sync.py` | New function added; existing functions untouched |
+| `docs/host-interop/HOST_CAPABILITY_MATRIX.md` | Cross-reference sentence added; rows unchanged |
+| `docs/host-interop/README.md` | One list entry added |
+| `GENIA_STATE.md §0` | One bullet point added under "Implemented today" |
+| `src/genia/`, `hosts/python/`, `spec/` | No changes |
+| CI (pytest -q) | New test runs; must pass before merge |
+
+---
+
+## 10. DOC IMPACT
+
+**`GENIA_STATE.md` §0 addition (exact required wording):**
+
+```
+- A formal host capability registry contract is documented at
+  `docs/host-interop/capabilities.md`. It is the authoritative reference
+  for capability names, Genia surface, input/output shapes, normalized error
+  behavior, and portability status for each host capability.
+```
+
+**`docs/host-interop/README.md` addition (exact required wording):**
+
+```
+- `capabilities.md` for the formal per-capability contract
+  (name, Genia surface, input, output, errors, portability status)
+```
+
+This entry goes before the existing `HOST_INTEROP.md` entry so it is the first reference.
+
+**`docs/host-interop/HOST_CAPABILITY_MATRIX.md` addition (exact required wording):**
+
+In the opening section, after the status legend, before the browser playground note:
+
+```
+For the formal per-capability contract (input shapes, output shapes,
+normalized error behavior, and portability status), see
+`docs/host-interop/capabilities.md`.
+```
+
+---
+
+## 11. CONSTRAINTS
+
+Must:
+- Follow existing markdown conventions in `docs/host-interop/`
+- Follow existing test patterns in `test_semantic_doc_sync.py` (string matching, `read_text`, `normalize`)
+- Use only Genia type names in capability contracts (no Python types)
+- Keep capabilities.md truthful: all claims grounded in GENIA_STATE.md
+
+Must not:
+- Add a YAML schema file
+- Add a Python validation registry or dataclass
+- Modify any runtime file
+- Add shared spec YAML cases
+- Describe future hosts as implemented
+- Change any existing test assertion
+
+---
+
+## 12. COMPLEXITY CHECK
+
+[x] Minimal
+[x] Necessary
+
+The primary deliverable (capabilities.md) is a single markdown document. The test addition is one function using existing patterns. Three small edits to existing docs. This is the minimum that satisfies all 12 spec invariants with a verifiable artifact.
+
+The validation layer stays at its simplest possible form: string-based doc-sync assertions. No schema, no reflection, no runtime hooks. This matches the "keep it tiny" directive from the pre-flight.
+
+---
+
+## 13. FINAL CHECK
+
+- [x] Matches spec exactly — all 29 capabilities covered; all 12 invariants mapped to concrete test assertions
+- [x] No new behavior introduced — docs-only change; no runtime modifications
+- [x] Structure is clear and implementable — template defined, file locations defined, exact wording for related-file updates defined
+- [x] TDD order preserved — test phase commits failing test before implementation phase writes capabilities.md
+- [x] Existing tests not broken — new function is additive only
+- [x] Validation layer is minimal — string matching in existing test file; no schema format
+- [x] Ready for test phase — `test_capability_registry_invariants` definition is fully specified above

--- a/docs/host-interop/capability-registry-spec.md
+++ b/docs/host-interop/capability-registry-spec.md
@@ -1,0 +1,512 @@
+# Spec: Host Capability Registry Contract
+# Issue #118 — Spec Phase
+
+**Status:** Spec-only — no implementation, no design decisions.
+**Branch:** docs/host-capability-registry-contract
+**Authority:** GENIA_STATE.md is the final authority for all behavioral claims in this spec.
+
+---
+
+## 1. PURPOSE
+
+This spec defines exactly what `docs/host-interop/capabilities.md` must contain.
+
+A host capability is a named, host-backed service exposed to Genia programs through the runtime substrate — not through language semantics or Core IR.
+
+This spec does not define:
+- language behavior (that lives in GENIA_STATE.md and GENIA_RULES.md)
+- Core IR nodes (that lives in docs/architecture/core-ir-portability.md)
+- implementation strategy (that is a design-phase decision)
+- whether a validation layer is added (that is a design-phase decision)
+
+---
+
+## 2. SCOPE (FROM PRE-FLIGHT)
+
+### Included
+
+- Define a minimal host capability registry contract in `docs/host-interop/capabilities.md`.
+- Document each capability with: name, Genia surface, input shape, output shape, normalized error behavior, portability status.
+- Cover the capability groups listed in §5.
+- Update `docs/host-interop/HOST_CAPABILITY_MATRIX.md` to reference the new capability registry.
+- Update `docs/host-interop/README.md` to point to the new document.
+- Update `GENIA_STATE.md` §0 to record that a formal capability registry contract exists.
+
+### Excluded
+
+- Implementing new host capabilities.
+- Adding Node.js, Java, Rust, Go, or C++ hosts.
+- Redefining Genia language semantics.
+- Changing Core IR.
+- Building a generic multi-host capability conformance runner.
+- Describing speculative or unimplemented capabilities as current.
+- Deciding the validation layer design (that is the design phase).
+
+---
+
+## 3. CAPABILITY ENTRY REQUIREMENTS
+
+Every entry in `capabilities.md` must declare exactly these fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | YES | Canonical capability name. Dotted namespaced string. Stable. |
+| `genia_surface` | YES | The Genia-visible name(s) through which this capability is accessed (function name, value name, or module path). |
+| `input` | YES | Genia value types accepted at the host bridge boundary. Must use Genia type names only (not Python types). |
+| `output` | YES | Genia value type returned by the host bridge. Must use Genia type names only. |
+| `errors` | YES | Normalized error behaviors. Category (TypeError / ValueError / RuntimeError / FileNotFoundError), message prefix, and trigger condition. No Python exception names. |
+| `portability` | YES | Exactly one of the status terms defined in §4. |
+| `notes` | OPTIONAL | Short clarifying text. Must not contradict GENIA_STATE.md. |
+
+A capability entry must not contain:
+- Python implementation details (class names, module paths from `src/genia/`)
+- Unimplemented behaviors described as current
+- Language semantics that belong in GENIA_STATE.md
+
+---
+
+## 4. PORTABILITY VOCABULARY
+
+`capabilities.md` must use exactly these portability status terms and no others:
+
+| Term | Meaning |
+|---|---|
+| `language contract` | All hosts must implement this capability. It is part of the shared portable contract. |
+| `Python-host-only` | Implemented only in the Python reference host. Not part of the shared portable contract. Future hosts may implement it. |
+| `not implemented` | Not implemented in any host in the current phase. |
+
+These terms must match the status column in `HOST_CAPABILITY_MATRIX.md`.
+
+Prohibited phrasings: "will be implemented", "planned", "experimental" (without also giving portability status), "all hosts support" (unless `language contract` is accurate and verified against GENIA_STATE.md).
+
+---
+
+## 5. REQUIRED CAPABILITY GROUPS
+
+`capabilities.md` must document every capability group and every individual capability listed below. All behavioral claims must be grounded in GENIA_STATE.md.
+
+### 5.1 I/O Substrate
+
+| Capability name | Portability |
+|---|---|
+| `io.stdout` | `language contract` |
+| `io.stderr` | `language contract` |
+| `io.stdin` | `language contract` |
+
+### 5.2 Time / Sleep
+
+| Capability name | Portability |
+|---|---|
+| `time.sleep` | `Python-host-only` |
+
+### 5.3 Randomness
+
+| Capability name | Portability |
+|---|---|
+| `random.rng` | `Python-host-only` |
+| `random.rand` | `Python-host-only` |
+| `random.rand-int` | `Python-host-only` |
+| `random.rand-seeded` | `Python-host-only` |
+| `random.rand-int-seeded` | `Python-host-only` |
+
+### 5.4 HTTP Serving
+
+| Capability name | Portability |
+|---|---|
+| `http.serve` | `Python-host-only` |
+
+### 5.5 Process / Mailbox
+
+| Capability name | Portability |
+|---|---|
+| `process.spawn` | `Python-host-only` |
+| `process.send` | `Python-host-only` |
+| `process.alive` | `Python-host-only` |
+| `process.failed` | `Python-host-only` |
+| `process.error` | `Python-host-only` |
+
+### 5.6 Refs / Cells
+
+| Capability name | Portability |
+|---|---|
+| `ref.create` | `Python-host-only` |
+| `ref.get` | `Python-host-only` |
+| `ref.set` | `Python-host-only` |
+| `ref.update` | `Python-host-only` |
+| `cell.create` | `Python-host-only` |
+| `cell.send` | `Python-host-only` |
+| `cell.get` | `Python-host-only` |
+| `cell.restart` | `Python-host-only` |
+
+### 5.7 Bytes / JSON / ZIP Bridge
+
+| Capability name | Portability |
+|---|---|
+| `bytes.utf8-encode` | `Python-host-only` |
+| `bytes.utf8-decode` | `Python-host-only` |
+| `json.parse` | `Python-host-only` |
+| `json.stringify` | `Python-host-only` |
+| `zip.entries` | `Python-host-only` |
+| `zip.write` | `Python-host-only` |
+
+---
+
+## 6. CAPABILITY CONTRACTS (EXACT)
+
+Each sub-section below defines the exact contract that `capabilities.md` must record for that capability. All inputs, outputs, and errors are stated in Genia types only.
+
+### 6.1 `io.stdout`
+
+- **genia_surface:** `stdout` (runtime value); `print(value)`, `write(stdout, value)`, `writeln(stdout, value)`, `flush(stdout)`
+- **input:** any Genia display-formattable value
+- **output:** `none("nil")` (side effect: text written to host stdout stream)
+- **errors:**
+  - `RuntimeError` on broken pipe in file/command/pipe execution mode; this is normal downstream termination and must not surface as a traceback
+- **portability:** `language contract`
+- **notes:** `stdout` is a first-class runtime capability value, not a string. `print(value)` is sugar for writing a display-formatted value plus newline to stdout.
+
+### 6.2 `io.stderr`
+
+- **genia_surface:** `stderr` (runtime value); `log(value)`, `write(stderr, value)`, `writeln(stderr, value)`, `flush(stderr)`
+- **input:** any Genia display-formattable value
+- **output:** `none("nil")` (side effect: text written to host stderr stream)
+- **errors:**
+  - broken pipe on stderr must be handled best-effort without recursive noisy failures
+- **portability:** `language contract`
+- **notes:** `log(value)` is sugar for writing a display-formatted value plus newline to stderr.
+
+### 6.3 `io.stdin`
+
+- **genia_surface:** `stdin` (runtime value); used as a Flow source via `stdin |> lines`
+- **input:** none (stdin is a source, not a sink)
+- **output:** `Flow` (lazy single-use pull sequence of string lines) when used via `stdin |> lines`
+- **errors:**
+  - invalid second consumption: `RuntimeError("Flow has already been consumed")`
+- **portability:** `language contract`
+- **notes:** Binding `stdin` into a flow must not force a full stdin read up front. `stdin()` (call form) returns a cached list of full stdin lines and is a separate compatibility surface; the primary source behavior is `stdin |> lines`.
+
+### 6.4 `time.sleep`
+
+- **genia_surface:** `sleep(ms)`
+- **input:** `ms` — Number (non-negative)
+- **output:** `none("nil")` (side effect: host thread blocks for `ms` milliseconds)
+- **errors:**
+  - `TypeError` when `ms` is not numeric
+  - `ValueError` when `ms < 0`
+- **portability:** `Python-host-only`
+- **notes:** Blocking primitive only. Does not introduce a scheduler or async/await surface.
+
+### 6.5 `random.rng`
+
+- **genia_surface:** `rng(seed)`
+- **input:** `seed` — Number (non-negative integer)
+- **output:** opaque RNG state value
+- **errors:**
+  - `TypeError` when `seed` is not an integer
+  - `ValueError` when `seed < 0`
+- **portability:** `Python-host-only`
+- **notes:** The same seed must yield the same sequence. The current Python host uses a fixed 32-bit LCG. The opaque RNG state value is not a plain Genia data type.
+
+### 6.6 `random.rand`
+
+- **genia_surface:** `rand()`
+- **input:** none
+- **output:** Number (float in `[0, 1)`)
+- **errors:** none defined
+- **portability:** `Python-host-only`
+- **notes:** Uses host-RNG; not deterministic. Convenience form only.
+
+### 6.7 `random.rand-int`
+
+- **genia_surface:** `rand_int(n)`
+- **input:** `n` — Number (positive integer)
+- **output:** Number (integer in `[0, n)`)
+- **errors:**
+  - `TypeError` when `n` is not an integer
+  - `ValueError` when `n <= 0`
+- **portability:** `Python-host-only`
+- **notes:** Uses host-RNG; not deterministic. Convenience form only.
+
+### 6.8 `random.rand-seeded`
+
+- **genia_surface:** `rand(rng_state)`
+- **input:** `rng_state` — opaque RNG state value (from `rng(seed)` or prior `rand(rng_state)`)
+- **output:** List — `[next_rng_state, float]` where float is in `[0, 1)`
+- **errors:**
+  - `TypeError` when `rng_state` is not a valid RNG state value
+- **portability:** `Python-host-only`
+- **notes:** Deterministic and state-threaded. The same state must produce the same next state and float.
+
+### 6.9 `random.rand-int-seeded`
+
+- **genia_surface:** `rand_int(rng_state, n)`
+- **input:** `rng_state` — opaque RNG state value; `n` — Number (positive integer)
+- **output:** List — `[next_rng_state, int]` where int is in `[0, n)`
+- **errors:**
+  - `TypeError` when `rng_state` is not a valid RNG state value
+  - `TypeError` when `n` is not an integer
+  - `ValueError` when `n <= 0`
+- **portability:** `Python-host-only`
+- **notes:** Deterministic and state-threaded.
+
+### 6.10 `http.serve`
+
+- **genia_surface:** `import web` then `web/serve_http(config, handler)`
+- **input:** `config` — Map; `handler` — Function `(request_map) -> response_map`
+- **output:** none (blocking; does not return while server is running)
+- **errors:**
+  - invalid handler return is normalized to a `500 internal server error` response (not a language-level error)
+- **portability:** `Python-host-only`
+- **notes:** Synchronous/blocking only. Request map fields: `method`, `path`, `query`, `headers`, `body`, `raw_body`, `client`. Response map fields: `status`, `headers`, `body`. No middleware, path params, streaming, websockets, or async support.
+
+### 6.11 `process.spawn`
+
+- **genia_surface:** `spawn(handler)`
+- **input:** `handler` — Function (message handler, receives messages sent to the process)
+- **output:** opaque Process handle value
+- **errors:**
+  - `TypeError` when `handler` is not callable
+- **portability:** `Python-host-only`
+- **notes:** Creates a host-thread worker with FIFO mailbox. Processes are fail-stop: handler exceptions cache an error string, exit the worker, and cause future `send` calls to raise.
+
+### 6.12 `process.send`
+
+- **genia_surface:** `send(process, message)`
+- **input:** `process` — Process handle value; `message` — any Genia value
+- **output:** `none("nil")` (side effect: message enqueued in process mailbox)
+- **errors:**
+  - `RuntimeError` when the process has already failed
+- **portability:** `Python-host-only`
+- **notes:** Mailbox is FIFO per process. One handler invocation at a time per process.
+
+### 6.13 `process.alive`
+
+- **genia_surface:** `process_alive?(process)`
+- **input:** `process` — Process handle value
+- **output:** Boolean
+- **errors:** none defined
+- **portability:** `Python-host-only`
+
+### 6.14 `process.failed`
+
+- **genia_surface:** `process_failed?(process)`
+- **input:** `process` — Process handle value
+- **output:** Boolean
+- **errors:** none defined
+- **portability:** `Python-host-only`
+
+### 6.15 `process.error`
+
+- **genia_surface:** `process_error(process)`
+- **input:** `process` — Process handle value
+- **output:** `some(error_string)` when process has failed; `none("nil")` otherwise
+- **errors:** none defined
+- **portability:** `Python-host-only`
+
+### 6.16 `ref.create`
+
+- **genia_surface:** `ref(initial_value)`
+- **input:** `initial_value` — any Genia value
+- **output:** opaque Ref value
+- **errors:** none defined
+- **portability:** `Python-host-only`
+- **notes:** Refs are synchronized host objects.
+
+### 6.17 `ref.get`
+
+- **genia_surface:** `ref_get(ref_value)`
+- **input:** `ref_value` — Ref value
+- **output:** the current stored Genia value
+- **errors:**
+  - `TypeError` when argument is not a Ref value
+- **portability:** `Python-host-only`
+
+### 6.18 `ref.set`
+
+- **genia_surface:** `ref_set(ref_value, new_value)`
+- **input:** `ref_value` — Ref value; `new_value` — any Genia value
+- **output:** `none("nil")` (side effect: stored value updated)
+- **errors:**
+  - `TypeError` when first argument is not a Ref value
+- **portability:** `Python-host-only`
+
+### 6.19 `ref.update`
+
+- **genia_surface:** `ref_update(ref_value, f)`
+- **input:** `ref_value` — Ref value; `f` — Function `(current_value) -> new_value`
+- **output:** `none("nil")` (side effect: stored value replaced by `f(current_value)`)
+- **errors:**
+  - `TypeError` when first argument is not a Ref value
+  - `TypeError` when `f` is not callable
+- **portability:** `Python-host-only`
+
+### 6.20 `cell.create`
+
+- **genia_surface:** `cell(initial_state)` / `cell_with_state(ref_value)`
+- **input:** `initial_state` — any Genia value (for `cell`); `ref_value` — Ref value (for `cell_with_state`)
+- **output:** opaque Cell value
+- **errors:** none defined
+- **portability:** `Python-host-only`
+- **notes:** Cells queue asynchronous updates serialized one at a time. Cells are fail-stop.
+
+### 6.21 `cell.send`
+
+- **genia_surface:** `cell_send(cell, update_fn)`
+- **input:** `cell` — Cell value; `update_fn` — Function `(current_state) -> next_state`
+- **output:** `none("nil")` (update is asynchronous; side effect: update enqueued)
+- **errors:**
+  - `RuntimeError` when the cell has already failed
+- **portability:** `Python-host-only`
+- **notes:** Failed updates preserve last successful state. Nested `cell_send` calls issued during an update are staged and committed only if that update succeeds.
+
+### 6.22 `cell.get`
+
+- **genia_surface:** `cell_get(cell)` / `cell_state(cell)`
+- **input:** `cell` — Cell value
+- **output:** the last successful state Genia value
+- **errors:**
+  - `RuntimeError` when the cell has already failed
+- **portability:** `Python-host-only`
+
+### 6.23 `cell.restart`
+
+- **genia_surface:** `restart_cell(cell, new_state)`
+- **input:** `cell` — Cell value; `new_state` — any Genia value
+- **output:** `none("nil")` (side effect: failure cleared, state replaced, queued pre-restart updates discarded)
+- **errors:** none defined
+- **portability:** `Python-host-only`
+
+### 6.24 `bytes.utf8-encode`
+
+- **genia_surface:** `utf8_encode(string)`
+- **input:** String
+- **output:** opaque Bytes wrapper value
+- **errors:**
+  - `TypeError` when argument is not a String
+- **portability:** `Python-host-only`
+
+### 6.25 `bytes.utf8-decode`
+
+- **genia_surface:** `utf8_decode(bytes)`
+- **input:** opaque Bytes wrapper value
+- **output:** String
+- **errors:**
+  - `ValueError` for invalid UTF-8 byte sequences
+  - `TypeError` when argument is not a Bytes value
+- **portability:** `Python-host-only`
+
+### 6.26 `json.parse`
+
+- **genia_surface:** `json_parse(string)`
+- **input:** String
+- **output:** parsed Genia value (`none("json-parse-error", context)` on failure — this is NOT an error raise; it is a structured absence return)
+- **errors:** none raised — failures return structured `none("json-parse-error", context)`, not exceptions
+- **portability:** `Python-host-only`
+- **notes:** JSON objects become runtime Map values (the same family as `map_new`/`map_put`). Internal bridge primitive is `_json_parse`; public surface is the prelude-backed `json_parse`.
+
+### 6.27 `json.stringify`
+
+- **genia_surface:** `json_stringify(value)` / `json_pretty(value)`
+- **input:** any Genia value that can be represented as JSON (Number, String, Boolean, List, Map, `none("nil")`)
+- **output:** String (`none("json-stringify-error", context)` on failure — structured absence, not an exception)
+- **errors:** none raised — failures return structured `none("json-stringify-error", context)`, not exceptions
+- **portability:** `Python-host-only`
+- **notes:** Current output format: `indent=2`, sorted keys. `json_pretty` is a compatibility alias for `json_stringify`. Internal bridge primitive is `_json_stringify`.
+
+### 6.28 `zip.entries`
+
+- **genia_surface:** `zip_entries(path)`
+- **input:** String (file path)
+- **output:** List of opaque Zip entry wrapper values (in archive order; eager, not lazy)
+- **errors:**
+  - `FileNotFoundError` when `path` does not exist or is not accessible
+- **portability:** `Python-host-only`
+- **notes:** Returns an eager list in this phase, not a lazy Flow. Each entry exposes `entry_name`, `entry_bytes`, `set_entry_bytes`, `update_entry_bytes`, `entry_json`.
+
+### 6.29 `zip.write`
+
+- **genia_surface:** `zip_write(entries, path)` / `zip_write(path, entries)`
+- **input:** List of opaque Zip entry wrapper values; String (output file path)
+- **output:** String (the output path)
+- **errors:**
+  - `TypeError` when entries is not a list of Zip entry values
+  - `FileNotFoundError` / `RuntimeError` on write failure
+- **portability:** `Python-host-only`
+- **notes:** Preserves entry order. Accepts both argument orderings for pipeline compatibility.
+
+---
+
+## 7. INVARIANTS
+
+These are truths that must hold in the completed `capabilities.md`. These drive doc-sync tests.
+
+1. Every capability listed in §5 has an entry in `capabilities.md`.
+2. Every entry has all required fields from §3 present and non-empty.
+3. Every `portability` value is exactly one of the three terms defined in §4.
+4. No entry contains Python class names, Python module paths from `src/genia/`, or Python-specific exception type names.
+5. No entry describes unimplemented behavior as implemented.
+6. No entry claims any non-Python host implements a capability (all non-Python hosts are `not implemented` in the current phase).
+7. Every `portability: language contract` capability is listed as `Implemented` in `HOST_CAPABILITY_MATRIX.md`.
+8. Every `portability: Python-host-only` capability is listed as `Python-host-only` in `HOST_CAPABILITY_MATRIX.md`.
+9. The document does not use prohibited phrasings from §4.
+10. The document does not contain the words "will", "planned", "future", or "coming soon" in capability contract descriptions.
+11. Structured absence (`none(reason, ctx)`) is used for expected-absent results; it is not conflated with error raises.
+12. The document does not define or redefine language semantics (those belong in GENIA_STATE.md).
+
+---
+
+## 8. RELATED FILE UPDATE REQUIREMENTS
+
+### 8.1 `GENIA_STATE.md` §0
+
+Must add a sentence confirming that a formal host capability registry contract document exists at `docs/host-interop/capabilities.md` and that it is the authoritative reference for capability names, input/output shapes, error behavior, and portability status.
+
+### 8.2 `docs/host-interop/HOST_CAPABILITY_MATRIX.md`
+
+Must add a reference to `capabilities.md` in the opening section. The matrix rows must remain consistent with the portability status in `capabilities.md` (no conflicts allowed).
+
+### 8.3 `docs/host-interop/README.md`
+
+Must add `capabilities.md` to the "Start here" list with a one-line description: the formal per-capability contract reference.
+
+---
+
+## 9. NON-GOALS
+
+- This spec does NOT define a validation layer. Whether a JSON schema, Python dataclass, or runtime checker is added is a design-phase decision.
+- This spec does NOT add new capabilities. Only currently implemented capabilities are documented.
+- This spec does NOT change any Python host runtime behavior.
+- This spec does NOT add shared spec YAML cases.
+- This spec does NOT define how future hosts implement capabilities.
+- This spec does NOT introduce a new Genia language surface.
+- `docs/contract/semantic_facts.json` and `tests/test_semantic_doc_sync.py` may not need to change; that is a design-phase determination.
+
+---
+
+## 10. DOC REQUIREMENTS
+
+- `capabilities.md` must include a maturity notice: "Host capability registry contract is **partial** — Python is the reference host. Future hosts are planned/scaffolded only."
+- The doc must label each capability group with its portability zone.
+- Examples within the doc must be classified as **Valid** (directly tested), **Likely valid**, or **Illustrative**, consistent with README.md example classification conventions.
+- The doc must not contain speculative features.
+
+---
+
+## 11. COMPLEXITY CHECK
+
+[x] Minimal — reveals existing substrate structure without adding complexity.
+
+This spec organizes boundaries that already exist implicitly. The risk zone is any validation layer added in the design phase; keep it tiny or defer it.
+
+---
+
+## 12. FINAL CHECK
+
+- [x] No implementation details included
+- [x] No scope expansion beyond pre-flight
+- [x] All behavioral claims grounded in GENIA_STATE.md
+- [x] All capability contracts grounded in GENIA_RULES.md and GENIA_REPL_README.md
+- [x] Portability status for each capability matches current HOST_CAPABILITY_MATRIX.md
+- [x] No Python host runtime files are changed by this spec
+- [x] No shared spec YAML cases are added or modified by this spec
+- [x] Structured absence (`none(...)`) is correctly distinguished from error raises in contracts

--- a/tests/test_semantic_doc_sync.py
+++ b/tests/test_semantic_doc_sync.py
@@ -481,6 +481,224 @@ def test_arch_doc_lowering_invariants_cover_ir_assign_placement() -> None:
     )
 
 
+# --- Issue #118: Host capability registry contract doc-sync tests ---
+# These tests enforce that capabilities.md exists, is complete, and is
+# internally consistent per the 12 invariants in the spec.
+# They FAIL until the implementation phase creates capabilities.md
+# and updates the three related files.
+
+_CAPABILITIES_DOC = "docs/host-interop/capabilities.md"
+
+# Invariant 1: all 29 required capability names must appear in the document.
+_REQUIRED_CAPABILITY_NAMES = [
+    "io.stdout",
+    "io.stderr",
+    "io.stdin",
+    "time.sleep",
+    "random.rng",
+    "random.rand",
+    "random.rand-int",
+    "random.rand-seeded",
+    "random.rand-int-seeded",
+    "http.serve",
+    "process.spawn",
+    "process.send",
+    "process.alive",
+    "process.failed",
+    "process.error",
+    "ref.create",
+    "ref.get",
+    "ref.set",
+    "ref.update",
+    "cell.create",
+    "cell.send",
+    "cell.get",
+    "cell.restart",
+    "bytes.utf8-encode",
+    "bytes.utf8-decode",
+    "json.parse",
+    "json.stringify",
+    "zip.entries",
+    "zip.write",
+]
+
+_ALLOWED_PORTABILITY_TERMS = frozenset(
+    ["language contract", "Python-host-only", "not implemented"]
+)
+
+_PROHIBITED_PHRASES = [
+    "will be implemented",
+    "coming soon",
+    "Node.js: Implemented",
+    "Java: Implemented",
+    "Rust: Implemented",
+    "Go: Implemented",
+    "C++: Implemented",
+]
+
+_PROHIBITED_INTERNAL_NAMES = [
+    "src/genia/interpreter.py",
+    "class Ir",
+    "class Ast",
+    "src/genia/evaluator",
+]
+
+
+def test_capability_registry_all_required_names_present() -> None:
+    """Invariant 1: every required capability name appears in capabilities.md."""
+    text = read_text(_CAPABILITIES_DOC)
+    for name in _REQUIRED_CAPABILITY_NAMES:
+        assert f"`{name}`" in text, (
+            f"capabilities.md is missing required capability entry: `{name}`"
+        )
+
+
+def test_capability_registry_required_fields_present() -> None:
+    """Invariant 2: required fields (name, genia_surface, input, output, errors,
+    portability) appear at least once per capability (29 entries minimum)."""
+    text = read_text(_CAPABILITIES_DOC)
+    required_field_markers = [
+        "**name:**",
+        "**genia_surface:**",
+        "**input:**",
+        "**output:**",
+        "**errors:**",
+        "**portability:**",
+    ]
+    for marker in required_field_markers:
+        count = text.count(marker)
+        assert count >= len(_REQUIRED_CAPABILITY_NAMES), (
+            f"capabilities.md has {count} occurrences of '{marker}' "
+            f"but needs at least {len(_REQUIRED_CAPABILITY_NAMES)} (one per capability)"
+        )
+
+
+def test_capability_registry_portability_values_are_canonical() -> None:
+    """Invariant 3: every portability field uses exactly one of the three
+    allowed status terms; no other portability value may appear."""
+    text = read_text(_CAPABILITIES_DOC)
+    portability_lines = [
+        line for line in text.splitlines() if "**portability:**" in line
+    ]
+    assert len(portability_lines) >= len(_REQUIRED_CAPABILITY_NAMES), (
+        f"capabilities.md has {len(portability_lines)} portability lines "
+        f"but needs at least {len(_REQUIRED_CAPABILITY_NAMES)}"
+    )
+    for line in portability_lines:
+        assert any(term in line for term in _ALLOWED_PORTABILITY_TERMS), (
+            f"portability line uses a non-canonical status term: {line!r}\n"
+            f"Allowed terms: {sorted(_ALLOWED_PORTABILITY_TERMS)}"
+        )
+
+
+def test_capability_registry_no_python_internal_names() -> None:
+    """Invariant 4: capabilities.md must not contain Python-internal class names
+    or source paths from src/genia/."""
+    text = read_text(_CAPABILITIES_DOC)
+    for fragment in _PROHIBITED_INTERNAL_NAMES:
+        assert fragment not in text, (
+            f"capabilities.md must not reference Python internal name: {fragment!r}"
+        )
+
+
+def test_capability_registry_no_prohibited_phrases() -> None:
+    """Invariants 5, 6, 9, 10: capabilities.md must not use prohibited
+    phrasings that overclaim implementation status or future-host status."""
+    text = read_text(_CAPABILITIES_DOC)
+    for phrase in _PROHIBITED_PHRASES:
+        assert phrase not in text, (
+            f"capabilities.md contains prohibited phrase: {phrase!r}"
+        )
+
+
+def test_capability_registry_no_future_tense_in_contracts() -> None:
+    """Invariant 10: capability contract field lines must not use future tense."""
+    text = read_text(_CAPABILITIES_DOC)
+    field_lines = [
+        line for line in text.splitlines()
+        if any(f"**{field}:**" in line for field in
+               ["input", "output", "errors", "portability", "genia_surface", "name"])
+    ]
+    future_words = ["coming soon", "will be", "not yet"]
+    for line in field_lines:
+        for word in future_words:
+            assert word not in line.lower(), (
+                f"capability contract field line uses future-tense phrase {word!r}: {line!r}"
+            )
+
+
+def test_capability_registry_structured_absence_not_conflated_with_errors() -> None:
+    """Invariant 11: json.parse and json.stringify must document failures as
+    structured absence (none(...)) not as exception raises."""
+    text = read_text(_CAPABILITIES_DOC)
+    assert 'none("json-parse-error"' in text, (
+        "capabilities.md must document json.parse failure as "
+        'none("json-parse-error", context), not as a raised exception'
+    )
+    assert 'none("json-stringify-error"' in text, (
+        "capabilities.md must document json.stringify failure as "
+        'none("json-stringify-error", context), not as a raised exception'
+    )
+    assert 'raises `none(' not in text, (
+        "capabilities.md must not describe structured absence as a raised exception"
+    )
+
+
+def test_capability_registry_no_core_ir_semantics() -> None:
+    """Invariant 12: capabilities.md must not define Core IR nodes or language
+    semantics that belong in GENIA_STATE.md."""
+    text = read_text(_CAPABILITIES_DOC)
+    ir_markers = ["IrPipeline", "IrOptionSome", "IrOptionNone", "IrBinary", "IrBlock"]
+    for marker in ir_markers:
+        assert marker not in text, (
+            f"capabilities.md must not reference Core IR node: {marker!r} — "
+            "Core IR semantics belong in docs/architecture/core-ir-portability.md"
+        )
+
+
+def test_capability_registry_maturity_notice_present() -> None:
+    """Doc requirements: capabilities.md must carry the required maturity notice."""
+    text = read_text(_CAPABILITIES_DOC)
+    assert "Python is the reference host" in text, (
+        "capabilities.md must include the maturity notice stating "
+        "Python is the reference host"
+    )
+    assert "partial" in text.lower(), (
+        "capabilities.md must include a maturity notice describing the "
+        "registry contract as partial"
+    )
+
+
+def test_capability_registry_cross_referenced_from_host_interop_readme() -> None:
+    """Spec §8.3: docs/host-interop/README.md must list capabilities.md in its
+    start-here section."""
+    text = read_text("docs/host-interop/README.md")
+    assert "capabilities.md" in text, (
+        "docs/host-interop/README.md must reference capabilities.md "
+        "in its start-here list"
+    )
+
+
+def test_capability_registry_cross_referenced_from_capability_matrix() -> None:
+    """Spec §8.2: HOST_CAPABILITY_MATRIX.md must reference capabilities.md
+    as the per-capability contract source."""
+    text = read_text("docs/host-interop/HOST_CAPABILITY_MATRIX.md")
+    assert "capabilities.md" in text, (
+        "HOST_CAPABILITY_MATRIX.md must reference capabilities.md "
+        "as the formal per-capability contract document"
+    )
+
+
+def test_genia_state_records_capability_registry_exists() -> None:
+    """Spec §8.1: GENIA_STATE.md §0 must record that the formal capability
+    registry contract exists at docs/host-interop/capabilities.md."""
+    text = read_text("GENIA_STATE.md")
+    assert "capabilities.md" in text, (
+        "GENIA_STATE.md §0 must record that the formal host capability "
+        "registry contract is documented at docs/host-interop/capabilities.md"
+    )
+
+
 def test_rules_doc_8_4_mentions_slash_lowering_form() -> None:
     rules = read_text("GENIA_RULES.md")
     marker = "§8.4"


### PR DESCRIPTION
This pull request introduces a formal and comprehensive documentation of the host capability registry contract for Genia, centralizing the authoritative reference for all host-backed capabilities. The new `docs/host-interop/capabilities.md` file details the contract for each capability, including names, Genia surface, input/output shapes, error normalization, and portability status. References to this new document have been added throughout the documentation to clarify its role as the single source of truth for host capabilities.

Key documentation and registry updates:

**Host Capability Registry Documentation**
- Added a new file, `docs/host-interop/capabilities.md`, that serves as the authoritative contract for all host-backed capabilities, specifying capability names, Genia surface, input/output shapes, normalized error handling, and portability status. This document also defines capability groups, error semantics, and the distinction between language contract and Python-host-only capabilities.

**Cross-document References and Integration**
- Updated `GENIA_STATE.md`, `README.md`, `docs/host-interop/README.md`, and `docs/host-interop/HOST_CAPABILITY_MATRIX.md` to reference the new `capabilities.md` as the formal contract for host capabilities, ensuring all documentation points to a single source of truth. [[1]](diffhunk://#diff-865cff63a4bb7e67f17086ab8b6cb9e9559a7508e0daf95234604eb450418abcR45) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R502) [[3]](diffhunk://#diff-97bcd252b45e35a6f7afc3688bb64cdc7d6473cc040a35eb8858a3e4735c5fe3R13) [[4]](diffhunk://#diff-b5e3bc1db0accc7203ce462cda77bb5f0782c71bcf6c75006c883fde1e0fa678R14-R15)