### PR TITLE
- Refactor Flow so the host retains only the minimal execution kernel:

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -238,6 +238,7 @@ CLI contract summary (actual behavior):
     - running `ctx` starts as `{}` and persists across input items
     - `rules()` is the identity stage
     - orchestration/defaulting/most contract validation now live in `src/genia/std/prelude/flow.genia`
+    - the host rules kernel consumes normalized rule output from prelude rather than providing user-visible defaults itself
     - contract violations raise runtime errors prefixed with `invalid-rules-result:`
   - `keep_some_else(stage, dead_handler, flow)` is explicit dead-letter routing for Option-returning per-item stages:
     - `stage` receives the original raw item

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -819,6 +819,7 @@ When changing syntax/semantics/runtime behavior, update together:
   - source-bound stdin/runtime integration
   - sink/materialization boundaries
 - language-visible `rules` orchestration, defaulting, and most contract validation now live in prelude/Genia code
+- the host rules kernel consumes normalized rule output from prelude and must not provide user-visible rule-result defaults itself
 - phase-1 flow builtins:
   - sources/transforms: `lines`, `map`, `filter`, `take`, `rules`
   - stdlib aliases over `take`: `head(flow)`, `head(n, flow)`
@@ -912,6 +913,7 @@ Rule-contract violations raise runtime errors prefixed with `invalid-rules-resul
 * `record` is the current item being transformed
 * `ctx` is persistent rule-processing state across items
 * in this phase, the host runtime keeps the lazy Flow kernel while `src/genia/std/prelude/flow.genia` handles most user-visible rule semantics
+* the host rules kernel expects normalized prelude output with `emit` and `ctx` already present
 
 ## `keep_some_else(stage, dead_handler[, flow])`
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -54,7 +54,7 @@ Scaffolded or planned, not implemented as hosts:
 
 - Shared host contract is **Partial**: the contract categories above are documented, and executable shared spec coverage is implemented for `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior in the Python reference host. Other hosts are not implemented.
 - Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist for `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior in this phase.
-- Flow behavior is implemented in Python, and shared semantic-spec coverage for flow is now **active but partial**. Current flow shared coverage is limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)` behavior, `rules(..fns)` compatibility behavior, `step_*` / `rule_*` equivalence, the `rules()` identity stage, and error propagation via invalid-reducer-on-flow diagnostic. Advanced Flow behavior is not covered by shared semantic specs in this phase.
+- Flow behavior is implemented in Python, and shared semantic-spec coverage for flow is now **active but partial**. Current flow shared coverage is limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)` behavior, `rules(..fns)` compatibility behavior, `step_*` / `rule_*` equivalence, the `rules()` identity stage, selected rule result defaulting/no-effect behavior, and error propagation via invalid-reducer-on-flow diagnostic. Advanced Flow behavior is not covered by shared semantic specs in this phase.
 - IR stability remains **Partial**: the minimal portable Core IR contract is documented with field-level lowering invariants (bare `none` reason=null, `none()` reason wrapped as `IrQuote`, `lhs/name` → `IrBinary(op=SLASH)`, `IrAssign` placement in `IrBlock.exprs`, optional fields), the Python runtime guards that boundary, and shared semantic-spec case coverage now validates the full portable node family in the Python reference host, including `quasiquote` bodies with `unquote` and `unquote_splicing` in list context.
 
 **Explicit limitations:**
@@ -128,7 +128,7 @@ PYTHON REFERENCE HOST:
 - All conformance is validated against the Python reference host.
 - The current shared spec runner executes eval cases (`spec/eval/`), comparing normalized `stdout`, `stderr`, and `exit_code`.
 - The current shared spec runner executes CLI cases (`spec/cli/`) through the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`.
