### PR TITLE
feat(callable): #237 move invoke_callable to callable module

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1698,7 +1698,7 @@ Notable autoloaded functions include:
 
 ## 8) Tail calls and optimization behavior
 
-Callable dispatch semantics (arity resolution, none-propagation detection, closure capture, TCO trampoline) live in `src/genia/callable.py`; expression dispatch and Flow dispatch are evaluator integration in `src/genia/interpreter.py`.
+Callable dispatch semantics (arity resolution, none-propagation detection, closure capture, TCO trampoline, invocation dispatch via `invoke_callable`) live in `src/genia/callable.py`; expression evaluation and pipeline dispatch (eval_call, eval_pipeline_stage) remain in `src/genia/interpreter.py`.
 
 Implemented tail-call/runtime behavior:
 

--- a/src/genia/callable.py
+++ b/src/genia/callable.py
@@ -1,15 +1,13 @@
-"""Genia callable runtime — issue #236.
+"""Genia callable runtime — issues #236, #237.
 
 Defines callable value types (GeniaFunction, GeniaFunctionGroup, TailCall),
-the TCO trampoline (eval_with_tco), and none-awareness detection helpers.
-
-Evaluator integration (invoke_callable, eval_call, eval_pipeline_stage) remains
-in interpreter.py and is out of scope for this module.
+the TCO trampoline (eval_with_tco), none-awareness detection helpers, and
+invoke_callable — the module-level dispatch entry point used by the evaluator.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 if __package__ in (None, ""):
     import sys
@@ -30,7 +28,15 @@ if __package__ in (None, ""):
         pattern_explicitly_handles_some,
     )
     from genia.environment import Env
-    from genia.values import GeniaMap, _merge_metadata_maps
+    from genia.values import (
+        GeniaFlow,
+        GeniaMap,
+        _merge_metadata_maps,
+        _normalize_absence,
+        _runtime_type_name,
+        is_none,
+        truthy,
+    )
     from genia.lexer import SourceSpan
 else:
     from .ir import (
@@ -46,7 +52,15 @@ else:
         pattern_explicitly_handles_some,
     )
     from .environment import Env
-    from .values import GeniaMap, _merge_metadata_maps
+    from .values import (
+        GeniaFlow,
+        GeniaMap,
+        _merge_metadata_maps,
+        _normalize_absence,
+        _runtime_type_name,
+        is_none,
+        truthy,
+    )
     from .lexer import SourceSpan
 
 
@@ -482,3 +496,167 @@ def _callable_explicitly_handles_some(fn: Any, arity: int, callee_node: Optional
             or _body_delegates_to_option_aware(genia_body)
         )
     return False
