### PR TITLE
Feature/issue 261 seq resource finalization

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -128,7 +128,7 @@ PYTHON REFERENCE HOST:
 - All conformance is validated against the Python reference host.
 - The current shared spec runner executes eval cases (`spec/eval/`), comparing normalized `stdout`, `stderr`, and `exit_code`. Eval shared coverage includes list-side Seq-compatible `collect`, `run`, lazy `each`, item-preserving `each |> collect`, the existing `seq-compatible-list-transform-chain` fixture, and selected Seq-compatible non-list/non-Flow diagnostics.
 - The current shared spec runner executes CLI cases (`spec/cli/`) through the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`.
-- The current shared spec runner executes Flow cases (`spec/flow/`) through command-source execution in the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`. Flow shared coverage includes first-wave cases proving lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `evolve(init, f)` progression, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, selected rule result defaulting/no-effect behavior, deterministic `keep_some(...)` option-filtering behavior, error propagation via invalid-reducer-on-flow diagnostic, and Flow/value boundary enforcement (value function `count` misused as a pipe stage); focused core stdlib Flow coverage for direct `map`, `filter`, and `scan` over Flow inputs, including composed `map`/`filter` and bounded `evolve |> scan |> take |> collect` cases; and Seq-compatible terminal coverage for `each` preserving items, `each(print) |> run`, and `collect` materialization.
+- The current shared spec runner executes Flow cases (`spec/flow/`) through command-source execution in the Python host adapter, comparing normalized `stdout`, `stderr`, and `exit_code`. Flow shared coverage includes first-wave cases proving lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `evolve(init, f)` progression, `refine(..steps)`, `rules(..fns)`, `step_*` / `rule_*` equivalence, `rules()` identity, selected rule result defaulting/no-effect behavior, deterministic `keep_some(...)` option-filtering behavior, error propagation via invalid-reducer-on-flow diagnostic, and Flow/value boundary enforcement (value function `count` misused as a pipe stage); focused core stdlib Flow coverage for direct `map`, `filter`, and `scan` over Flow inputs, including composed `map`/`filter` and bounded `evolve |> scan |> take |> collect` cases; Seq-compatible terminal coverage for `each` preserving items, `each(print) |> run`, and `collect` materialization; and a resource lifecycle case (`seq-finalization-drop-take`) proving Flow-aware `drop |> take |> collect` composition with bounded pulling and correct output.
 - The current shared spec runner executes error cases (`spec/error/`) through the same eval execution path used by eval cases, comparing exact normalized `stdout`, exact normalized `stderr`, and exact `exit_code`.
 - CLI shared spec coverage proves deterministic non-interactive file mode, `-c` command mode, and `-p` pipe mode behavior. Current shared CLI coverage includes basic file execution, file-mode `main(argv())` dispatch, trailing `argv()` exposure, command-mode final-value execution, valid pipe-mode Flow-stage usage, explicit `stdin` / `run` rejection, and current pipe-mode guidance for bare per-item stages, bare reducers, and non-Flow final results. REPL mode is not included in shared executable spec coverage.
 - The observable CLI shared-spec contract is limited to `stdout`, `stderr`, and `exit_code`.
@@ -1091,6 +1091,18 @@ Flow semantics:
 - `scan` is a per-flow stateful transform where `step(state, item)` must return `[next_state, output]`
 - `scan` keeps state internal to the operator while emitting one output item per input item
 - invalid flow-source misuse fails with clear Genia-facing runtime errors instead of leaked Python iterator errors