-- The current shared spec runner executes Flow cases (`spec/flow/`) through command-source execution in the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`. Flow shared coverage includes first-wave cases proving lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, deterministic `keep_some(...)` option-filtering behavior, error propagation via invalid-reducer-on-flow diagnostic, and Flow/value boundary enforcement (value function `count` misused as a pipe stage); and focused core stdlib Flow coverage for direct `map` and `filter` over Flow inputs, including a composed `map`/`filter` chain case.
+- The current shared spec runner executes Flow cases (`spec/flow/`) through command-source execution in the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`. Flow shared coverage includes first-wave cases proving lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, selected rule result defaulting/no-effect behavior, deterministic `keep_some(...)` option-filtering behavior, error propagation via invalid-reducer-on-flow diagnostic, and Flow/value boundary enforcement (value function `count` misused as a pipe stage); and focused core stdlib Flow coverage for direct `map` and `filter` over Flow inputs, including a composed `map`/`filter` chain case.
 - The current shared spec runner executes error cases (`spec/error/`) through the same eval execution path used by eval cases, comparing exact normalized `stdout`, exact normalized `stderr`, and exact `exit_code`.
 - CLI shared spec coverage proves deterministic non-interactive file mode, `-c` command mode, and `-p` pipe mode behavior. Current shared CLI coverage includes basic file execution, file-mode `main(argv())` dispatch, trailing `argv()` exposure, command-mode final-value execution, valid pipe-mode Flow-stage usage, explicit `stdin` / `run` rejection, and current pipe-mode guidance for bare per-item stages, bare reducers, and non-Flow final results. REPL mode is not included in shared executable spec coverage.
 - The observable CLI shared-spec contract is limited to `stdout`, `stderr`, and `exit_code`.
