### PR TITLE
Feature/issue 255 seq genia seq

### DIFF
--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -850,11 +850,12 @@ When changing syntax/semantics/runtime behavior, update together:
 
 ## 19.1) Seq compatibility invariants
 
-- Seq is a semantic compatibility category for ordered value production, not a runtime value, type constructor, syntax form, helper, or Core IR node.
+- Seq is a semantic compatibility category for ordered value production, not a public runtime value, type constructor, syntax form, helper, or Core IR node.
 - In this phase, only lists and Flow are Seq-compatible public values.
 - Lists are eager and reusable.
 - Flow is lazy, pull-based, source-bound, and single-use.
 - Iterators and generators are host implementation details, not portable Genia values.
+- Python reference-host internal lifecycle helpers for Seq-compatible sources must not create a public Seq surface.
 - Seq compatibility does not change pipeline call shape.
 - Seq compatibility does not change Option-aware pipeline behavior.
 - No implicit list-to-Flow conversion is introduced.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -409,11 +409,12 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - flows through flow-only stages stay flows (must `collect` to see a list)
   - Option composes orthogonally: per-item Options use `keep_some` in flows; pipeline-level `some`/`none` propagation works the same in both worlds
 - `Seq` is a semantic compatibility category for ordered value production.
-  - Seq is not a runtime value, type constructor, syntax form, helper, or Core IR node.
+  - Seq is not a public runtime value, type constructor, syntax form, helper, or Core IR node.
   - In this phase, the implemented Seq-compatible public values are lists and Flow.
   - Lists are eager and reusable.
   - Flow is lazy, pull-based, source-bound, and single-use.
   - Iterators and generators are host implementation details, not portable Genia values.
+  - The Python reference host uses an internal `GeniaSeq` helper to model ordered-source consumption lifecycle; this does not create a public Seq surface.
   - Seq compatibility does not change pipeline call shape or Option-aware pipeline behavior.
   - Explicit bridges such as `lines`, `collect`, and `run` still define Value<->Flow crossings.
   - Maturity: Partial; list and Flow behavior is implemented, while Seq remains semantic terminology rather than a separate public surface.

--- a/src/genia/values.py
+++ b/src/genia/values.py
@@ -528,36 +528,117 @@ class GeniaZipEntry:
         return f"<zip-entry {self.name!r} {len(self.data.value)}>"
 
 
-class GeniaFlow:
+class GeniaSeq:
     def __init__(
         self,
         iterator_factory: Callable[[], Iterable[Any]],
         *,
-        label: str = "flow",
+        label: str = "seq",
+        single_use: bool,
         close_on_early_termination: bool = True,
+        reuse_error: str = "Flow has already been consumed",
+        invalid_source_prefix: str = "Flow source",
     ):
         self._iterator_factory = iterator_factory
         self._label = label
+        self._single_use = single_use
         self._consumed = False
         self._close_on_early_termination = close_on_early_termination
+        self._reuse_error = reuse_error
+        self._invalid_source_prefix = invalid_source_prefix
+
+    @classmethod
+    def reusable(
+        cls,
+        iterator_factory: Callable[[], Iterable[Any]],
+        *,
+        label: str = "seq",
+        close_on_early_termination: bool = True,
+    ) -> "GeniaSeq":
+        return cls(
+            iterator_factory,
+            label=label,
+            single_use=False,
+            close_on_early_termination=close_on_early_termination,
+        )
+
+    @classmethod
+    def single_use(
+        cls,
+        iterator_factory: Callable[[], Iterable[Any]],
+        *,
+        label: str = "seq",
+        close_on_early_termination: bool = True,
+    ) -> "GeniaSeq":
+        return cls(
+            iterator_factory,
+            label=label,
+            single_use=True,
+            close_on_early_termination=close_on_early_termination,
+        )
 
     def consume(self) -> Iterable[Any]:
-        if self._consumed:
-            raise RuntimeError("Flow has already been consumed")
-        self._consumed = True
+        if self._single_use:
+            if self._consumed:
+                raise RuntimeError(self._reuse_error)
+            self._consumed = True
         produced = self._iterator_factory()
         try:
             return iter(produced)
         except TypeError:
-            raise TypeError(f"Flow source {self._label} did not produce an iterable") from None
+            raise TypeError(f"{self._invalid_source_prefix} {self._label} did not produce an iterable") from None
 
-    def __repr__(self) -> str:
-        state = "consumed" if self._consumed else "ready"
-        return f"<flow {self._label} {state}>"
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @property
+    def consumed(self) -> bool:
+        return self._consumed
+
+    @property
+    def is_single_use(self) -> bool:
+        return self._single_use
 
     @property
     def close_on_early_termination(self) -> bool:
         return self._close_on_early_termination