+- Seq/Flow resource lifecycle (Partial):
+  - a closeable source is a Seq-compatible source backed by a resource that requires cleanup when consumption ends
+  - closeable sources are finalized (resource released) on: normal exhaustion, early termination, and error interruption
+  - finalization is synchronous and source-local; no async cancellation or scheduler involvement
+  - finalization is idempotent: further finalization requests after the first are no-ops
+  - `take(n)` stops pulling after n values and finalizes any closeable upstream; `take(0)` does not pull any item values but still finalizes if the source was acquired
+  - `drop(n)` pulls and discards exactly n values, then passes remaining values downstream without over-pulling
+  - `drop(n) |> take(m)` pulls exactly n+m values total, then finalizes any closeable upstream
+  - terminal consumers (`collect`, `run`) finalize closeable upstream on normal exhaustion or error interruption
+  - finalization-error behavior: if a primary user or source error is already propagating, finalization errors are suppressed; if no primary error exists, finalization errors surface
+  - list sources are never finalized; lists have no resource lifecycle
+  - PYTHON REFERENCE HOST: finalization is implemented via the iterable `.close()` protocol (generator close); the `close_on_early_termination` flag on internal `GeniaSeq`/`GeniaFlow` objects controls whether cleanup is attempted; these internals are not public Genia surfaces
 - host-backed Flow kernel remains intentionally small in this phase:
   - flow value creation and single-consumption enforcement
   - lazy pull-based iteration over upstream sources
@@ -1100,9 +1112,9 @@ Flow semantics:
   - Flow-producing and Flow-consuming primitive boundaries used by prelude wrappers
 - Flow vs Value classification model:
   - the one rule: raw values stay values, flows stay flows, only explicit bridges cross the boundary
-  - Value functions (list in, value out): `reduce`, `sum`, `count`, `first`, `last`, `nth`, `take`, `drop`, `reverse`
+  - Value functions (list in, value out): `reduce`, `sum`, `count`, `first`, `last`, `nth`, `reverse`
   - Flow functions (flow in, flow out): `keep_some`, `keep_some_else`, `scan`, `rules`, `tee`, `merge`, `zip`, `head`
-  - Polymorphic functions (work on both lists and flows): `map`, `filter`
+  - Polymorphic functions (work on both lists and flows): `map`, `filter`, `take`, `drop`
   - Seq-compatible helpers (list or Flow): `each`, `collect`, `run`
   - Bridge: source (value → flow): `lines`, `evolve`, `stdin_keys`
   - Bridge: materialize (flow → value): `collect`

--- a/docs/cheatsheet/piepline-flow-vs-value.md
+++ b/docs/cheatsheet/piepline-flow-vs-value.md
@@ -27,6 +27,8 @@ Value world                          Flow world
 [1, 2, 3]                            stdin |> lines        ← source bridge
   |> map(f)        polymorphic         |> map(f)
   |> filter(p)     polymorphic         |> filter(p)
+  |> take(n)       polymorphic         |> take(n)
+  |> drop(n)       polymorphic         |> drop(n)
   |> sum           value-only          |> collect  ← bridge to value
                                        |> sum      (now value world)
                                        |> each(print) |> run  ← sink
@@ -78,8 +80,8 @@ Recovery pattern: wrap the pipeline, not a single stage.
 | `first` | `first(xs)` | Returns `some(x)` or `none(...)` |
 | `last` | `last(xs)` | Returns `some(x)` or `none(...)` |
 | `nth` | `nth(index, xs)` | Returns `some(x)` or `none(...)` |
-| `take` | `take(n, xs)` | First n items as list |
-| `drop` | `drop(n, xs)` | Skip first n items |
+| `take` | `take(n, xs)` | Also works as flow stage; polymorphic |
+| `drop` | `drop(n, xs)` | Also works as flow stage; polymorphic |
 | `reverse` | `reverse(xs)` | Reversed list |
 
 ### 🔵 Flow functions (flow in, flow out)
@@ -88,6 +90,8 @@ Recovery pattern: wrap the pipeline, not a single stage.
 | --- | --- | --- |
 | `map` | `flow \|> map(f)` | Polymorphic with list version above |
 | `filter` | `flow \|> filter(pred)` | Polymorphic with list version above |