+
+
+# ---------------------------------------------------------------------------
+# Module-level invocation dispatcher — issue #237
+# ---------------------------------------------------------------------------
+
+def invoke_callable(
+    fn: Any,
+    args: list[Any],
+    *,
+    tail_position: bool,
+    callee_node: Optional[IrNode] = None,
+    skip_none_propagation: bool = False,
+    autoload_resolver: Optional[Callable[[str, int], Any]] = None,
+) -> Any:
+    """Dispatch a Genia callable value with evaluated args.
+
+    Dispatch order: none-guard → GeniaFunctionGroup → GeniaMap → str → callable.
+    Returns TailCall when tail_position=True for GeniaFunctionGroup and plain-callable
+    paths. The autoload_resolver callback is consulted at most once for
+    GeniaFunctionGroup when arity resolution initially fails.
+    """
+    if not skip_none_propagation:
+        first_none = next((arg for arg in args if is_none(arg)), None)
+        if first_none is not None and not _callable_explicitly_handles_none(fn, len(args), callee_node):
+            return first_none
+
+    if isinstance(fn, GeniaFunctionGroup):
+        if isinstance(callee_node, IrVar) and len(args) >= 1 and isinstance(args[-1], GeniaFlow):
+            if callee_node.name == "map" and len(args) == 2:
+                mapper = args[0]
+                source = args[1]
+
+                def _map_iterator() -> Any:
+                    items = source.consume()
+                    try:
+                        for item in items:
+                            yield invoke_callable(mapper, [item], tail_position=False, autoload_resolver=autoload_resolver)
+                    finally:
+                        if source.close_on_early_termination:
+                            close = getattr(items, "close", None)
+                            if callable(close):
+                                close()
+
+                return GeniaFlow(_map_iterator, label="map", close_on_early_termination=source.close_on_early_termination)
+
+            if callee_node.name == "filter" and len(args) == 2:
+                predicate = args[0]
+                source = args[1]
+
+                def _filter_iterator() -> Any:
+                    items = source.consume()
+                    try:
+                        for item in items:
+                            if truthy(invoke_callable(predicate, [item], tail_position=False, autoload_resolver=autoload_resolver)):
+                                yield item
+                    finally:
+                        if source.close_on_early_termination:
+                            close = getattr(items, "close", None)
+                            if callable(close):
+                                close()
+
+                return GeniaFlow(_filter_iterator, label="filter", close_on_early_termination=source.close_on_early_termination)
+
+            if callee_node.name == "take" and len(args) == 2:
+                count = args[0]
+                source = args[1]
+                if not isinstance(count, int) or isinstance(count, bool):
+                    raise TypeError("take expected an integer count as first argument")
+
+                def _take_iterator() -> Any:
+                    if count <= 0:
+                        return
+                    remaining = count
+                    items = source.consume()
+                    upstream = iter(items)
+                    try:
+                        while remaining > 0:
+                            try:
+                                item = next(upstream)
+                            except StopIteration:
+                                return
+                            yield item
+                            remaining -= 1
+                    finally:
+                        if source.close_on_early_termination:
+                            close = getattr(items, "close", None)
+                            if callable(close):
+                                close()
+
+                return GeniaFlow(_take_iterator, label="take", close_on_early_termination=source.close_on_early_termination)
+
+        arity = len(args)
+
+        def _resolve_target(functions: GeniaFunctionGroup, call_arity: int) -> Any:
+            exact = functions.get(call_arity)
+            if exact is not None:
+                return exact
+            vararg_matches = [
+                candidate
+                for candidate in functions.values()
+                if isinstance(candidate, GeniaFunction)
+                and candidate.rest_param is not None
+                and call_arity >= candidate.arity
+            ]
+            if len(vararg_matches) == 1:
+                return vararg_matches[0]
+            if len(vararg_matches) > 1:
+                callee = callee_node.name if isinstance(callee_node, IrVar) else "function"
+                candidates = ", ".join(
+                    f"{callee}/{candidate.arity}+"
+                    for candidate in sorted(vararg_matches, key=lambda f: f.arity)
+                )
+                raise TypeError(
+                    f"Ambiguous function resolution: {callee}/{call_arity}. Matching varargs: {candidates}"
+                )
+            return None
+
+        target = _resolve_target(fn, arity)
+
+        if target is None and autoload_resolver is not None and isinstance(callee_node, IrVar):
+            resolved = autoload_resolver(callee_node.name, arity)
+            if resolved is not None:
+                fn = resolved
+                if isinstance(fn, GeniaFunctionGroup):
+                    target = _resolve_target(fn, arity)
+
+        if target is None:
+            callee = callee_node.name if isinstance(callee_node, IrVar) else "function"
+            available = ", ".join(f"{callee}/{n}" for n in fn.sorted_arities())
+            raise TypeError(f"No matching function: {callee}/{arity}. Available: {available}")
+
+        if tail_position:
+            return TailCall(target, tuple(args))
+        return _normalize_absence(target(*args))
+
+    if isinstance(fn, GeniaMap):
+        arg_count = len(args)
+        if arg_count == 1:
+            return fn.get(args[0])
+        if arg_count == 2:
+            key = args[0]
+            if fn.has(key):
+                return fn.get(key)
+            return args[1]
+        raise TypeError(f"map callable expected 1 or 2 args, got {arg_count}")
+
+    if isinstance(fn, str):
+        arg_count = len(args)
+        if arg_count not in (1, 2):
+            raise TypeError(f"string projector expected 1 or 2 args, got {arg_count}")
+        target_map = args[0]
+        if not isinstance(target_map, GeniaMap):
+            raise TypeError("string projector expected a map-like target as first argument")
+        if arg_count == 2 and not target_map.has(fn):
+            return args[1]
+        return target_map.get(fn)
+
+    if not callable(fn):
+        raise TypeError(f"pipeline stage expected a callable value, received {_runtime_type_name(fn)}")
+
+    if tail_position:
+        return TailCall(fn, tuple(args))
+    return _normalize_absence(fn(*args))

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -183,7 +183,6 @@ if __package__ in (None, ""):
         TailCall as TailCall,
         eval_with_tco as eval_with_tco,
         invoke_callable as _invoke_callable,
