### PR TITLE
Feature/issue 167 add format

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -188,6 +188,8 @@ CLI contract summary (actual behavior):
     - `display(value)` returns the user-facing display representation string without writing output
     - `debug_repr(value)` returns the debug representation string without writing output
     - these entry points are minimal #185 surface area; #166 owns the broader Representation System model
+  - public prelude-backed string formatting helper:
+    - `format(template, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; it supports escaped braces with `{{` and `}}`
   - public flow helpers are prelude-backed wrappers: `lines`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, plus `rule_*` compatibility constructors and preferred `step_*` constructors
   - public sink helpers are prelude-backed wrappers: `write`, `writeln`, `flush`
   - raw CLI primitive: `argv`
@@ -326,7 +328,7 @@ CLI contract summary (actual behavior):
 - output routing:
   - `print(...)` writes to `stdout`
   - `log(...)` writes to `stderr`
-  - `display(value)` and `debug_repr(value)` return representation strings and do not write to `stdout` or `stderr`
+  - `display(value)`, `debug_repr(value)`, and `format(template, values)` return strings and do not write to `stdout` or `stderr`
   - `write(sink, value)` / `writeln(sink, value)` are public prelude-backed wrappers over the host sink bridge
   - `flush(sink)` is a public prelude-backed wrapper over the host sink bridge
   - broken pipe on `stdout` output in command/file execution is treated as normal downstream termination without a Python traceback

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -944,9 +944,18 @@ Representation System entry points (#185, implemented):
 - They are entry points into that system, not independent formatting utilities.
 - `display(value)` returns a string containing the user-facing display representation of `value`.
 - `debug_repr(value)` returns a string containing the debug representation of `value`.
-- Neither function writes to `stdout` or `stderr`.
-- Neither function mutates runtime state.
-- Neither function changes `print`, `log`, `write`, `writeln`, REPL result display, CLI final-result rendering, or pipeline semantics.
+- `format(template, values)` is a public prelude-backed helper for building strings from a small placeholder template.
+- `format(template, values)` returns a string and does not write output.
+- `format` supports only:
+  - named placeholders such as `{name}`, looked up in a map by string key
+  - positional placeholders such as `{0}`, looked up in a list by zero-based index
+  - escaped braces `{{` and `}}`
+- Placeholder replacements use the same user-facing display representation as `display(value)`.
+- Missing fields and invalid placeholders raise deterministic errors.
+- `format` does not support field paths, interpolation string syntax, width/alignment/precision specifiers, localization, tagged formats, or debug rendering.
+- These helpers do not write to `stdout` or `stderr`.
+- These helpers do not mutate runtime state.
+- These helpers do not change `print`, `log`, `write`, `writeln`, REPL result display, CLI final-result rendering, or pipeline semantics.
 - `print(value)`, `log(value)`, `write(sink, value)`, and `writeln(sink, value)` remain output operations; `display(value)` and `debug_repr(value)` return ordinary strings.
 - For ordinary runtime data, the minimal implemented representation behavior is:
   - strings: `display("x")` returns `x`; `debug_repr("x")` returns `"x"` with debug escaping

--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Current consistency note:
 - `help()` now points users toward the public prelude-backed stdlib surface, while raw host-backed runtime names remain intentionally generic
 - REPL/debug output now renders structured absence with visible context metadata, for example `none("missing-key", {key: "name"})`
 - `display(value)` and `debug_repr(value)` are the first public Representation System entry points: they return display/debug representation strings without writing output
+- `format(template, values)` is a public prelude-backed string helper: it returns a string, uses `display(value)` for replacements, and supports only `{name}`, `{0}`, `{{`, and `}}`
 - `some(pattern)`, `none(reason)`, and `none(reason, context)` are supported in pattern matching for Option values
 - new `?`-suffixed APIs are boolean-returning; `get?` remains the current compatibility exception and `get` is the preferred maybe-aware lookup name
 - Flow, MetaEnv, Ref, and Process handles are runtime values, but they are not plain data in the same sense as numbers/lists/maps
@@ -890,6 +891,7 @@ flush(stdout)
 - `flush(sink)` flushes a sink and returns `none("nil")`
 - `print(...)` writes to `stdout`, and `log(...)` writes to `stderr`
 - `display(value)` and `debug_repr(value)` return representation strings and do not write output
+- `format(template, values)` returns a string built from named or positional placeholders and does not write output
 - `input()` remains independent of `stdin`
 - broken pipe on `stdout` output in Unix pipelines is treated as normal downstream termination
 - flow-driven stdout writes use the same quiet broken-pipe path

--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -67,8 +67,15 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 | --- | --- |
 | display string | `display(value)` |
 | debug string | `debug_repr(value)` |
+| template string | `format(template, values)` |
 
-`display` and `debug_repr` return strings. They do not write output. They are the first public Representation System entry points; broader representation behavior belongs to #166.
+`display`, `debug_repr`, and `format` return strings. They do not write output. `format` supports only named placeholders (`{name}`), positional placeholders (`{0}`), and escaped braces (`{{`, `}}`); replacements use display rendering.
+
+<!-- [case: core-format-named] -->
+```genia
+format("Hello {name}", {name: "Genia"})
+```
+Classification: **Valid** (directly tested)
 
 ## List And Sequence Helpers
 
@@ -90,6 +97,7 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 | --- | --- |
 | checks | `is_empty(s)`, `contains(s, needle)`, `starts_with(s, prefix)`, `ends_with(s, suffix)` |
 | transforms | `concat(a, b)`, `lower(s)`, `upper(s)`, `trim(s)`, `trim_start(s)`, `trim_end(s)` |
+| formatting | `format(template, values)` |
 | split / join | `split(s, sep)`, `split_whitespace(s)`, `join(sep, xs)` |
 | option-returning | `find(s, needle)`, `parse_int(text)`, `parse_int(text, base)` |
 
@@ -283,7 +291,7 @@ first_or_none(xs) =
 | Helper | Shape |
 | --- | --- |
 | sink output | `write(sink, value)`, `writeln(sink, value)`, `flush(sink)` |
-| representation strings | `display(value)`, `debug_repr(value)` |
+| representation strings | `display(value)`, `debug_repr(value)`, `format(template, values)` |
 | terminal control | `clear_screen()`, `move_cursor(x, y)` |
 | grid rendering | `render_grid(grid)` |
 

--- a/spec/error/error-format-invalid-placeholder-chars.yaml
+++ b/spec/error/error-format-invalid-placeholder-chars.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format invalid placeholder dot notation
+source: |
+  format("Value: {user.name}", {user: {name: "Alice"}})
+stdout: ""
+stderr: |
+  Error: format invalid placeholder
+exit_code: 1

--- a/spec/error/error-format-invalid-placeholder-chars.yaml
+++ b/spec/error/error-format-invalid-placeholder-chars.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format invalid placeholder dot notation
-source: |
-  format("Value: {user.name}", {user: {name: "Alice"}})
-stdout: ""
-stderr: |
-  Error: format invalid placeholder
-exit_code: 1
+name: error-format-invalid-placeholder-chars
+category: error
+input:
+  source: |
+    format("Value: {user.name}", {user: {name: "Alice"}})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format invalid placeholder
+  exit_code: 1

--- a/spec/error/error-format-invalid-placeholder-empty.yaml
+++ b/spec/error/error-format-invalid-placeholder-empty.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format invalid placeholder empty
+source: |
+  format("Value: {}", {})
+stdout: ""
+stderr: |
+  Error: format invalid placeholder
+exit_code: 1

--- a/spec/error/error-format-invalid-placeholder-empty.yaml
+++ b/spec/error/error-format-invalid-placeholder-empty.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format invalid placeholder empty
-source: |
-  format("Value: {}", {})
-stdout: ""
-stderr: |
-  Error: format invalid placeholder
-exit_code: 1
+name: error-format-invalid-placeholder-empty
+category: error
+input:
+  source: |
+    format("Value: {}", {})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format invalid placeholder
+  exit_code: 1

--- a/spec/error/error-format-invalid-placeholder-whitespace.yaml
+++ b/spec/error/error-format-invalid-placeholder-whitespace.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format invalid placeholder whitespace
+source: |
+  format("Value: { name }", {name: "test"})
+stdout: ""
+stderr: |
+  Error: format invalid placeholder
+exit_code: 1

--- a/spec/error/error-format-invalid-placeholder-whitespace.yaml
+++ b/spec/error/error-format-invalid-placeholder-whitespace.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format invalid placeholder whitespace
-source: |
-  format("Value: { name }", {name: "test"})
-stdout: ""
-stderr: |
-  Error: format invalid placeholder
-exit_code: 1
+name: error-format-invalid-placeholder-whitespace
+category: error
+input:
+  source: |
+    format("Value: { name }", {name: "test"})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format invalid placeholder
+  exit_code: 1

--- a/spec/error/error-format-missing-named-field.yaml
+++ b/spec/error/error-format-missing-named-field.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format missing named field
-source: |
-  format("Hello {name}!", {greeting: "Hi"})
-stdout: ""
-stderr: |
-  Error: format missing field: name
-exit_code: 1
+name: error-format-missing-named-field
+category: error
+input:
+  source: |
+    format("Hello {name}!", {greeting: "Hi"})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format missing field: name
+  exit_code: 1

--- a/spec/error/error-format-missing-named-field.yaml
+++ b/spec/error/error-format-missing-named-field.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format missing named field
+source: |
+  format("Hello {name}!", {greeting: "Hi"})
+stdout: ""
+stderr: |
+  Error: format missing field: name
+exit_code: 1

--- a/spec/error/error-format-missing-positional-field.yaml
+++ b/spec/error/error-format-missing-positional-field.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format missing positional field
-source: |
-  format("First {0} Second {1}", ["A"])
-stdout: ""
-stderr: |
-  Error: format missing field: 1
-exit_code: 1
+name: error-format-missing-positional-field
+category: error
+input:
+  source: |
+    format("First {0} Second {1}", ["A"])
+expected:
+  stdout: ""
+  stderr: |
+    Error: format missing field: 1
+  exit_code: 1

--- a/spec/error/error-format-missing-positional-field.yaml
+++ b/spec/error/error-format-missing-positional-field.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format missing positional field
+source: |
+  format("First {0} Second {1}", ["A"])
+stdout: ""
+stderr: |
+  Error: format missing field: 1
+exit_code: 1

--- a/spec/error/error-format-named-non-map.yaml
+++ b/spec/error/error-format-named-non-map.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format named placeholder non-map values
+source: |
+  format("Hello {name}", ["list"])
+stdout: ""
+stderr: |
+  Error: format expected a map for named placeholder: name
+exit_code: 1

--- a/spec/error/error-format-named-non-map.yaml
+++ b/spec/error/error-format-named-non-map.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format named placeholder non-map values
-source: |
-  format("Hello {name}", ["list"])
-stdout: ""
-stderr: |
-  Error: format expected a map for named placeholder: name
-exit_code: 1
+name: error-format-named-non-map
+category: error
+input:
+  source: |
+    format("Hello {name}", ["list"])
+expected:
+  stdout: ""
+  stderr: |
+    Error: format expected a map for named placeholder: name
+  exit_code: 1

--- a/spec/error/error-format-non-string-template.yaml
+++ b/spec/error/error-format-non-string-template.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format non-string template
-source: |
-  format(42, {})
-stdout: ""
-stderr: |
-  Error: format expected a string template
-exit_code: 1
+name: error-format-non-string-template
+category: error
+input:
+  source: |
+    format(42, {})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format expected a string template
+  exit_code: 1

--- a/spec/error/error-format-non-string-template.yaml
+++ b/spec/error/error-format-non-string-template.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format non-string template
+source: |
+  format(42, {})
+stdout: ""
+stderr: |
+  Error: format expected a string template
+exit_code: 1

--- a/spec/error/error-format-positional-non-list.yaml
+++ b/spec/error/error-format-positional-non-list.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format positional placeholder non-list values
-source: |
-  format("Item {0}", {num: 1})
-stdout: ""
-stderr: |
-  Error: format expected a list for positional placeholder: 0
-exit_code: 1
+name: error-format-positional-non-list
+category: error
+input:
+  source: |
+    format("Item {0}", {num: 1})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format expected a list for positional placeholder: 0
+  exit_code: 1

--- a/spec/error/error-format-positional-non-list.yaml
+++ b/spec/error/error-format-positional-non-list.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format positional placeholder non-list values
+source: |
+  format("Item {0}", {num: 1})
+stdout: ""
+stderr: |
+  Error: format expected a list for positional placeholder: 0
+exit_code: 1

--- a/spec/error/error-format-unmatched-left-brace.yaml
+++ b/spec/error/error-format-unmatched-left-brace.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format unmatched left brace
-source: |
-  format("Value: {", {})
-stdout: ""
-stderr: |
-  Error: format invalid placeholder
-exit_code: 1
+name: error-format-unmatched-left-brace
+category: error
+input:
+  source: |
+    format("Value: {", {})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format invalid placeholder
+  exit_code: 1

--- a/spec/error/error-format-unmatched-left-brace.yaml
+++ b/spec/error/error-format-unmatched-left-brace.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format unmatched left brace
+source: |
+  format("Value: {", {})
+stdout: ""
+stderr: |
+  Error: format invalid placeholder
+exit_code: 1

--- a/spec/error/error-format-unmatched-right-brace.yaml
+++ b/spec/error/error-format-unmatched-right-brace.yaml
@@ -1,8 +1,10 @@
-kind: error
-name: error format unmatched right brace
-source: |
-  format("Value: }", {})
-stdout: ""
-stderr: |
-  Error: format invalid placeholder
-exit_code: 1
+name: error-format-unmatched-right-brace
+category: error
+input:
+  source: |
+    format("Value: }", {})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format invalid placeholder
+  exit_code: 1

--- a/spec/error/error-format-unmatched-right-brace.yaml
+++ b/spec/error/error-format-unmatched-right-brace.yaml
@@ -1,0 +1,8 @@
+kind: error
+name: error format unmatched right brace
+source: |
+  format("Value: }", {})
+stdout: ""
+stderr: |
+  Error: format invalid placeholder
+exit_code: 1

--- a/spec/eval/format-display-number.yaml
+++ b/spec/eval/format-display-number.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format display number
+source: |
+  format("Answer: {answer}", {answer: 42})
+stdout: |
+  Answer: 42
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-display-number.yaml
+++ b/spec/eval/format-display-number.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format display number
-source: |
-  format("Answer: {answer}", {answer: 42})
-stdout: |
-  Answer: 42
-stderr: ""
-exit_code: 0
+name: format-display-number
+category: eval
+input:
+  source: |
+    format("Answer: {answer}", {answer: 42})
+expected:
+  stdout: |
+    Answer: 42
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-display-number.yaml
+++ b/spec/eval/format-display-number.yaml
@@ -5,6 +5,6 @@ input:
     format("Answer: {answer}", {answer: 42})
 expected:
   stdout: |
-    Answer: 42
+    "Answer: 42"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-display-option-none.yaml
+++ b/spec/eval/format-display-option-none.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format display option none
+source: |
+  format("Value: {val}", {val: none})
+stdout: |
+  Value: none
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-display-option-none.yaml
+++ b/spec/eval/format-display-option-none.yaml
@@ -5,6 +5,6 @@ input:
     format("Value: {val}", {val: none})
 expected:
   stdout: |
-    Value: none("nil")
+    "Value: none(\"nil\")"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-display-option-none.yaml
+++ b/spec/eval/format-display-option-none.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format display option none
-source: |
-  format("Value: {val}", {val: none})
-stdout: |
-  Value: none
-stderr: ""
-exit_code: 0
+name: format-display-option-none
+category: eval
+input:
+  source: |
+    format("Value: {val}", {val: none})
+expected:
+  stdout: |
+    Value: none("nil")
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-display-option-some.yaml
+++ b/spec/eval/format-display-option-some.yaml
@@ -5,6 +5,6 @@ input:
     format("Value: {val}", {val: some(100)})
 expected:
   stdout: |
-    Value: some(100)
+    "Value: some(100)"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-display-option-some.yaml
+++ b/spec/eval/format-display-option-some.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format display option some
-source: |
-  format("Value: {val}", {val: some(100)})
-stdout: |
-  Value: some(100)
-stderr: ""
-exit_code: 0
+name: format-display-option-some
+category: eval
+input:
+  source: |
+    format("Value: {val}", {val: some(100)})
+expected:
+  stdout: |
+    Value: some(100)
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-display-option-some.yaml
+++ b/spec/eval/format-display-option-some.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format display option some
+source: |
+  format("Value: {val}", {val: some(100)})
+stdout: |
+  Value: some(100)
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-display-string.yaml
+++ b/spec/eval/format-display-string.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format display string without quotes
+source: |
+  format("Result: {text}", {text: "hello"})
+stdout: |
+  Result: hello
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-display-string.yaml
+++ b/spec/eval/format-display-string.yaml
@@ -5,6 +5,6 @@ input:
     format("Result: {text}", {text: "hello"})
 expected:
   stdout: |
-    Result: hello
+    "Result: hello"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-display-string.yaml
+++ b/spec/eval/format-display-string.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format display string without quotes
-source: |
-  format("Result: {text}", {text: "hello"})
-stdout: |
-  Result: hello
-stderr: ""
-exit_code: 0
+name: format-display-string
+category: eval
+input:
+  source: |
+    format("Result: {text}", {text: "hello"})
+expected:
+  stdout: |
+    Result: hello
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-empty-template.yaml
+++ b/spec/eval/format-empty-template.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format empty template
+source: |
+  format("", {})
+stdout: |
+  
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-empty-template.yaml
+++ b/spec/eval/format-empty-template.yaml
@@ -4,6 +4,6 @@ input:
   source: |
     format("", {})
 expected:
-  stdout: "\n"
+  stdout: "\"\"\n"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-empty-template.yaml
+++ b/spec/eval/format-empty-template.yaml
@@ -1,8 +1,9 @@
-kind: eval
-name: format empty template
-source: |
-  format("", {})
-stdout: |
-  
-stderr: ""
-exit_code: 0
+name: format-empty-template
+category: eval
+input:
+  source: |
+    format("", {})
+expected:
+  stdout: "\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-escaped-braces-left.yaml
+++ b/spec/eval/format-escaped-braces-left.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format escaped left brace
+source: |
+  format("Set {{x}}", {})
+stdout: |
+  Set {x}
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-escaped-braces-left.yaml
+++ b/spec/eval/format-escaped-braces-left.yaml
@@ -5,6 +5,6 @@ input:
     format("Set {{x}}", {})
 expected:
   stdout: |
-    Set {x}
+    "Set {x}"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-escaped-braces-left.yaml
+++ b/spec/eval/format-escaped-braces-left.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format escaped left brace
-source: |
-  format("Set {{x}}", {})
-stdout: |
-  Set {x}
-stderr: ""
-exit_code: 0
+name: format-escaped-braces-left
+category: eval
+input:
+  source: |
+    format("Set {{x}}", {})
+expected:
+  stdout: |
+    Set {x}
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-escaped-braces-mixed.yaml
+++ b/spec/eval/format-escaped-braces-mixed.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format mixed escaped and regular braces
-source: |
-  format("{{key}} = {0}", ["value"])
-stdout: |
-  {key} = value
-stderr: ""
-exit_code: 0
+name: format-escaped-braces-mixed
+category: eval
+input:
+  source: |
+    format("{{key}} = {0}", ["value"])
+expected:
+  stdout: |
+    {key} = value
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-escaped-braces-mixed.yaml
+++ b/spec/eval/format-escaped-braces-mixed.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format mixed escaped and regular braces
+source: |
+  format("{{key}} = {0}", ["value"])
+stdout: |
+  {key} = value
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-escaped-braces-mixed.yaml
+++ b/spec/eval/format-escaped-braces-mixed.yaml
@@ -5,6 +5,6 @@ input:
     format("{{key}} = {0}", ["value"])
 expected:
   stdout: |
-    {key} = value
+    "{key} = value"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-escaped-braces-right.yaml
+++ b/spec/eval/format-escaped-braces-right.yaml
@@ -5,6 +5,6 @@ input:
     format("End }}", {})
 expected:
   stdout: |
-    End }
+    "End }"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-escaped-braces-right.yaml
+++ b/spec/eval/format-escaped-braces-right.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format escaped right brace
-source: |
-  format("End }}", {})
-stdout: |
-  End }
-stderr: ""
-exit_code: 0
+name: format-escaped-braces-right
+category: eval
+input:
+  source: |
+    format("End }}", {})
+expected:
+  stdout: |
+    End }
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-escaped-braces-right.yaml
+++ b/spec/eval/format-escaped-braces-right.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format escaped right brace
+source: |
+  format("End }}", {})
+stdout: |
+  End }
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-mixed-named-positional.yaml
+++ b/spec/eval/format-mixed-named-positional.yaml
@@ -1,8 +1,0 @@
-kind: eval
-name: format mixed named and positional placeholders
-source: |
-  format("Named {key}: {0}, Value: {val}", ["X"], {key: "K", val: "V"})
-stdout: |
-  Named K: X, Value: V
-stderr: ""
-exit_code: 0

--- a/spec/eval/format-mixed-named-positional.yaml
+++ b/spec/eval/format-mixed-named-positional.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format mixed named and positional placeholders
+source: |
+  format("Named {key}: {0}, Value: {val}", ["X"], {key: "K", val: "V"})
+stdout: |
+  Named K: X, Value: V
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-named-basic.yaml
+++ b/spec/eval/format-named-basic.yaml
@@ -5,6 +5,6 @@ input:
     format("Hello {name}!", {name: "Alice"})
 expected:
   stdout: |
-    Hello Alice!
+    "Hello Alice!"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-named-basic.yaml
+++ b/spec/eval/format-named-basic.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format named placeholder basic
-source: |
-  format("Hello {name}!", {name: "Alice"})
-stdout: |
-  Hello Alice!
-stderr: ""
-exit_code: 0
+name: format-named-basic
+category: eval
+input:
+  source: |
+    format("Hello {name}!", {name: "Alice"})
+expected:
+  stdout: |
+    Hello Alice!
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-named-basic.yaml
+++ b/spec/eval/format-named-basic.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format named placeholder basic
+source: |
+  format("Hello {name}!", {name: "Alice"})
+stdout: |
+  Hello Alice!
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-named-multiple.yaml
+++ b/spec/eval/format-named-multiple.yaml
@@ -5,6 +5,6 @@ input:
     format("{greeting} {name}, you are {age} years old", {greeting: "Hello", name: "Bob", age: 30})
 expected:
   stdout: |
-    Hello Bob, you are 30 years old
+    "Hello Bob, you are 30 years old"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-named-multiple.yaml
+++ b/spec/eval/format-named-multiple.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format multiple named placeholders
+source: |
+  format("{greeting} {name}, you are {age} years old", {greeting: "Hello", name: "Bob", age: 30})
+stdout: |
+  Hello Bob, you are 30 years old
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-named-multiple.yaml
+++ b/spec/eval/format-named-multiple.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format multiple named placeholders
-source: |
-  format("{greeting} {name}, you are {age} years old", {greeting: "Hello", name: "Bob", age: 30})
-stdout: |
-  Hello Bob, you are 30 years old
-stderr: ""
-exit_code: 0
+name: format-named-multiple
+category: eval
+input:
+  source: |
+    format("{greeting} {name}, you are {age} years old", {greeting: "Hello", name: "Bob", age: 30})
+expected:
+  stdout: |
+    Hello Bob, you are 30 years old
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-positional-basic.yaml
+++ b/spec/eval/format-positional-basic.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format positional placeholder basic
-source: |
-  format("Item {0} costs {1}", ["apple", "5"])
-stdout: |
-  Item apple costs 5
-stderr: ""
-exit_code: 0
+name: format-positional-basic
+category: eval
+input:
+  source: |
+    format("Item {0} costs {1}", ["apple", "5"])
+expected:
+  stdout: |
+    Item apple costs 5
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-positional-basic.yaml
+++ b/spec/eval/format-positional-basic.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format positional placeholder basic
+source: |
+  format("Item {0} costs {1}", ["apple", "5"])
+stdout: |
+  Item apple costs 5
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-positional-basic.yaml
+++ b/spec/eval/format-positional-basic.yaml
@@ -5,6 +5,6 @@ input:
     format("Item {0} costs {1}", ["apple", "5"])
 expected:
   stdout: |
-    Item apple costs 5
+    "Item apple costs 5"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-positional-leading-zeros.yaml
+++ b/spec/eval/format-positional-leading-zeros.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format positional placeholder with leading zeros
-source: |
-  format("{00} {001}", ["X", "Y"])
-stdout: |
-  X Y
-stderr: ""
-exit_code: 0
+name: format-positional-leading-zeros
+category: eval
+input:
+  source: |
+    format("{00} {001}", ["X", "Y"])
+expected:
+  stdout: |
+    X Y
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-positional-leading-zeros.yaml
+++ b/spec/eval/format-positional-leading-zeros.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format positional placeholder with leading zeros
+source: |
+  format("{00} {001}", ["X", "Y"])
+stdout: |
+  X Y
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-positional-leading-zeros.yaml
+++ b/spec/eval/format-positional-leading-zeros.yaml
@@ -5,6 +5,6 @@ input:
     format("{00} {001}", ["X", "Y"])
 expected:
   stdout: |
-    X Y
+    "X Y"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-positional-multiple.yaml
+++ b/spec/eval/format-positional-multiple.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format multiple positional placeholders
+source: |
+  format("First: {0}, Second: {1}, Third: {2}", ["A", "B", "C"])
+stdout: |
+  First: A, Second: B, Third: C
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-positional-multiple.yaml
+++ b/spec/eval/format-positional-multiple.yaml
@@ -5,6 +5,6 @@ input:
     format("First: {0}, Second: {1}, Third: {2}", ["A", "B", "C"])
 expected:
   stdout: |
-    First: A, Second: B, Third: C
+    "First: A, Second: B, Third: C"
   stderr: ""
   exit_code: 0

--- a/spec/eval/format-positional-multiple.yaml
+++ b/spec/eval/format-positional-multiple.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format multiple positional placeholders
-source: |
-  format("First: {0}, Second: {1}, Third: {2}", ["A", "B", "C"])
-stdout: |
-  First: A, Second: B, Third: C
-stderr: ""
-exit_code: 0
+name: format-positional-multiple
+category: eval
+input:
+  source: |
+    format("First: {0}, Second: {1}, Third: {2}", ["A", "B", "C"])
+expected:
+  stdout: |
+    First: A, Second: B, Third: C
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-repeated-placeholders.yaml
+++ b/spec/eval/format-repeated-placeholders.yaml
@@ -1,0 +1,8 @@
+kind: eval
+name: format repeated placeholders
+source: |
+  format("{0} and {0} again", ["same"])
+stdout: |
+  same and same again
+stderr: ""
+exit_code: 0

--- a/spec/eval/format-repeated-placeholders.yaml
+++ b/spec/eval/format-repeated-placeholders.yaml
@@ -1,8 +1,10 @@
-kind: eval
-name: format repeated placeholders
-source: |
-  format("{0} and {0} again", ["same"])
-stdout: |
-  same and same again
-stderr: ""
-exit_code: 0
+name: format-repeated-placeholders
+category: eval
+input:
+  source: |
+    format("{0} and {0} again", ["same"])
+expected:
+  stdout: |
+    same and same again
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-repeated-placeholders.yaml
+++ b/spec/eval/format-repeated-placeholders.yaml
@@ -5,6 +5,6 @@ input:
     format("{0} and {0} again", ["same"])
 expected:
   stdout: |
-    same and same again
+    "same and same again"
   stderr: ""
   exit_code: 0

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -580,6 +580,73 @@ def make_global_env(
             raise TypeError("join expected a list of strings, received list")
         return separator.join(xs)
 
+    def format_fn(template: Any, values: Any) -> str:
+        if not isinstance(template, str):
+            raise TypeError("format expected a string template")
+
+        def _is_named_placeholder(body: str) -> bool:
+            if body == "":
+                return False
+            first = body[0]
+            if not (first == "_" or ("A" <= first <= "Z") or ("a" <= first <= "z")):
+                return False
+            return all(
+                ch == "_"
+                or ("A" <= ch <= "Z")
+                or ("a" <= ch <= "z")
+                or ("0" <= ch <= "9")
+                for ch in body[1:]
+            )
+
+        def _is_positional_placeholder(body: str) -> bool:
+            return body != "" and all("0" <= ch <= "9" for ch in body)
+
+        def _format_placeholder(body: str) -> str:
+            if _is_positional_placeholder(body):
+                if not isinstance(values, list):
+                    raise TypeError(
+                        f"format expected a list for positional placeholder: {body}"
+                    )
+                index = int(body, 10)
+                if index >= len(values):
+                    raise ValueError(f"format missing field: {index}")
+                return format_display(values[index])
+
+            if _is_named_placeholder(body):
+                if not isinstance(values, GeniaMap):
+                    raise TypeError(f"format expected a map for named placeholder: {body}")
+                if not values.has(body):
+                    raise ValueError(f"format missing field: {body}")
+                return format_display(values.get(body))
+
+            raise ValueError("format invalid placeholder")
+
+        pieces: list[str] = []
+        i = 0
+        while i < len(template):
+            ch = template[i]
+            if ch == "{":
+                if i + 1 < len(template) and template[i + 1] == "{":
+                    pieces.append("{")
+                    i += 2
+                    continue
+                close = template.find("}", i + 1)
+                if close < 0:
+                    raise ValueError("format invalid placeholder")
+                pieces.append(_format_placeholder(template[i + 1 : close]))
+                i = close + 1
+                continue
+            if ch == "}":
+                if i + 1 < len(template) and template[i + 1] == "}":
+                    pieces.append("}")
+                    i += 2
+                    continue
+                raise ValueError("format invalid placeholder")
+            pieces.append(ch)
+            i += 1
+
+        return "".join(pieces)
+
     def trim_fn(value: Any) -> str:
         return _ensure_string(value, "trim").strip()
 
@@ -2775,6 +2842,7 @@ def make_global_env(
     env.set("_split", split_fn)
     env.set("_split_whitespace", split_whitespace_fn)
     env.set("_join", join_fn)
+    env.set("_format", format_fn)
     env.set("_trim", trim_fn)
     env.set("_trim_start", trim_start_fn)
     env.set("_trim_end", trim_end_fn)
@@ -2944,6 +3012,7 @@ def make_global_env(
     env.register_autoload("split", 2, "std/prelude/string.genia")
     env.register_autoload("split_whitespace", 1, "std/prelude/string.genia")
     env.register_autoload("join", 2, "std/prelude/string.genia")
+    env.register_autoload("format", 2, "std/prelude/string.genia")
     env.register_autoload("trim", 1, "std/prelude/string.genia")
     env.register_autoload("trim_start", 1, "std/prelude/string.genia")
     env.register_autoload("trim_end", 1, "std/prelude/string.genia")

--- a/src/genia/std/prelude/string.genia
+++ b/src/genia/std/prelude/string.genia
@@ -28,6 +28,9 @@ split_whitespace(value) = _split_whitespace(value)
 @doc "Join a list of strings with a separator."
 join(sep, xs) = _join(sep, xs)
 
+@doc "Format a string template with named or positional placeholders."
+format(template, values) = _format(template, values)
+
 @doc "Trim leading and trailing whitespace."
 trim(value) = _trim(value)
 

--- a/tests/data/cheatsheet_core_cases.json
+++ b/tests/data/cheatsheet_core_cases.json
@@ -50,6 +50,11 @@
     "expected_result": "\"Adds one to x.\""
   },
   {
+    "id": "core-format-named",
+    "source": "format(\"Hello {name}\", {name: \"Genia\"})",
+    "expected_result": "\"Hello Genia\""
+  },
+  {
     "id": "core-actor-call-reply",
     "source": "handler(state, msg, _ctx) = [\"reply\", state + msg, state + msg]\na = actor(0, handler)\nactor_call(a, 5)",
     "expected_result": "5"


### PR DESCRIPTION
Adds format(template, values) as a pure prelude-backed string helper.

Behavior:

Supports named placeholders like {name} from maps.
Supports positional placeholders like {0} from lists.
Supports escaped braces with {{ and }}.
Uses display rendering for substituted values.
Returns a string and does not write output.
Raises deterministic errors for missing fields, invalid placeholders, wrong template type, and wrong values container.
Tests Run

Focused format specs: 24 passed, 0 failed
Shared spec runner: 189 passed
Combined unit/doc checks: 136 passed
Earlier related checks:
tests/unit/test_strings_utf8.py: 6 passed
related spec runner tests: 119 passed
Docs Updated

GENIA_STATE.md
README.md
GENIA_REPL_README.md
docs/cheatsheet/core.md
tests/data/cheatsheet_core_cases.json
Known Limitations

No format/3
No field paths like {user.name}
No interpolation string syntax
No width/alignment/precision format specifiers
No localization, tagged formats, or debug rendering
Follow-Up Issues
None needed for issue #167.