+| `take` | `flow \|> take(n)` | Polymorphic with list version above; limits flow and stops upstream promptly |
+| `drop` | `flow \|> drop(n)` | Polymorphic with list version above; skips first n pulled items |
 | `head` | `head(n, flow)` / `flow \|> head(n)` | Limits flow; stops upstream promptly |
 | `keep_some` | `keep_some(flow)` or `keep_some(stage, flow)` | Unwraps `some(v)`, drops `none(...)` |
 | `keep_some_else` | `keep_some_else(stage, handler, flow)` | Routes `some(v)` forward; `none(...)` to handler |
@@ -149,7 +153,8 @@ Recovery pattern: wrap the pipeline, not a single stage.
 | First item | 🟢 `first(xs)` | 🟣 `flow \|> head(1) \|> collect \|> first` | [case: pfv-first] |
 | Last item | 🟢 `last(xs)` | 🟣 `flow \|> collect \|> last` | [case: pfv-last] |
 | Nth item | 🟢 `nth(index, xs)` | 🟣 `flow \|> collect \|> nth(index)` | [case: pfv-nth] |
-| Take first n | 🟢 `take(n, xs)` | 🟣 `flow \|> head(n) \|> collect` | [case: pfv-take-head] |
+| Take first n | 🟢 `take(n, xs)` | 🔵 `flow \|> take(n)` | [case: pfv-take-flow] |
+| Drop first n | 🟢 `drop(n, xs)` | 🔵 `flow \|> drop(n)` | [case: pfv-drop-flow] |
 
 ## Option handling in both worlds
 
@@ -249,4 +254,4 @@ Classification: **Valid** (directly tested)
 - Flows are single-use; reusing a consumed flow raises a runtime error.
 - `keep_some` is flow-oriented, not a list helper.
 - Pipe mode runs the stage expression over `stdin |> lines` and consumes the final Flow automatically; do not include explicit `stdin` or `run`.
-- `map` and `filter` are polymorphic: they work on both lists and flows, staying in whichever world they receive.
+- `map`, `filter`, `take`, and `drop` are polymorphic: they work on both lists and flows, staying in whichever world they receive.