-        _callable_explicitly_handles_none,
         _callable_explicitly_handles_some,
     )
 else:
@@ -330,7 +329,6 @@ else:
         TailCall as TailCall,
         eval_with_tco as eval_with_tco,
         invoke_callable as _invoke_callable,
-        _callable_explicitly_handles_none,
         _callable_explicitly_handles_some,
     )
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -164,6 +164,7 @@ if __package__ in (None, ""):
         is_none,
         make_none,
         symbol,
+        truthy,
     )
     from genia.optimizer import (
         optimize_program as optimize_program,
@@ -181,6 +182,7 @@ if __package__ in (None, ""):
         GeniaFunctionGroup as GeniaFunctionGroup,
         TailCall as TailCall,
         eval_with_tco as eval_with_tco,
+        invoke_callable as _invoke_callable,
         _callable_explicitly_handles_none,
         _callable_explicitly_handles_some,
     )
@@ -307,6 +309,7 @@ else:
         is_none,
         make_none,
         symbol,
+        truthy,
     )
     from .lexer import SourceSpan, lex
     from .parser import Parser
@@ -326,6 +329,7 @@ else:
         GeniaFunctionGroup as GeniaFunctionGroup,
         TailCall as TailCall,
         eval_with_tco as eval_with_tco,
+        invoke_callable as _invoke_callable,
         _callable_explicitly_handles_none,
         _callable_explicitly_handles_some,
     )
@@ -1418,148 +1422,19 @@ class Evaluator:
         callee_node: IrNode | None = None,
         skip_none_propagation: bool = False,
     ) -> Any:
-        if not skip_none_propagation:
-            first_none = next((arg for arg in args if is_none(arg)), None)
-            if first_none is not None and not _callable_explicitly_handles_none(fn, len(args), callee_node):
-                return first_none
+        def _autoload(name: str, arity: int) -> Any:
+            if self.env.try_autoload(name, arity):
+                return self.env.get(name)
+            return None
 
