### PR TITLE
docs(seq): define Seq core contract issue #254

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -228,6 +228,10 @@ CLI contract summary (actual behavior):
 - flow runtime (phase 1):
   - `stdin |> lines` creates a lazy single-use flow
   - Flow is a runtime value family; Flow/value crossing still depends on explicit bridge/stage helpers such as `lines`, `collect`, and `run`
+  - Seq is the semantic abstraction for ordered value production.
+    - List is the eager reusable Seq-compatible value.
+    - Flow is the lazy single-use Seq-compatible value.
+    - Iterator is a host implementation detail.
   - binding `stdin` into a flow does not read all input up front
   - `stdin()` still returns cached full stdin lines for compatibility
   - transforms: `lines`, `tee`, `merge`, `zip`, `scan`, `keep_some`, `keep_some_else`, `map`, `filter`, `take`, `rules`

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -848,6 +848,19 @@ When changing syntax/semantics/runtime behavior, update together:
 - `stdin |> lines` must remain lazy; binding the source must not force a full stdin read up front
 - reaching EOF or a `take`/`head` limit is normal completion (not an error)
 
+## 19.1) Seq compatibility invariants
+
+- Seq is a semantic compatibility category for ordered value production, not a runtime value, type constructor, syntax form, helper, or Core IR node.
+- In this phase, only lists and Flow are Seq-compatible public values.
+- Lists are eager and reusable.
+- Flow is lazy, pull-based, source-bound, and single-use.
+- Iterators and generators are host implementation details, not portable Genia values.
+- Seq compatibility does not change pipeline call shape.
+- Seq compatibility does not change Option-aware pipeline behavior.
+- No implicit list-to-Flow conversion is introduced.
+- No implicit Flow-to-list conversion is introduced.
+- Matching a Flow as a list requires explicit materialization first.
+
 ## `rules(..fns)`
 
 `rules(..fns)` is a Flow-stage function that applies rule functions to each incoming flow item.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -408,6 +408,15 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - lists through value-only stages stay lists (no implicit flow promotion)
   - flows through flow-only stages stay flows (must `collect` to see a list)
   - Option composes orthogonally: per-item Options use `keep_some` in flows; pipeline-level `some`/`none` propagation works the same in both worlds
+- `Seq` is a semantic compatibility category for ordered value production.
+  - Seq is not a runtime value, type constructor, syntax form, helper, or Core IR node.
+  - In this phase, the implemented Seq-compatible public values are lists and Flow.
+  - Lists are eager and reusable.
+  - Flow is lazy, pull-based, source-bound, and single-use.
+  - Iterators and generators are host implementation details, not portable Genia values.
+  - Seq compatibility does not change pipeline call shape or Option-aware pipeline behavior.
+  - Explicit bridges such as `lines`, `collect`, and `run` still define Value<->Flow crossings.
+  - Maturity: Partial; list and Flow behavior is implemented, while Seq remains semantic terminology rather than a separate public surface.
 - pipeline debugging helpers are implemented as prelude-level identity stages:
   - `inspect(value)` logs and returns `value` unchanged
   - `trace(label, value)` logs `label` plus `value` and returns `value` unchanged

--- a/README.md
+++ b/README.md
@@ -837,6 +837,11 @@ get("name", person)
 - Flow is still explicit:
   - Flow values move through pipelines only when explicit bridge/stage functions such as `lines`, `collect`, and `run` are used
   - there is no implicit Value↔Flow conversion
+- Seq is the semantic abstraction for ordered value production.
+  - List is the eager reusable Seq-compatible value.
+  - Flow is the lazy single-use Seq-compatible value.
+  - Iterator is a host implementation detail.
+  - Seq is not a public runtime type, syntax form, helper, or Core IR node.
 
 ### Flow runtime (Phase 1)
 

--- a/docs/cheatsheet/piepline-flow-vs-value.md
+++ b/docs/cheatsheet/piepline-flow-vs-value.md
@@ -4,6 +4,11 @@ The one rule that makes Genia pipelines predictable:
 
 > **Raw values stay values.  Flows stay flows.  Only explicit bridges cross the boundary.**
 
+Seq is the semantic abstraction for ordered value production.
+List is the eager reusable Seq-compatible value.
+Flow is the lazy single-use Seq-compatible value.
+Iterator is a host implementation detail.
+
 Option behavior (`some` / `none`) composes with this rule but does not erase it:
 pipelines auto-lift ordinary stages over `some(x)` and short-circuit on `none(...)`,
 regardless of whether the pipeline carries values or flows.

--- a/docs/host-interop/HOST_INTEROP.md
+++ b/docs/host-interop/HOST_INTEROP.md
@@ -316,6 +316,10 @@ Flow semantics are shared language/runtime semantics, even if hosts implement th
 
 Current contract:
 