--- a/spec/flow/seq-finalization-drop-take.yaml
+++ b/spec/flow/seq-finalization-drop-take.yaml
@@ -1,0 +1,18 @@
+name: seq-finalization-drop-take
+category: flow
+input:
+  source: |
+    stdin |> lines |> drop(2) |> take(2) |> collect
+  stdin: |
+    a
+    b
+    c
+    d
+    e
+expected:
+  stdout: "[\"c\", \"d\"]\n"
+  stderr: ""
+  exit_code: 0
+notes:
+  Proves Flow-aware drop composes with bounded downstream take without materializing a list.
+  Close/finalization itself is covered by Python reference-host unit tests because shared specs expose only stdout, stderr, and exit_code.

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -818,6 +818,15 @@ def make_global_env(
         if callable(close):
             close()
 
+    def _finalize_iterable(iterable: Any, *, primary_error: bool) -> None:
+        if primary_error:
+            try:
+                _maybe_close_iterable(iterable)
+            except Exception:
+                pass
+            return
+        _maybe_close_iterable(iterable)
+
     class _FlowTeeState:
         def __init__(self, upstream: GeniaFlow):
             self._upstream = upstream
@@ -1047,6 +1056,7 @@ def make_global_env(
             def iterator() -> Iterable[Any]:
                 state = initial_state
                 items = upstream.consume()
+                primary_error = False
                 try:
                     for item in items:
                         result = _invoke_raw_from_builtin(step, [state, item])
@@ -1055,9 +1065,12 @@ def make_global_env(
                             yield emitted_item
                         if halt:
                             return
+                except Exception:
+                    primary_error = True
+                    raise
                 finally:
                     if upstream.close_on_early_termination:
-                        _maybe_close_iterable(items)
+                        _finalize_iterable(items, primary_error=primary_error)
 
             return GeniaFlow(
                 iterator,
@@ -1076,12 +1089,16 @@ def make_global_env(
 
             def iterator() -> Iterable[Any]:
                 items = upstream.consume()
+                primary_error = False
                 try:
                     for item in items:
                         yield mapper(item)
+                except Exception:
+                    primary_error = True
+                    raise
                 finally:
                     if upstream.close_on_early_termination:
-                        _maybe_close_iterable(items)
+                        _finalize_iterable(items, primary_error=primary_error)
 
             return GeniaFlow(iterator, label="map", close_on_early_termination=upstream.close_on_early_termination)
         if not isinstance(source, list):
@@ -1095,13 +1112,17 @@ def make_global_env(
 
             def iterator() -> Iterable[Any]:
                 items = upstream.consume()
+                primary_error = False
                 try:
                     for item in items:
                         if truthy(predicate(item)):
                             yield item
+                except Exception:
+                    primary_error = True
+                    raise
                 finally:
                     if upstream.close_on_early_termination:
-                        _maybe_close_iterable(items)
+                        _finalize_iterable(items, primary_error=primary_error)
 
             return GeniaFlow(iterator, label="filter", close_on_early_termination=upstream.close_on_early_termination)
         if not isinstance(source, list):
@@ -1114,10 +1135,13 @@ def make_global_env(
         upstream = _ensure_flow(source, "take")
 
         def iterator() -> Iterable[Any]:
+            items = iter(upstream.consume())
             if n <= 0:
+                if upstream.close_on_early_termination:
+                    _finalize_iterable(items, primary_error=False)
                 return
             remaining = n
-            items = iter(upstream.consume())
+            primary_error = False
             try:
                 while remaining > 0:
                     try:
@@ -1126,9 +1150,12 @@ def make_global_env(
                         return
                     yield item
                     remaining -= 1
+            except Exception:
+                primary_error = True
+                raise
             finally:
                 if upstream.close_on_early_termination:
-                    _maybe_close_iterable(items)
+                    _finalize_iterable(items, primary_error=primary_error)
 
         return GeniaFlow(iterator, label="take", close_on_early_termination=upstream.close_on_early_termination)
 
@@ -1146,6 +1173,7 @@ def make_global_env(
         def iterator() -> Iterable[Any]:
             state = initial_state
             items = upstream.consume()
+            primary_error = False
             try:
                 for item in items:
                     result = _invoke_from_builtin(step, [state, item])
@@ -1156,9 +1184,12 @@ def make_global_env(
                         )
                     state = result[0]
                     yield result[1]
+            except Exception:
+                primary_error = True
+                raise
             finally:
                 if upstream.close_on_early_termination:
-                    _maybe_close_iterable(items)
+                    _finalize_iterable(items, primary_error=primary_error)
 
         return GeniaFlow(iterator, label="scan", close_on_early_termination=upstream.close_on_early_termination)
 
@@ -1279,13 +1310,17 @@ def make_global_env(
 
         def iterator() -> Iterable[Any]:
             items = upstream.consume()
+            primary_error = False
             try:
                 for item in items:
                     effect(item)
                     yield item
+            except Exception:
+                primary_error = True
+                raise
             finally:
                 if upstream.close_on_early_termination:
-                    _maybe_close_iterable(items)
+                    _finalize_iterable(items, primary_error=primary_error)
 
         return GeniaFlow(iterator, label="each", close_on_early_termination=upstream.close_on_early_termination)
 
@@ -1297,11 +1332,15 @@ def make_global_env(
 
         flow = source
         items = flow.consume()
+        primary_error = False
         try:
             return list(items)
+        except Exception:
+            primary_error = True
+            raise
         finally:
             if flow.close_on_early_termination:
-                _maybe_close_iterable(items)
+                _finalize_iterable(items, primary_error=primary_error)
 
     def run_fn(source: Any) -> None:
         if isinstance(source, list):
@@ -1313,12 +1352,16 @@ def make_global_env(
 
         flow = source
         items = flow.consume()
+        primary_error = False
         try:
             for _ in items:
                 pass
+        except Exception:
+            primary_error = True
+            raise
         finally:
             if flow.close_on_early_termination:
-                _maybe_close_iterable(items)
+                _finalize_iterable(items, primary_error=primary_error)
         return None
 
     def _emit_help(text: str) -> None:

--- a/src/genia/callable.py
+++ b/src/genia/callable.py
@@ -97,6 +97,22 @@ class DebugHooks:
 NOOP_DEBUG_HOOKS = DebugHooks()
 
 
+def _maybe_close_iterable(iterable: Any) -> None:
+    close = getattr(iterable, "close", None)
+    if callable(close):
+        close()
+
+
+def _finalize_iterable(iterable: Any, *, primary_error: bool) -> None:
+    if primary_error:
+        try:
+            _maybe_close_iterable(iterable)
+        except Exception:
+            pass
+        return
+    _maybe_close_iterable(iterable)
+
+
 # ---------------------------------------------------------------------------
 # Callable value types
 # ---------------------------------------------------------------------------
@@ -532,14 +548,16 @@ def invoke_callable(
 
                 def _map_iterator() -> Any:
                     items = source.consume()
+                    primary_error = False
                     try:
                         for item in items:
                             yield invoke_callable(mapper, [item], tail_position=False, autoload_resolver=autoload_resolver)
+                    except Exception:
+                        primary_error = True
+                        raise
                     finally:
                         if source.close_on_early_termination:
-                            close = getattr(items, "close", None)
-                            if callable(close):
-                                close()
+                            _finalize_iterable(items, primary_error=primary_error)
 
                 return GeniaFlow(_map_iterator, label="map", close_on_early_termination=source.close_on_early_termination)
 
@@ -549,15 +567,17 @@ def invoke_callable(
 
                 def _filter_iterator() -> Any:
                     items = source.consume()
+                    primary_error = False
                     try:
                         for item in items:
                             if truthy(invoke_callable(predicate, [item], tail_position=False, autoload_resolver=autoload_resolver)):
                                 yield item
+                    except Exception:
+                        primary_error = True
+                        raise
                     finally:
                         if source.close_on_early_termination:
-                            close = getattr(items, "close", None)
-                            if callable(close):
-                                close()
+                            _finalize_iterable(items, primary_error=primary_error)
 
                 return GeniaFlow(_filter_iterator, label="filter", close_on_early_termination=source.close_on_early_termination)
 
@@ -568,11 +588,14 @@ def invoke_callable(
                     raise TypeError("take expected an integer count as first argument")
 
                 def _take_iterator() -> Any:
+                    items = source.consume()
                     if count <= 0:
+                        if source.close_on_early_termination:
+                            _finalize_iterable(items, primary_error=False)
                         return
                     remaining = count
-                    items = source.consume()
                     upstream = iter(items)
+                    primary_error = False
                     try:
                         while remaining > 0:
                             try:
@@ -581,13 +604,43 @@ def invoke_callable(
                                 return
                             yield item
                             remaining -= 1
+                    except Exception:
+                        primary_error = True
+                        raise
                     finally:
                         if source.close_on_early_termination:
-                            close = getattr(items, "close", None)
-                            if callable(close):
-                                close()
+                            _finalize_iterable(items, primary_error=primary_error)
 
                 return GeniaFlow(_take_iterator, label="take", close_on_early_termination=source.close_on_early_termination)
+
+            if callee_node.name == "drop" and len(args) == 2:
+                count = args[0]
+                source = args[1]
+                if not isinstance(count, int) or isinstance(count, bool):
+                    raise TypeError("drop expected an integer count as first argument")
+
+                def _drop_iterator() -> Any:
+                    items = source.consume()
+                    upstream = iter(items)
+                    primary_error = False
+                    try:
+                        remaining = count
+                        while remaining > 0:
+                            try:
+                                next(upstream)
+                            except StopIteration:
+                                return
+                            remaining -= 1
+                        for item in upstream:
+                            yield item
+                    except Exception:
+                        primary_error = True
+                        raise
+                    finally:
+                        if source.close_on_early_termination:
+                            _finalize_iterable(items, primary_error=primary_error)
+
+                return GeniaFlow(_drop_iterator, label="drop", close_on_early_termination=source.close_on_early_termination)
 
         arity = len(args)
 

--- a/tests/data/pipeline_flow_vs_value_cases.json
+++ b/tests/data/pipeline_flow_vs_value_cases.json
@@ -66,9 +66,14 @@
     "expected_result": "some(\"b\")"
   },
   {
-    "id": "pfv-take-head",
-    "source": "[\"a\", \"b\", \"c\"] |> lines |> head(2) |> collect",
+    "id": "pfv-take-flow",
+    "source": "[\"a\", \"b\", \"c\"] |> lines |> take(2) |> collect",
     "expected_result": "[\"a\", \"b\"]"
+  },
+  {
+    "id": "pfv-drop-flow",
+    "source": "[\"a\", \"b\", \"c\"] |> lines |> drop(1) |> collect",
+    "expected_result": "[\"b\", \"c\"]"
   },
   {
     "id": "pfv-option-map-some",

--- a/tests/unit/test_flow_phase1.py
+++ b/tests/unit/test_flow_phase1.py
@@ -15,6 +15,48 @@ def make_number_flow_env(values):
     return env
 
 
+class CloseTrackingCounter:
+    def __init__(self, state, *, limit=100, close_error=None):
+        self._state = state
+        self._limit = limit
+        self._close_error = close_error
+        self._next = 0
+        self._closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._next >= self._limit:
+            raise StopIteration
+        value = self._next
+        self._next += 1
+        self._state["pulled"] += 1
+        return value
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        self._state["closed"] += 1
+        if self._close_error is not None:
+            raise self._close_error
+
+
+def make_close_tracking_flow_env(*, limit=100, close_error=None):
+    env = make_global_env()
+    state = {"pulled": 0, "closed": 0}
+
+    def ticks():
+        return GeniaFlow(
+            lambda: CloseTrackingCounter(state, limit=limit, close_error=close_error),
+            label="ticks",
+        )
+
+    env.set("ticks", ticks)
+    return env, state
+
+
 def test_flow_reusable_stage_and_run(capsys):
     src = """
     clean(flow) =
@@ -256,6 +298,14 @@ def test_take_zero_does_not_pull_upstream():
     assert state["pulled"] == 0
 
 
+def test_take_zero_closes_close_tracking_flow_without_pulling():
+    env, state = make_close_tracking_flow_env()
+
+    assert run_source("ticks() |> take(0) |> collect", env) == []
+    assert state["pulled"] == 0
+    assert state["closed"] == 1
+
+
 def test_take_stops_without_overpulling_generator_backed_flow():
     env = make_global_env()
     state = {"pulled": 0}
@@ -388,6 +438,61 @@ def test_filter_fast_path_propagates_early_close_to_upstream():
     env.set("ticks", ticks)
     assert run_source("ticks() |> filter((x) -> x % 2 == 0) |> take(2) |> collect", env) == [0, 2]
     assert state["pulled"] == 3
+    assert state["closed"] == 1
+
+
+def test_flow_drop_passes_tail_without_overpulling_and_closes_on_downstream_take():
+    env, state = make_close_tracking_flow_env()
+
+    assert run_source("ticks() |> drop(2) |> take(2) |> collect", env) == [2, 3]
+    assert state["pulled"] == 4
+    assert state["closed"] == 1
+
+
+def test_flow_drop_exhaustion_closes_short_closeable_source():
+    env, state = make_close_tracking_flow_env(limit=3)
+
+    assert run_source("ticks() |> drop(5) |> collect", env) == []
+    assert state["pulled"] == 3
+    assert state["closed"] == 1
+
+
+def test_nested_flow_finalization_is_idempotent_for_upstream_source():
+    env, state = make_close_tracking_flow_env()
+
+    src = """
+    ticks()
+      |> map((x) -> x + 1)
+      |> filter((x) -> x > 0)
+      |> take(2)
+      |> collect
+    """
+
+    assert run_source(src, env) == [1, 2]
+    assert state["pulled"] == 2
+    assert state["closed"] == 1
+
+
+def test_primary_error_suppresses_finalization_error_during_map_cleanup():
+    env, state = make_close_tracking_flow_env(close_error=RuntimeError("cleanup boom"))
+
+    def boom(_item):
+        raise RuntimeError("primary boom")
+
+    env.set("boom", boom)
+
+    with pytest.raises(RuntimeError, match="primary boom"):
+        run_source("ticks() |> map(boom) |> collect", env)
+    assert state["pulled"] == 1
+    assert state["closed"] == 1
+
+
+def test_collect_surfaces_finalization_error_when_no_primary_error_exists():
+    env, state = make_close_tracking_flow_env(limit=1, close_error=RuntimeError("cleanup boom"))
+
+    with pytest.raises(RuntimeError, match="cleanup boom"):
+        run_source("ticks() |> collect", env)
+    assert state["pulled"] == 1
     assert state["closed"] == 1
 
 


### PR DESCRIPTION
## Summary

Implements Seq/Flow resource finalization semantics for issue #261.

This change makes closeable Flow sources finalize predictably when consumption ends through normal exhaustion, early termination, or error interruption. It also adds Flow-aware `drop`, updates the Flow/Value classification for `take` and `drop`, and syncs the cheatsheet examples/tests so the docs match the implemented behavior.

## What changed

- Added Flow-aware `drop(n, flow)` support.
- Updated Flow finalization paths so closeable upstream sources are finalized on:
  - normal exhaustion
  - bounded early termination
  - user/source error interruption
- Preserved primary-error behavior:
  - cleanup errors surface when no primary error exists
  - cleanup errors are suppressed when a primary user/source error is already propagating
- Updated `take(0)` behavior so it does not pull item values but still finalizes an acquired closeable upstream source.
- Added shared Flow spec coverage for `drop |> take |> collect`.
- Added Python unit tests for close-tracking Flow behavior.
- Updated `GENIA_STATE.md` with Partial Seq/Flow resource lifecycle semantics.
- Updated `docs/cheatsheet/piepline-flow-vs-value.md` and its sidecar cases so `take` and `drop` are documented as polymorphic list/flow helpers.

## Files changed

- `src/genia/callable.py`
- `src/genia/builtins.py`
- `GENIA_STATE.md`
- `docs/cheatsheet/piepline-flow-vs-value.md`
- `spec/flow/seq-finalization-drop-take.yaml`
- `tests/unit/test_flow_phase1.py`
- `tests/data/pipeline_flow_vs_value_cases.json`

## Validation

Run during implementation/audit cycle:

- `uv run pytest -q tests/unit/test_flow_phase1.py tests/unit/test_flow_shared_spec_runner.py`
- `uv run python -m tools.spec_runner --verbose`
- `uv run pytest -q`
- cheatsheet validation for the Flow vs Value sidecar cases

Previous full-suite result reported in handoff:

- `2049 passed`

## Notes

- No new syntax was added.
- No new public `Seq` runtime value/type/helper was added.
- Seq remains semantic compatibility terminology.
- Python reference-host cleanup mechanics are documented as implementation details, not portable language mechanisms.

## Issue

Closes #261