-        if isinstance(fn, GeniaFunctionGroup):
-            if isinstance(callee_node, IrVar) and len(args) == 2 and isinstance(args[1], GeniaFlow):
-                if callee_node.name == "map":
-                    mapper = args[0]
-                    source = args[1]
-
-                    def iterator() -> Iterable[Any]:
-                        items = source.consume()
-                        try:
-                            for item in items:
-                                yield self.invoke_callable(mapper, [item], tail_position=False)
-                        finally:
-                            if source.close_on_early_termination:
-                                close = getattr(items, "close", None)
-                                if callable(close):
-                                    close()
-
-                    return GeniaFlow(iterator, label="map", close_on_early_termination=source.close_on_early_termination)
-                if callee_node.name == "filter":
-                    predicate = args[0]
-                    source = args[1]
-
-                    def iterator() -> Iterable[Any]:
-                        items = source.consume()
-                        try:
-                            for item in items:
-                                if truthy(self.invoke_callable(predicate, [item], tail_position=False)):
-                                    yield item
-                        finally:
-                            if source.close_on_early_termination:
-                                close = getattr(items, "close", None)
-                                if callable(close):
-                                    close()
-
-                    return GeniaFlow(
-                        iterator,
-                        label="filter",
-                        close_on_early_termination=source.close_on_early_termination,
-                    )
-                if callee_node.name == "take":
-                    count = args[0]
-                    source = args[1]
-                    if not isinstance(count, int) or isinstance(count, bool):
-                        raise TypeError("take expected an integer count as first argument")
-
-                    def iterator() -> Iterable[Any]:
-                        if count <= 0:
-                            return
-                        remaining = count
-                        items = source.consume()
-                        upstream = iter(items)
-                        try:
-                            while remaining > 0:
-                                try:
-                                    item = next(upstream)
-                                except StopIteration:
-                                    return
-                                yield item
-                                remaining -= 1
-                        finally:
-                            if source.close_on_early_termination:
-                                close = getattr(items, "close", None)
-                                if callable(close):
-                                    close()
-
-                    return GeniaFlow(iterator, label="take", close_on_early_termination=source.close_on_early_termination)
-            arity = len(args)
-
-            def resolve_target(functions: GeniaFunctionGroup, call_arity: int) -> Any | None:
-                exact = functions.get(call_arity)
-                if exact is not None:
-                    return exact
-
-                vararg_matches = [
-                    candidate
-                    for candidate in functions.values()
-                    if isinstance(candidate, GeniaFunction)
-                    and candidate.rest_param is not None
-                    and call_arity >= candidate.arity
-                ]
-                if len(vararg_matches) == 1:
-                    return vararg_matches[0]
-                if len(vararg_matches) > 1:
-                    callee = callee_node.name if isinstance(callee_node, IrVar) else "function"
-                    candidates = ", ".join(
-                        f"{callee}/{candidate.arity}+"
-                        for candidate in sorted(vararg_matches, key=lambda f: f.arity)
-                    )
-                    raise TypeError(
-                        f"Ambiguous function resolution: {callee}/{call_arity}. Matching varargs: {candidates}"
-                    )
-                return None
-
-            target = resolve_target(fn, arity)
-
-            if target is None and isinstance(callee_node, IrVar):
-                if self.env.try_autoload(callee_node.name, arity):
-                    fn = self.env.get(callee_node.name)
-                    if isinstance(fn, GeniaFunctionGroup):
-                        target = resolve_target(fn, arity)
-
-            if target is None:
-                callee = callee_node.name if isinstance(callee_node, IrVar) else "function"
-                available = ", ".join(f"{callee}/{n}" for n in fn.sorted_arities())
-                raise TypeError(f"No matching function: {callee}/{arity}. Available: {available}")
-            if tail_position:
-                return TailCall(target, tuple(args))
-            return _normalize_absence(target(*args))
-
-        if isinstance(fn, GeniaMap):
-            arg_count = len(args)
-            if arg_count == 1:
-                return fn.get(args[0])
-            if arg_count == 2:
-                key = args[0]
-                if fn.has(key):
-                    return fn.get(key)
-                return args[1]
-            raise TypeError(f"map callable expected 1 or 2 args, got {arg_count}")
-
-        if isinstance(fn, str):
-            arg_count = len(args)
-            if arg_count not in (1, 2):
-                raise TypeError(f"string projector expected 1 or 2 args, got {arg_count}")
-            target = args[0]
-            if not isinstance(target, GeniaMap):
-                raise TypeError("string projector expected a map-like target as first argument")
-            if arg_count == 2 and not target.has(fn):
-                return args[1]
-            return target.get(fn)
-
-        if not callable(fn):
-            raise TypeError(f"pipeline stage expected a callable value, received {_runtime_type_name(fn)}")
-
-        if tail_position:
-            return TailCall(fn, tuple(args))
-        return _normalize_absence(fn(*args))
+        return _invoke_callable(
+            fn,
+            args,
+            tail_position=tail_position,
+            callee_node=callee_node,
+            skip_none_propagation=skip_none_propagation,
+            autoload_resolver=_autoload,
+        )
 
     def match_pattern(self, pattern: IrPattern, args: tuple[Any, ...]) -> Optional[dict[str, Any]]:
         return match_pattern(pattern, args)
