### PR TITLE
feat(flow): add every(ms) time-based flow source

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -202,7 +202,7 @@ CLI contract summary (actual behavior):
   - raw callback invocation: `apply_raw(f, args)` — language-contract host primitive; bypasses `none(...)` short-circuit; `args` must be a list
   - promises: `force`
   - pair primitives: `cons`, `car`, `cdr`, `pair?`, `null?`
-  - Python-host-only simulation primitives (phase 2): explicit `rng(seed)` plus `rand`, `rand_int`, and `sleep`
+  - Python-host-only simulation primitives (phase 2): explicit `rng(seed)` plus `rand`, `rand_int`, `sleep`, and `every`
   - Python-host-only bytes/json/zip bridge builtins (phase 1):
     - `utf8_encode`, `utf8_decode`
     - internal JSON bridge primitives: `_json_parse`, `_json_stringify`
@@ -752,6 +752,10 @@ This recursive shape is not in tail position and can still hit Python recursion 
 - `sleep(ms)` blocks execution for `ms` milliseconds and raises:
   - `TypeError` when `ms` is not numeric
   - `ValueError` when `ms < 0`
+- `every(ms)` returns a lazy, pull-based, infinite Flow that emits `none("tick")` after each `ms`-millisecond wait; timing is best-effort host wall-clock; raises:
+  - `TypeError` when `ms` is not numeric
+  - `ValueError` when `ms < 0`
+  - `every(0)` is allowed; termination is controlled by downstream (e.g. `take`)
 
 The explicit seeded RNG is reproducible: the same seed yields the same sequence on the current Python host.
 These are blocking/runtime primitives only; they do not introduce scheduler/async runtime behavior.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1061,7 +1061,7 @@ Flow semantics:
   - Value functions (list in, value out): `reduce`, `sum`, `count`, `first`, `last`, `nth`, `take`, `drop`, `reverse`
   - Flow functions (flow in, flow out): `keep_some`, `keep_some_else`, `scan`, `rules`, `each`, `tee`, `merge`, `zip`, `head`
   - Polymorphic functions (work on both lists and flows): `map`, `filter`
-  - Bridge: source (value → flow): `lines`, `evolve`, `stdin_keys`
+  - Bridge: source (value → flow): `lines`, `evolve`, `stdin_keys`, `every`
   - Bridge: materialize (flow → value): `collect`
   - Bridge: consume (flow → effect): `run`
   - Option behavior (`some`/`none` auto-lifting in pipelines) composes with the Flow vs Value distinction but does not erase it
@@ -1622,6 +1622,7 @@ Behavior:
   - `rand_int(n)`
   - `rand_int(rng_state, n)`
 - `sleep(ms)`
+- `every(ms)`
 
 Behavior:
 
@@ -1633,6 +1634,7 @@ Behavior:
 - the explicit seeded RNG uses a simple 32-bit LCG so the same seed yields the same sequence on the current Python host
 - `rand_int(...)` raises clear `TypeError` for non-integer `n` and `ValueError` for `n <= 0` in both convenience and seeded forms
 - `sleep(ms)` blocks current execution for `ms` milliseconds; raises clear `TypeError` for non-numeric values and `ValueError` for negative values
+- `every(ms)` returns a lazy, pull-based, infinite Flow; each pull waits `ms` milliseconds then emits `none("tick")`; timing is best-effort host wall-clock and not deterministic; raises clear `TypeError` for non-numeric values and `ValueError` for negative values; `every(0)` is allowed and emits without delay; host-backed and non-portable
 
 ## 7) Autoloaded stdlib
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository currently provides:
 - host-backed refs with public prelude-backed helpers (`ref`, `ref_get`, `ref_set`, `ref_update`) (**Python-host-only**)
 - raw host-backed `argv()` plus prelude-backed CLI parsing helpers (`cli_parse`, `cli_flag?`, `cli_option`, `cli_option_or`) (**Python-host-only**)
 - a minimal allowlisted Python host-interop layer via ordinary module imports (`import python`, `import python.json as pyjson`) (**Python-host-only**)
-- simulation primitives (`rng`, `rand`, `rand_int`, `sleep`) (**Python-host-only**)
+- simulation primitives (`rng`, `rand`, `rand_int`, `sleep`, `every`) (**Python-host-only**)
 - terminal helpers and input sources (`clear_screen`, `move_cursor`, `render_grid`, `stdin_keys`) (**Python-host-only**)
 - a minimal host-backed HTTP serving foundation with prelude helpers (`serve_http`, `get`, `post`, `route_request`, `ok_text`, `json`) (**Python-host-only**)
 - shell pipeline stage `$(command)` for invoking host shell commands inside pipelines (**Python-host-only**, not portable; see below)

--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -105,9 +105,11 @@ Python-host-only runtime helpers in the current reference host; not part of the 
 | convenience int | `rand_int(n)` |
 | seeded int | `rand_int(rng_state, n)` |
 | delay | `sleep(ms)` |
+| time-based flow source | `every(ms)` |
 
 Use `rng(seed)` plus the seeded overloads when you need reproducible tests or demos.
 Use `rand()` / `rand_int(n)` when host-backed nondeterministic convenience is fine.
+Use `every(ms)` to drive pull-based pipelines at a fixed interval; each pull emits `none("tick")`.
 
 ## Flow (Runtime Value Family)
 