@@ -990,6 +990,7 @@ Representation System entry points (#185, implemented):
   - `rule_*` compatibility constructors
   - `step_*` preferred constructors
   - `rules` orchestration, defaulting, and contract validation now primarily live in prelude/Genia code
+  - the host rules kernel consumes normalized rule output from prelude and does not provide rule-result defaults itself
 - Flow-adjacent helper extraction boundary:
   - pure helpers that operate on ordinary Genia values and return ordinary Genia values may live in prelude
   - stage composition wrappers, curried/immediate dispatch glue, and rule/refine result defaulting are prelude responsibilities when they do not create, consume, or schedule Flow values
@@ -1073,6 +1074,7 @@ Flow semantics:
   - `rules()` is the identity stage
   - contract violations raise `RuntimeError` messages prefixed with `invalid-rules-result:`
   - rule orchestration, defaulting of omitted fields, and most contract checking are implemented in `src/genia/std/prelude/flow.genia` in this phase
+  - the host rules kernel expects the prelude layer to pass normalized rule output with `emit` and `ctx` fields already present
 - `keep_some_else` semantics:
   - it is an explicit Flow-stage helper for Option-returning per-item stages
   - for each input item `x`, it evaluates `stage(x)`

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The Semantic Spec System defines and validates observable behavior for Genia usi
 - The current shared spec runner executes Parse cases (spec/parse/) by calling the Python host parse adapter directly; for `kind: ok` cases the normalized AST is compared exactly; for `kind: error` cases the error type is compared exactly and the message is matched as a substring.
 - CLI shared specs use the same envelope shape as eval and IR specs. Their input fields are `source`, `file`, `command`, `stdin`, `argv`, and `debug_stdio`; their expected fields are `stdout`, `stderr`, and `exit_code`.
 - CLI shared specs cover file mode, command mode, and pipe mode only. Current shared CLI coverage includes basic file execution, file-mode `main(argv())` dispatch, trailing `argv()` exposure, command-mode final-value execution, valid pipe-mode Flow-stage usage, and current pipe-mode guidance/error cases for explicit `stdin`, explicit `run`, bare per-item stages, bare reducers, and non-Flow final results. REPL is excluded from shared executable coverage.
-- Flow shared coverage is partial and limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, deterministic `keep_some(...)` option-filtering behavior, and error propagation via invalid-reducer-on-flow diagnostic; focused core stdlib Flow coverage for direct `map` and `filter` over Flow inputs (including a composed chain) has been added but does not constitute full stdlib conformance.
+- Flow shared coverage is partial and limited to first-wave cases proving only lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, selected rule result defaulting/no-effect behavior, deterministic `keep_some(...)` option-filtering behavior, and error propagation via invalid-reducer-on-flow diagnostic; focused core stdlib Flow coverage for direct `map` and `filter` over Flow inputs (including a composed chain) has been added but does not constitute full stdlib conformance.
 - Error shared coverage is active but initial only. Current error shared cases assert only the observable surface: `stdout`, `stderr`, and `exit_code`; this now includes deterministic pattern-related failure coverage for match-miss, guard-all-fail, and malformed glob diagnostics. In this phase, `stdout` must be `""`, `stderr` must match exactly, `exit_code` must be `1`, and `notes` remain informational only.
 - Parse shared coverage is active but initial only. Current parse shared cases cover stable, already-implemented syntax forms. Parse spec coverage expands only when new forms are explicitly added and tested.
 
@@ -571,7 +571,7 @@ Current consistency note:
 - helpers such as `map_some`, `flat_map_some`, `then_get`, `then_first`, `then_nth`, and `then_find` remain useful for explicit Option values and higher-order code
 - public String, Map, Ref, Process, and sink helper names are prelude-backed wrappers over host-backed runtime primitives
 - the public Option helper surface remains help-visible through prelude/autoload metadata, while canonical `some(...)` / `none(...)` constructor forms also lower explicitly in Core IR
-- public Flow helper names `lines`, `rules`, `each`, `collect`, and `run` are also prelude-backed; the host keeps the lazy Flow kernel while `rules` orchestration/defaulting mostly live in prelude
+- public Flow helper names `lines`, `rules`, `each`, `collect`, and `run` are also prelude-backed; the host keeps the lazy Flow kernel while `rules` orchestration/defaulting live in prelude
 - Flow reuse and invalid flow-source failures are surfaced as clear Genia-facing runtime errors rather than raw Python iterator errors
 - `help()` now points users toward the public prelude-backed stdlib surface, while raw host-backed runtime names remain intentionally generic
 - REPL/debug output now renders structured absence with visible context metadata, for example `none("missing-key", {key: "name"})`
@@ -865,6 +865,7 @@ stdin |> lines |> take(2) |> each(print) |> run
   - `ctx` starts as `{}` and persists across items
   - `rules()` is the identity stage
   - orchestration, defaulting, and most contract validation now live in prelude/Genia code
+  - the host rules kernel consumes normalized rule output from prelude rather than providing user-visible defaults itself
 - `take` stops upstream pulling as soon as the limit is satisfied
 - `take` / `head` and quiet broken-pipe termination stop generator-backed upstream work promptly
 - `collect(flow)` materializes reusable data, while `run(flow)` drives effects to completion

--- a/scripts/genia-new.sh
+++ b/scripts/genia-new.sh
@@ -78,7 +78,7 @@ echo
 echo "Next prompt:"
 echo
 cat <<EOF
-Follow docs/process/preflight-prompt.md.
+Follow docs/process/00-preflight.md.
 
 CHANGE NAME: issue #${ISSUE} ${SLUG}
 CHANGE SLUG: ${CHANGE_SLUG}
@@ -89,3 +89,4 @@ ${HANDOFF_DIR}/
 Output pre-flight to:
 ${HANDOFF_DIR}/00-preflight.md
 EOF
+

--- a/spec/flow/README.md
+++ b/spec/flow/README.md
@@ -19,6 +19,8 @@ Current first-wave Flow shared coverage proves only:
 - `rules(..fns)` compatibility behavior (`rules-rule-emit-deterministic`)
 - `step_*` / `rule_*` equivalence (`step-rule-helper-equivalence`)
 - `rules()` identity stage (`rules-identity-stage`)
+- selected rule result defaulting and context persistence (`rules-defaulting-and-context`)
+- structured `none(reason, context)` as a no-effect rule result (`rules-structured-none-skips`)
 - error propagation via invalid-reducer-on-flow diagnostic (`flow-error-propagation-sum-on-flow`)
 - deterministic Option filtering in Flow pipelines via `keep_some(...)` (`flow-keep-some-parse-int`)
 - focused core stdlib Flow coverage: direct `map` over a Flow (`flow-map-basic`), direct `filter` over a Flow (`flow-filter-basic`), and a composed `map`/`filter` chain (`flow-map-filter-chain`)

--- a/spec/flow/rules-defaulting-and-context.yaml
+++ b/spec/flow/rules-defaulting-and-context.yaml
@@ -1,0 +1,21 @@
+name: rules-defaulting-and-context
+category: flow
+input:
+  source: |
+    count_seen(record, ctx) = {
+      seen = unwrap_or(0, get("seen", ctx)) + 1
+      some({ctx: {seen: seen}, emit: [seen]})
+    }
+
+    stdin
+      |> lines
+      |> rules((row, ctx) -> some({}), count_seen)
+      |> collect
+  stdin: |
+    a
+    b
+    c
+expected:
+  stdout: "[1, 2, 3]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/flow/rules-structured-none-skips.yaml
+++ b/spec/flow/rules-structured-none-skips.yaml
@@ -1,0 +1,15 @@
+name: rules-structured-none-skips
+category: flow
+input:
+  source: |
+    stdin
+      |> lines
+      |> rules((row, ctx) -> none("skip", {row: row}))
+      |> collect
+  stdin: |
+    a
+    b
+expected:
+  stdout: "[]\n"
+  stderr: ""
+  exit_code: 0

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -6381,11 +6381,15 @@ def make_global_env(
                     if not isinstance(result, GeniaMap):
                         raise RuntimeError("_rules_kernel expected a map result")
 
-                    emitted = result.get("emit", [])
+                    if not result.has("emit"):
+                        raise RuntimeError("_rules_kernel expected emit to be present")
+                    emitted = result.get("emit")
                     if not isinstance(emitted, list):
                         raise RuntimeError("_rules_kernel expected emit to be a list")
 
-                    current_ctx = result.get("ctx", current_ctx)
+                    if not result.has("ctx"):
+                        raise RuntimeError("_rules_kernel expected ctx to be present")
+                    current_ctx = result.get("ctx")
 
                     for value in emitted:
                         yield value

--- a/tests/unit/test_flow_split_boundary_121.py
+++ b/tests/unit/test_flow_split_boundary_121.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _function_body(source: str, name: str) -> str:
+    marker = f"    def {name}"
+    start = source.index(marker)
+    next_def = source.find("\n    def ", start + len(marker))
+    if next_def == -1:
+        return source[start:]
+    return source[start:next_def]
+
+
+def test_rules_kernel_does_not_default_rule_result_fields_in_host() -> None:
+    """Issue #121 keeps rule result defaulting in the portable Flow layer."""
+
+    source = (REPO / "src/genia/interpreter.py").read_text(encoding="utf-8")
+    body = _function_body(source, "rules_kernel_fn")
+
+    assert '.get("emit", [])' not in body
+    assert '.get("ctx", current_ctx)' not in body

--- a/tools/spec_runner/README.md
+++ b/tools/spec_runner/README.md
@@ -50,7 +50,7 @@ Verbose mode prints each spec name before execution starts, then prints a timing
 - Eval, CLI, and Flow cases normalize `stdout`/`stderr` line endings before comparison
 - Error cases use the same line-ending normalization as eval before comparison
 - The current CLI suite covers deterministic non-interactive file, command, and pipe cases, including file-mode `main(argv())` dispatch, command-mode final-value execution, valid pipe-mode Flow-stage usage, and current pipe-mode guidance/error cases for explicit `stdin`, explicit `run`, bare per-item stages, bare reducers, and non-Flow final results. REPL is not covered by shared executable specs
-- The current Flow suite covers first-wave observable contract cases only: lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, and error propagation via invalid-reducer-on-flow diagnostic
+- The current Flow suite covers first-wave observable contract cases only: lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, selected rule result defaulting/no-effect behavior, and error propagation via invalid-reducer-on-flow diagnostic
 - The current Error suite covers initial normalized observable contract cases only: `stdout`, `stderr`, and `exit_code`, with `stdout` expected to be `""`, `stderr` matched exactly, and `exit_code` expected to be `1`
 - IR cases normalize portable Core IR before comparison and fail if host-local optimized IR appears in the shared IR path
 - Failures are reported per spec with expected vs actual fields


### PR DESCRIPTION
  - lazy pull loop
  - single-use consumption tracking
  - source/runtime integration
  - early-close and generator/resource cleanup
  - sink/materialization boundaries
  - primitive Flow-producing / Flow-consuming boundaries needed by prelude wrappers