@@ -1818,12 +1693,6 @@ class Evaluator:
                     return make_none("type-error", GeniaMap().put("source", ">=").put("left", _runtime_type_name(left)).put("right", _runtime_type_name(right)))
             case _:
                 raise RuntimeError(f"Unknown binary operator {node.op}")
-
-
-def truthy(value: Any) -> bool:
-    if is_none(value):
-        return False
-    return bool(value)
 
 
 def _annotation_metadata_error(name: str, value: Any, expected: str) -> TypeError:

--- a/src/genia/values.py
+++ b/src/genia/values.py
@@ -206,6 +206,14 @@ def _normalize_nil(value: Any) -> Any:
 
 
 OPTION_NONE = make_none("nil")
+
+
+def truthy(value: Any) -> bool:
+    if is_none(value):
+        return False
+    return bool(value)
+
+
 _RNG_MODULUS = 2**32
 _RNG_MULTIPLIER = 1664525
 _RNG_INCREMENT = 1013904223

--- a/tests/unit/test_callable_runtime.py
+++ b/tests/unit/test_callable_runtime.py
@@ -201,3 +201,288 @@ def test_callable_not_handles_none_for_unknown_name_group():
     from genia.callable import GeniaFunctionGroup, _callable_explicitly_handles_none
     fg = GeniaFunctionGroup(name="my_unknown_fn_xyz")
     assert _callable_explicitly_handles_none(fg, 1) is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers for invoke_callable tests