+
+
+class GeniaFlow:
+    def __init__(
+        self,
+        iterator_factory: Callable[[], Iterable[Any]] | GeniaSeq,
+        *,
+        label: str = "flow",
+        close_on_early_termination: bool = True,
+    ):
+        if isinstance(iterator_factory, GeniaSeq):
+            if iterator_factory.is_single_use:
+                self._seq = iterator_factory
+            else:
+                self._seq = GeniaSeq.single_use(
+                    iterator_factory.consume,
+                    label=iterator_factory.label,
+                    close_on_early_termination=iterator_factory.close_on_early_termination,
+                )
+        else:
+            self._seq = GeniaSeq.single_use(
+                iterator_factory,
+                label=label,
+                close_on_early_termination=close_on_early_termination,
+            )
+
+    def consume(self) -> Iterable[Any]:
+        return self._seq.consume()
+
+    def __repr__(self) -> str:
+        state = "consumed" if self._seq.consumed else "ready"
+        return f"<flow {self._seq.label} {state}>"
+
+    @property
+    def close_on_early_termination(self) -> bool:
+        return self._seq.close_on_early_termination
 
 
 class GeniaOutputSink:

--- a/tests/doc/test_seq_contract_docs.py
+++ b/tests/doc/test_seq_contract_docs.py
@@ -27,11 +27,12 @@ def test_state_defines_seq_as_semantic_contract_not_runtime_surface() -> None:
         "GENIA_STATE.md",
         [
             "`Seq` is a semantic compatibility category for ordered value production.",
-            "Seq is not a runtime value, type constructor, syntax form, helper, or Core IR node.",
+            "Seq is not a public runtime value, type constructor, syntax form, helper, or Core IR node.",
             "In this phase, the implemented Seq-compatible public values are lists and Flow.",
             "Lists are eager and reusable.",
             "Flow is lazy, pull-based, source-bound, and single-use.",
             "Iterators and generators are host implementation details, not portable Genia values.",
+            "The Python reference host uses an internal `GeniaSeq` helper to model ordered-source consumption lifecycle; this does not create a public Seq surface.",
         ],
     )
 

--- a/tests/unit/test_seq_runtime.py
+++ b/tests/unit/test_seq_runtime.py
@@ -1,0 +1,37 @@
+import pytest
+
+from genia import values
+
+
+def test_genia_seq_reusable_source_can_be_consumed_multiple_times():
+    seq = values.GeniaSeq.reusable(lambda: iter(["a", "b"]), label="letters")
+
+    assert list(seq.consume()) == ["a", "b"]
+    assert list(seq.consume()) == ["a", "b"]
+
+
+def test_genia_seq_single_use_source_rejects_second_consume_with_flow_error():
+    seq = values.GeniaSeq.single_use(lambda: iter([1, 2]), label="numbers")
+
+    assert list(seq.consume()) == [1, 2]
+    with pytest.raises(RuntimeError, match="Flow has already been consumed"):
+        list(seq.consume())
+
+
+def test_genia_flow_wraps_internal_seq_source_without_changing_public_behavior():
+    seq = values.GeniaSeq.single_use(lambda: iter(["x"]), label="numbers")
+    flow = values.GeniaFlow(seq)
+
+    assert repr(flow) == "<flow numbers ready>"
+    assert list(flow.consume()) == ["x"]
+    assert repr(flow) == "<flow numbers consumed>"
+    with pytest.raises(RuntimeError, match="Flow has already been consumed"):
+        list(flow.consume())
+
+
+def test_genia_flow_preserves_invalid_seq_source_diagnostic():
+    seq = values.GeniaSeq.single_use(lambda: None, label="badflow")
+    flow = values.GeniaFlow(seq)
+
+    with pytest.raises(TypeError, match="Flow source badflow did not produce an iterable"):
+        list(flow.consume())


### PR DESCRIPTION
**Commit Message**

```text
feat(seq): implement internal GeniaSeq runtime issue #255
```

**Summary**
Implemented an internal `GeniaSeq` lifecycle abstraction in `src/genia/values.py` and updated `GeniaFlow` to delegate consumption state, close policy, and display state through it. Public behavior stays unchanged: Flow remains lazy and single-use, lists remain reusable, and no public Seq API/syntax/Core IR surface was added.

**Docs Updated**
- `GENIA_STATE.md`: clarifies Seq is not a public runtime value and notes internal Python `GeniaSeq`
- `GENIA_RULES.md`: locks the same public/private Seq boundary
- `tests/doc/test_seq_contract_docs.py`: updates protected wording expectations

**Tests Run**
- `uv run pytest -q tests/unit/test_seq_runtime.py tests/unit/test_flow_phase1.py tests/doc/test_seq_contract_docs.py tests/doc/test_semantic_doc_sync.py` → 134 passed
- `uv tool run ruff check src/genia/values.py tests/unit/test_seq_runtime.py tests/doc/test_seq_contract_docs.py` → passed
- `uv run pytest -q` → 2005 passed

**Known Limitations**
`GeniaSeq` is internal only. It is not a public Genia value, helper, syntax form, or Core IR node.

**Follow-up Issues**
None identified.