@@ -115,6 +117,7 @@ Use `rand()` / `rand_int(n)` when host-backed nondeterministic convenience is fi
 | --- | --- |
 | source bridge | `lines(source)` |
 | experimental source bridge | `evolve()`, `evolve(count)` |
+| time-based source | `every(ms)` |
 | split / fan-in | `tee(flow) -> [left_flow, right_flow]`, `merge(flow1, flow2)`, `merge(pair)`, `zip(flow1, flow2)`, `zip(pair)` |
 | option keep-only | `keep_some(flow)`, `keep_some(stage, flow)` |
 | option routing | `keep_some_else(stage, dead_handler)`, `keep_some_else(stage, dead_handler, flow)` |

--- a/docs/host-interop/capabilities.md
+++ b/docs/host-interop/capabilities.md
@@ -59,7 +59,7 @@ Capabilities connecting Genia programs to the host I/O streams. These are `langu
 
 ---
 
-### Group: Time / Sleep
+### Group: Time
 
 #### `time.sleep`
 
@@ -72,6 +72,18 @@ Capabilities connecting Genia programs to the host I/O streams. These are `langu
   - `ValueError` — when `ms < 0`
 - **portability:** `Python-host-only`
 - **notes:** Blocking primitive only. Does not introduce a scheduler, async/await surface, or event loop.
+
+#### `time.every`
+
+- **name:** `time.every`
+- **genia_surface:** `every(ms)`
+- **input:** `ms` — Number (non-negative)
+- **output:** lazy, pull-based, infinite `Flow`; each pull waits `ms` milliseconds and emits `none("tick")`
+- **errors:**
+  - `TypeError` — when `ms` is not numeric
+  - `ValueError` — when `ms < 0`
+- **portability:** `Python-host-only`
+- **notes:** Pull-based only — no background thread, no scheduler. Timing is best-effort host wall-clock and not deterministic. `every(0)` is allowed. Termination is controlled by downstream (e.g. `take`). Does not introduce a scheduler, async/await surface, or cancellation API.
 
 ---
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -2409,6 +2409,19 @@ def make_global_env(
         time.sleep(ms / 1000.0)
         return None
 
+    def every_fn(ms: Any) -> GeniaFlow:
+        if not isinstance(ms, (int, float)) or isinstance(ms, bool):
+            raise TypeError("every expected a non-negative number")
+        if ms < 0:
+            raise ValueError("every expected ms >= 0")
+
+        def iterator():
+            while True:
+                time.sleep(ms / 1000.0)
+                yield make_none("tick")
+
+        return GeniaFlow(iterator, label=f"every({ms})")
+
     def utf8_encode_fn(value: Any) -> GeniaBytes:
         text = _ensure_string(value, "utf8_encode")
         return GeniaBytes(text.encode("utf-8"))
@@ -2966,6 +2979,7 @@ def make_global_env(
     env.set("_rand_int", rand_int_fn)
     env.set("_rand_int_seeded", seeded_rand_int_fn)
     env.set("sleep", sleep_fn)
+    env.set("every", every_fn)
     env.set("_byte_length", byte_length_fn)
     env.set("_is_empty", is_empty_fn)
     env.set("_concat", concat_fn)

--- a/tests/unit/test_time_sources.py
+++ b/tests/unit/test_time_sources.py
@@ -1,0 +1,58 @@
+import time
+
+import pytest
+
+from genia import make_global_env, run_source
+from genia.interpreter import GeniaFlow
+from genia.values import is_none
+
+
+def test_every_returns_a_flow():
+    result = run_source("every(1)", make_global_env())
+    assert isinstance(result, GeniaFlow)
+
+
+def test_every_take_3_emits_3_tick_values():
+    result = run_source("every(1) |> take(3) |> collect", make_global_env())
+    assert len(result) == 3
+    assert all(is_none(v) and v.reason == "tick" for v in result)
+
+
+def test_every_emits_after_minimum_elapsed_time():
+    started = time.perf_counter()
+    run_source("every(5) |> take(2) |> collect", make_global_env())
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    assert elapsed_ms >= 5.0
+
+
+def test_every_accepts_zero():
+    result = run_source("every(0) |> take(2) |> collect", make_global_env())
+    assert len(result) == 2
+
+
+def test_every_rejects_non_number():
+    with pytest.raises(TypeError, match="every expected a non-negative number"):
+        run_source('every("1")', make_global_env())
+
+
+def test_every_rejects_negative():
+    with pytest.raises(ValueError, match="every expected ms >= 0"):
+        run_source("every(-1)", make_global_env())
+
+
+def test_every_flow_is_single_use():
+    src = """
+    t = every(1)
+    t |> take(1) |> collect
+    t |> take(1) |> collect
+    """
+    with pytest.raises(RuntimeError, match="Flow has already been consumed"):
+        run_source(src, make_global_env())
+
+
+def test_every_early_termination_does_not_continue_ticking():
+    started = time.perf_counter()
+    result = run_source("every(100) |> take(1) |> collect", make_global_env())
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    assert len(result) == 1
+    assert elapsed_ms < 500.0


### PR DESCRIPTION
every(ms) returns a lazy, pull-based, infinite Flow that emits none(tick) after each ms-millisecond wait. Timing is best-effort host wall-clock. Termination is controlled downstream (e.g. take). Python reference host only; no scheduler, no background thread.