+# ---------------------------------------------------------------------------
+
+
+def _make_fn_returning(name, params, return_val, rest_param=None):
+    from genia.callable import GeniaFunction
+    from genia.environment import Env
+    from genia.ir import IrLiteral
+    return GeniaFunction(
+        name=name,
+        params=list(params),
+        rest_param=rest_param,
+        docstring=None,
+        body=IrLiteral(value=return_val),
+        closure=Env(None),
+    )
+
+
+def _make_group_1(name, return_val):
+    from genia.callable import GeniaFunctionGroup
+    fg = GeniaFunctionGroup(name=name)
+    fg.add_clause(_make_fn_returning(name, ["x"], return_val))
+    return fg
+
+
+def _make_ir_var(name):
+    from genia.ir import IrVar
+    return IrVar(name=name)
+
+
+# ---------------------------------------------------------------------------
+# 8. invoke_callable — import contract (FAIL before implementation)
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_callable_importable_from_genia_callable():
+    from genia.callable import invoke_callable  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# 9. truthy — moved to values.py (FAIL before implementation)
+# ---------------------------------------------------------------------------
+
+
+def test_truthy_importable_from_genia_values():
+    from genia.values import truthy  # noqa: F401
+
+
+def test_truthy_still_importable_from_interpreter():
+    from genia.interpreter import truthy  # noqa: F401
+
+
+def test_truthy_false_for_none():
+    from genia.values import truthy, make_none
+    assert truthy(make_none("x")) is False
+
+
+def test_truthy_true_for_nonzero_int():
+    from genia.values import truthy
+    assert truthy(1) is True
+
+
+def test_truthy_false_for_zero():
+    from genia.values import truthy
+    assert truthy(0) is False
+
+
+# ---------------------------------------------------------------------------
+# 10. invoke_callable — plain callable dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_callable_calls_plain_callable():
+    from genia.callable import invoke_callable
+    result = invoke_callable(lambda x: x + 1, [41], tail_position=False)
+    assert result == 42
+
+
+def test_invoke_callable_non_callable_raises_type_error():
+    from genia.callable import invoke_callable
+    with pytest.raises(TypeError, match="pipeline stage expected a callable value"):
+        invoke_callable(42, [], tail_position=False)
+
+
+def test_invoke_callable_plain_callable_tail_position_returns_tail_call():
+    from genia.callable import invoke_callable, TailCall
+    fn = lambda: 1  # noqa: E731
+    result = invoke_callable(fn, [], tail_position=True)
+    assert isinstance(result, TailCall)
+    assert result.fn is fn
+
+
+# ---------------------------------------------------------------------------
+# 11. invoke_callable — None short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_callable_none_short_circuits_before_dispatch():
+    from genia.callable import invoke_callable
+    from genia.values import make_none
+    n = make_none("x")
+    result = invoke_callable(lambda v: v, [n], tail_position=False)
+    assert result is n
+
+
+def test_invoke_callable_none_short_circuit_returns_first_none():
+    from genia.callable import invoke_callable
+    from genia.values import make_none
+    n1 = make_none("first")
+    n2 = make_none("second")
+    result = invoke_callable(lambda a, b: None, [n1, n2], tail_position=False)
+    assert result is n1
+
+
+def test_invoke_callable_none_propagation_skipped_when_flag_set():
+    from genia.callable import invoke_callable
+    from genia.values import make_none
+    n = make_none("x")
+    result = invoke_callable(lambda v: 99, [n], tail_position=False, skip_none_propagation=True)
+    assert result == 99
+
+
+# ---------------------------------------------------------------------------
+# 12. invoke_callable — GeniaMap dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_callable_map_arity_1_present_key():
+    from genia.callable import invoke_callable
+    from genia.values import GeniaMap
+    m = GeniaMap().put("name", "alice")
+    result = invoke_callable(m, ["name"], tail_position=False)
+    assert result == "alice"
+
+
+def test_invoke_callable_map_arity_1_missing_key_returns_none():
+    from genia.callable import invoke_callable
+    from genia.values import GeniaMap, is_none
+    m = GeniaMap()
+    result = invoke_callable(m, ["missing"], tail_position=False)
+    assert is_none(result)
+
+
+def test_invoke_callable_map_arity_2_missing_key_returns_default():
+    from genia.callable import invoke_callable
+    from genia.values import GeniaMap
+    m = GeniaMap()
+    result = invoke_callable(m, ["missing", "fallback"], tail_position=False)
+    assert result == "fallback"
+
+
+def test_invoke_callable_map_arity_2_present_key_ignores_default():
+    from genia.callable import invoke_callable
+    from genia.values import GeniaMap
+    m = GeniaMap().put("x", 99)
+    result = invoke_callable(m, ["x", "ignored"], tail_position=False)
+    assert result == 99
+
+
+def test_invoke_callable_map_wrong_arity_raises():
+    from genia.callable import invoke_callable
+    from genia.values import GeniaMap
+    m = GeniaMap()
+    with pytest.raises(TypeError, match="map callable expected 1 or 2 args, got 0"):
+        invoke_callable(m, [], tail_position=False)
+
+
+def test_invoke_callable_map_arity_3_raises():
+    from genia.callable import invoke_callable
+    from genia.values import GeniaMap
+    m = GeniaMap()
+    with pytest.raises(TypeError, match="map callable expected 1 or 2 args, got 3"):
+        invoke_callable(m, ["a", "b", "c"], tail_position=False)
+
+
+# ---------------------------------------------------------------------------
+# 13. invoke_callable — str projector dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_callable_str_projector_arity_1_present():
+    from genia.callable import invoke_callable
+    from genia.values import GeniaMap
+    m = GeniaMap().put("k", "val")
+    result = invoke_callable("k", [m], tail_position=False)
+    assert result == "val"
+
+
+def test_invoke_callable_str_projector_arity_2_missing_returns_default():
+    from genia.callable import invoke_callable
+    from genia.values import GeniaMap
+    m = GeniaMap()
+    result = invoke_callable("k", [m, "default"], tail_position=False)
+    assert result == "default"
+
+
+def test_invoke_callable_str_projector_non_map_raises():
+    from genia.callable import invoke_callable
+    with pytest.raises(TypeError, match="string projector expected a map-like target"):
+        invoke_callable("k", ["not_a_map"], tail_position=False)
+
+
+def test_invoke_callable_str_projector_wrong_arity_zero_raises():
+    from genia.callable import invoke_callable
+    with pytest.raises(TypeError, match="string projector expected 1 or 2 args, got 0"):
+        invoke_callable("k", [], tail_position=False)
+
+
+def test_invoke_callable_str_projector_wrong_arity_three_raises():
+    from genia.callable import invoke_callable
+    with pytest.raises(TypeError, match="string projector expected 1 or 2 args, got 3"):
+        invoke_callable("k", [None, None, None], tail_position=False)
+
+
+# ---------------------------------------------------------------------------
+# 14. invoke_callable — GeniaFunctionGroup dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_callable_function_group_exact_arity_returns_value():
+    from genia.callable import invoke_callable
+    fg = _make_group_1("f", 42)
+    result = invoke_callable(fg, [0], tail_position=False)
+    assert result == 42
+
+
+def test_invoke_callable_function_group_no_match_raises():
+    from genia.callable import invoke_callable
+    fg = _make_group_1("f", 0)
+    with pytest.raises(TypeError, match="No matching function: f/2"):
+        invoke_callable(fg, [1, 2], tail_position=False, callee_node=_make_ir_var("f"))
+
+
+def test_invoke_callable_function_group_tail_position_returns_tail_call():
+    from genia.callable import invoke_callable, TailCall
+    fg = _make_group_1("f", 0)
+    result = invoke_callable(fg, [1], tail_position=True)
+    assert isinstance(result, TailCall)
+
+
+def test_invoke_callable_function_group_ambiguous_varargs_raises():
+    from genia.callable import invoke_callable, GeniaFunctionGroup
+    fg = GeniaFunctionGroup(name="f")
+    fg.add_clause(_make_fn_returning("f", [], 0, rest_param="xs"))
+    fg.add_clause(_make_fn_returning("f", ["a"], 0, rest_param="xs"))
+    with pytest.raises(TypeError, match="Ambiguous function resolution"):
+        invoke_callable(fg, [1, 2], tail_position=False)
+
+
+def test_invoke_callable_function_group_autoload_resolver_called_on_miss():
+    from genia.callable import invoke_callable, GeniaFunctionGroup
+    fg_original = GeniaFunctionGroup(name="f")
+    fg_original.add_clause(_make_fn_returning("f", ["x", "y"], 0))
+    fg_resolved = GeniaFunctionGroup(name="f")
+    fg_resolved.add_clause(_make_fn_returning("f", ["x"], 7))
+    calls = []
+    def resolver(name, arity):
+        calls.append((name, arity))
+        return fg_resolved
+    result = invoke_callable(
+        fg_original, [1],
+        tail_position=False,
+        callee_node=_make_ir_var("f"),
+        autoload_resolver=resolver,
+    )
+    assert calls == [("f", 1)]
+    assert result == 7
+
+
+def test_invoke_callable_function_group_autoload_resolver_none_return_raises():
+    from genia.callable import invoke_callable, GeniaFunctionGroup
+    fg = GeniaFunctionGroup(name="f")
+    fg.add_clause(_make_fn_returning("f", ["x", "y"], 0))
+    def resolver(name, arity):
+        return None
+    with pytest.raises(TypeError, match="No matching function: f/1"):
+        invoke_callable(
+            fg, [1],
+            tail_position=False,
+            callee_node=_make_ir_var("f"),
+            autoload_resolver=resolver,
+        )


### PR DESCRIPTION
Evaluator delegates invocation dispatch to callable.py instead of owning it inline. Evaluator.invoke_callable becomes a thin wrapper that passes an autoload_resolver closure; callable.py gains the module-level invoke_callable with identical dispatch semantics.

truthy() moved from interpreter.py to values.py to eliminate the only remaining cross-module dependency.