### PR TITLE
fix(parser): allow newline after lambda arrow

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -551,6 +551,7 @@ Pipeline (Phase 2) evaluation model:
 - multiple definitions by arity shape are allowed
 - varargs named functions are supported (`f(a, ..rest) = ...`)
 - named functions may use either `=` or `->` for single-expression bodies, or `{ ... }` for block bodies
+- lambda single-expression bodies may start on the next line after the `->` token
 - bindings may carry metadata maps discoverable through `meta("name")`
 - doc lookup is available through `doc("name")`
 - lexical assignment uses the same `name = expr` surface syntax

--- a/spec/eval/lambda-body-newline-after-arrow.yaml
+++ b/spec/eval/lambda-body-newline-after-arrow.yaml
@@ -1,0 +1,11 @@
+name: lambda-body-newline-after-arrow
+category: eval
+description: Lambda bodies may start on the line after the arrow token
+input:
+  source: |
+    [1, 2] |> map((x) ->
+      x + 1)
+expected:
+  stdout: "[2, 3]\n"
+  stderr: ""
+  exit_code: 0

--- a/src/genia/parser.py
+++ b/src/genia/parser.py
@@ -792,6 +792,7 @@ class Parser:
                 self.skip_newlines()
                 if self.at("ARROW"):
                     self.eat("ARROW")
+                    self.skip_newlines()
                     body = self.parse_expr()
                     return Lambda(
                         params,

--- a/tests/unit/test_pipeline_operator.py
+++ b/tests/unit/test_pipeline_operator.py
@@ -135,6 +135,14 @@ def test_pipeline_with_lambda_rhs(run):
     assert run(src) == 16
 
 
+def test_pipeline_with_lambda_body_starting_on_next_line(run):
+    src = """
+    [1, 2] |> map((x) ->
+      x + 1)
+    """
+    assert run(src) == [2, 3]
+
+
 def test_pipeline_with_block_rhs(run):
     src = """
     inc(x) = x + 1


### PR DESCRIPTION
### Motivation
- The parser rejected single-expression lambda bodies that start on the next line after `->`, causing an `Unexpected token '\n' (NEWLINE)` error when using multiline lambdas in pipelines such as `map((x) ->\n  x + 1)`.

### Description
- Accept newline between `->` and the lambda body by calling `self.skip_newlines()` after consuming the `ARROW` in `src/genia/parser.py` so lambda bodies may start on the following line.
- Update the authoritative wording in `GENIA_STATE.md` to document that lambda single-expression bodies may start on the next line after `->`.
- Add a unit regression test `test_pipeline_with_lambda_body_starting_on_next_line` in `tests/unit/test_pipeline_operator.py` to cover the multiline lambda in a pipeline.
- Add a shared eval spec `spec/eval/lambda-body-newline-after-arrow.yaml` that asserts the behavior end-to-end.

### Testing
- Ran `pytest tests/unit/test_pipeline_operator.py` and the suite passed (26 tests, all green).
- Executed the new shared eval spec via the spec runner (`PYTHONPATH=src:. python -m tools.spec_runner.runner` / targeted `load_spec`+`execute_spec` flow) and it passed for `spec/eval/lambda-body-newline-after-arrow.yaml`.
- Verified `PYTHONPATH=src python src/genia/interpreter.py -c '[1,2] |> map((x) ->\n x + 1)'` returns the expected result (`[2, 3]`).
- Ran `pytest tests/doc/test_semantic_doc_sync.py` to ensure doc/state sync still passes (60 tests, all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1b07b45483299ab049eecfadd6df)