+- Seq is the semantic abstraction for ordered value production.
+- List is the eager reusable Seq-compatible value.
+- Flow is the lazy single-use Seq-compatible value.
+- Iterator is a host implementation detail.
 - Flow is a runtime value family
 - flows are lazy, pull-based, source-bound, and single-use
 - `|>` lowers to an explicit Core IR pipeline node with one source plus ordered stages

--- a/spec/flow/README.md
+++ b/spec/flow/README.md
@@ -4,6 +4,10 @@ This directory contains executable shared spec files for the active `flow` categ
 
 Flow shared coverage is intentionally partial and limited to first-wave observable contract cases in this phase.
 
+Flow shared specs cover the Flow side of the Seq contract only.
+They do not define a public Seq runtime value, Seq syntax, or host iterator semantics.
+List-side Seq behavior is covered through eval/list specs where applicable.
+
 Flow cases in this directory must:
 
 - include explicit terminal consumption through `collect` or `run`

--- a/tests/doc/test_seq_contract_docs.py
+++ b/tests/doc/test_seq_contract_docs.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def read_text(relpath: str) -> str:
+    return (REPO / relpath).read_text(encoding="utf-8")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split()).lower()
+
+
+def assert_contains_all(relpath: str, excerpts: list[str]) -> None:
+    text = normalize(read_text(relpath))
+    for excerpt in excerpts:
+        assert normalize(excerpt) in text, f"{relpath} missing Seq contract excerpt: {excerpt}"
+
+
+def test_state_defines_seq_as_semantic_contract_not_runtime_surface() -> None:
+    assert_contains_all(
+        "GENIA_STATE.md",
+        [
+            "`Seq` is a semantic compatibility category for ordered value production.",
+            "Seq is not a runtime value, type constructor, syntax form, helper, or Core IR node.",
+            "In this phase, the implemented Seq-compatible public values are lists and Flow.",
+            "Lists are eager and reusable.",
+            "Flow is lazy, pull-based, source-bound, and single-use.",
+            "Iterators and generators are host implementation details, not portable Genia values.",
+        ],
+    )
+
+
+def test_rules_lock_seq_pipeline_and_bridge_invariants() -> None:
+    assert_contains_all(
+        "GENIA_RULES.md",
+        [
+            "Seq compatibility does not change pipeline call shape.",
+            "Seq compatibility does not change Option-aware pipeline behavior.",
+            "No implicit list-to-Flow conversion is introduced.",
+            "No implicit Flow-to-list conversion is introduced.",
+            "Matching a Flow as a list requires explicit materialization first.",
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "relpath",
+    [
+        "README.md",
+        "GENIA_REPL_README.md",
+        "docs/host-interop/HOST_INTEROP.md",
+        "docs/cheatsheet/piepline-flow-vs-value.md",
+    ],
+)
+def test_public_docs_describe_seq_list_flow_iterator_split(relpath: str) -> None:
+    assert_contains_all(
+        relpath,
+        [
+            "Seq is the semantic abstraction for ordered value production.",
+            "List is the eager reusable Seq-compatible value.",
+            "Flow is the lazy single-use Seq-compatible value.",
+            "Iterator is a host implementation detail.",
+        ],
+    )
+
+
+def test_flow_spec_readme_records_seq_coverage_boundary() -> None:
+    assert_contains_all(
+        "spec/flow/README.md",
+        [
+            "Flow shared specs cover the Flow side of the Seq contract only.",
+            "They do not define a public Seq runtime value, Seq syntax, or host iterator semantics.",
+            "List-side Seq behavior is covered through eval/list specs where applicable.",
+        ],
+    )


### PR DESCRIPTION
**Commit Message**

`docs(seq): define Seq core contract issue #254`

**Summary**

Defines Seq as a semantic compatibility category for ordered value production, not a runtime value, syntax form, helper, type constructor, or Core IR node. Documents list as the eager reusable Seq-compatible value, Flow as the lazy single-use Seq-compatible value, and iterators/generators as host implementation details.

**Docs Updated**

- `GENIA_STATE.md`
- `GENIA_RULES.md`
- `README.md`
- `GENIA_REPL_README.md`
- `docs/host-interop/HOST_INTEROP.md`
- `docs/cheatsheet/piepline-flow-vs-value.md`
- `spec/flow/README.md`

**Tests Added**

- `tests/doc/test_seq_contract_docs.py`

**Tests Run**

- `uv run pytest -q tests/doc/test_seq_contract_docs.py tests/doc/test_semantic_doc_sync.py tests/unit/test_cheatsheet_*.py tests/unit/test_flow_shared_spec_runner.py --maxfail=20`
- Result: `163 passed`

**Known Limitations**

- No runtime behavior changed.
- Seq remains Partial semantic terminology over implemented list and Flow behavior.
- No public Seq type/helper/syntax/IR node exists.
- Flow shared specs cover only the Flow side of the Seq contract.