### PR TITLE
Feature/issue 262 seq seeded lazy seqs

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -204,7 +204,7 @@ CLI contract summary (actual behavior):
   - raw callback invocation: `apply_raw(f, args)` — language-contract host primitive; bypasses `none(...)` short-circuit; `args` must be a list
   - promises: `force`
   - pair primitives: `cons`, `car`, `cdr`, `pair?`, `null?`
-  - Python-host-only simulation primitives (phase 2): explicit `rng(seed)` plus `rand`, `rand_int`, and `sleep`
+  - Python-host-only simulation primitives (phase 2): explicit `rng(seed)` plus `rand`, `rand_int`, `rand_flow`, `rand_int_flow`, and `sleep`
   - Python-host-only bytes/json/zip bridge builtins (phase 1):
     - `utf8_encode`, `utf8_decode`
     - internal JSON bridge primitives: `_json_parse`, `_json_stringify`

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -749,6 +749,8 @@ This protects helper-based and pattern-based Option handling from silent semanti
   - `rand(rng_state)`
   - `rand_int(n)`
   - `rand_int(rng_state, n)`
+  - `rand_flow(seed)` (experimental)
+  - `rand_int_flow(seed, n)` (experimental)
 - `sleep(ms)` remains a host-backed blocking builtin
 - `rng(seed)` requires a non-negative integer seed and returns an explicit RNG state value
 - `rand()` returns a host-RNG float in `[0, 1)` for convenience use
@@ -757,6 +759,9 @@ This protects helper-based and pattern-based Option handling from silent semanti
 - `rand_int(rng_state, n)` requires a valid RNG state and positive integer `n`, returns `[next_rng_state, int]` with the integer in `[0, n)`
 - explicit seeded randomness is state-threaded and deterministic; the same seed must yield the same sequence
 - the current Python host uses a simple fixed 32-bit LCG for the explicit seeded RNG
+- `rand_flow(seed)` returns a lazy single-use Flow of floats in `[0, 1)`; seed must be a non-negative integer; raises `TypeError` for non-integer seed, `ValueError` for negative seed; Flow is unbounded
+- `rand_int_flow(seed, n)` returns a lazy single-use Flow of integers in `[0, n)`; seed must be a non-negative integer and `n` a positive integer; raises `TypeError`/`ValueError` for invalid arguments eagerly at call time; Flow is unbounded
+- both `rand_flow` and `rand_int_flow` are pure Genia prelude wrappers; they obey the standard single-use Flow contract
 - these are intentionally small runtime primitives only: no scheduler, no async/await, no event loop, no new syntax
 
 ## 14) Bytes / JSON / ZIP bridge invariants (host-backed only)

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1714,6 +1714,8 @@ Behavior notes:
   - `rand(rng_state)`
   - `rand_int(n)`
   - `rand_int(rng_state, n)`
+  - `rand_flow(seed)` (experimental)
+  - `rand_int_flow(seed, n)` (experimental)
 - `sleep(ms)`
 
 Behavior:
@@ -1726,6 +1728,11 @@ Behavior:
 - the explicit seeded RNG uses a simple 32-bit LCG so the same seed yields the same sequence on the current Python host
 - `rand_int(...)` raises clear `TypeError` for non-integer `n` and `ValueError` for `n <= 0` in both convenience and seeded forms
 - `sleep(ms)` blocks current execution for `ms` milliseconds; raises clear `TypeError` for non-numeric values and `ValueError` for negative values
+- `rand_flow(seed)` returns a lazy, pull-based, single-use Flow emitting floats in `[0, 1)`; same seed yields the same sequence across runs on the Python reference host; seed must be a non-negative integer; raises `TypeError` for non-integer seed and `ValueError` for negative seed; the Flow is unbounded and must be bounded with `take` or similar before `collect` or `run`
+- `rand_int_flow(seed, n)` returns a lazy, pull-based, single-use Flow emitting integers in `[0, n)`; same seed and `n` yield the same sequence across runs on the Python reference host; seed must be a non-negative integer and `n` a positive integer; raises `TypeError`/`ValueError` for invalid `seed` or `n` eagerly at call time; the Flow is unbounded and must be bounded before `collect` or `run`
+- both `rand_flow` and `rand_int_flow` are pure Genia prelude wrappers composed from `evolve`, `drop`, `map`, and existing seeded RNG helpers; no new Python kernel primitives
+- LANGUAGE CONTRACT: `rand_flow` and `rand_int_flow` expose a deterministic bounded lazy sequence contract; cross-host output reproducibility is not guaranteed in this phase
+- PYTHON REFERENCE HOST: determinism is provided by the existing 32-bit LCG via `rng`/`rand`/`rand_int`; internal RNG state is not exposed as a Genia-visible value during Flow consumption
 
 ## 7) Autoloaded stdlib
 
@@ -1777,7 +1784,7 @@ Notable autoloaded functions include:
 - ref: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
 - process: `spawn`, `send`, `process_alive?`
 - io: `write`, `writeln`, `flush`, `clear_screen`, `move_cursor`, `render_grid`
-- randomness: `rng`, `rand`, `rand_int`
+- randomness: `rng`, `rand`, `rand_int`, `rand_flow`, `rand_int_flow`
 - flow: `lines`, `tee`, `merge`, `zip`, `scan`, `rules`, `refine`, `each`, `collect`, `run`, `rule_*`, `step_*`
 - option: `some`, `none?`, `some?`, `get`, `get?`, `map_some`, `flat_map_some`, `then_get`, `then_first`, `then_nth`, `then_find`, `or_else`, `or_else_with`, `unwrap_or`, `absence_reason`, `absence_context`, `is_some?`, `is_none?`
 - string: `byte_length`, `is_empty`, `concat`, `contains`, `starts_with`, `ends_with`, `find`, `split`, `split_whitespace`, `join`, `trim`, `trim_start`, `trim_end`, `lower`, `upper`, `parse_int`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository currently provides:
 - host-backed refs with public prelude-backed helpers (`ref`, `ref_get`, `ref_set`, `ref_update`) (**Python-host-only**)
 - raw host-backed `argv()` plus prelude-backed CLI parsing helpers (`cli_parse`, `cli_flag?`, `cli_option`, `cli_option_or`) (**Python-host-only**)
 - a minimal allowlisted Python host-interop layer via ordinary module imports (`import python`, `import python.json as pyjson`) (**Python-host-only**)
-- simulation primitives (`rng`, `rand`, `rand_int`, `sleep`) (**Python-host-only**)
+- simulation primitives (`rng`, `rand`, `rand_int`, `rand_flow`, `rand_int_flow`, `sleep`) (**Python-host-only**)
 - terminal helpers and input sources (`clear_screen`, `move_cursor`, `render_grid`, `stdin_keys`) (**Python-host-only**)
 - a minimal host-backed HTTP serving foundation with prelude helpers (`serve_http`, `get`, `post`, `route_request`, `ok_text`, `json`) (**Python-host-only**)
 - shell pipeline stage `$(command)` for invoking host shell commands inside pipelines (**Python-host-only**, not portable; see below)
@@ -1109,6 +1109,8 @@ Integration note: [design/pipeline-semantics.md](design/pipeline-semantics.md)
 - `rand(rng_state)` returns `[next_rng_state, float]`
 - `rand_int(n)` returns a convenience host-RNG integer in `[0, n)` for positive integer `n`
 - `rand_int(rng_state, n)` returns `[next_rng_state, int]` deterministically in `[0, n)`
+- `rand_flow(seed)` returns a lazy single-use Flow of floats in `[0, 1)`; same seed yields same bounded output (experimental)
+- `rand_int_flow(seed, n)` returns a lazy single-use Flow of integers in `[0, n)`; same seed and `n` yield same bounded output (experimental)
 - `sleep(ms)` blocks for `ms` milliseconds
 - intentionally simple: no scheduler, no async/await, no event loop
 

--- a/spec/flow/rand-flow-deterministic-bounded.yaml
+++ b/spec/flow/rand-flow-deterministic-bounded.yaml
@@ -1,0 +1,14 @@
+name: rand-flow-deterministic-bounded
+category: flow
+input:
+  source: |
+    first = rand_flow(42) |> take(4) |> collect
+    second = rand_flow(42) |> take(4) |> collect
+    in_range = filter((x) -> x >= 0 && x < 1, first)
+    [first == second, count(first), count(in_range)]
+expected:
+  stdout: "[true, 4, 4]\n"
+  stderr: ""
+  exit_code: 0
+notes:
+  Proves rand_flow returns a bounded deterministic Flow and emits floats in [0, 1).

--- a/spec/flow/rand-int-flow-deterministic-bounded.yaml
+++ b/spec/flow/rand-int-flow-deterministic-bounded.yaml
@@ -1,0 +1,15 @@
+name: rand-int-flow-deterministic-bounded
+category: flow
+input:
+  source: |
+    first = rand_int_flow(42, 10) |> take(6) |> collect
+    second = rand_int_flow(42, 10) |> take(6) |> collect
+    in_range = filter((x) -> x >= 0 && x < 10, first)
+    ones = rand_int_flow(99, 1) |> take(4) |> collect
+    [first == second, count(first), count(in_range), ones]
+expected:
+  stdout: "[true, 6, 6, [0, 0, 0, 0]]\n"
+  stderr: ""
+  exit_code: 0
+notes:
+  Proves rand_int_flow returns a bounded deterministic Flow and emits ints in [0, n).

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -2222,6 +2222,27 @@ def make_global_env(
             raise ValueError("rng expected seed >= 0")
         return GeniaRng(seed % _RNG_MODULUS)
 
+    def rand_flow_seed_fn(seed: Any) -> GeniaRng:
+        if not isinstance(seed, int) or isinstance(seed, bool):
+            raise TypeError("rand_flow seed must be a non-negative integer")
+        if seed < 0:
+            raise ValueError("rand_flow seed must be a non-negative integer")
+        return GeniaRng(seed % _RNG_MODULUS)
+
+    def rand_int_flow_seed_fn(seed: Any) -> GeniaRng:
+        if not isinstance(seed, int) or isinstance(seed, bool):
+            raise TypeError("rand_int_flow seed must be a non-negative integer")
+        if seed < 0:
+            raise ValueError("rand_int_flow seed must be a non-negative integer")
+        return GeniaRng(seed % _RNG_MODULUS)
+
+    def rand_int_flow_bound_fn(n: Any) -> int:
+        if not isinstance(n, int) or isinstance(n, bool):
+            raise TypeError("rand_int_flow n must be a positive integer")
+        if n <= 0:
+            raise ValueError("rand_int_flow n must be a positive integer")
+        return n
+
     def _ensure_rng(value: Any, name: str) -> GeniaRng:
         if not isinstance(value, GeniaRng):
             raise TypeError(f"{name} expected an rng state")
@@ -2965,6 +2986,9 @@ def make_global_env(
     env.set("_map_items", map_items_fn)
     env.set("_pairs_error", pairs_error_fn)
     env.set("_rng", rng_fn)
+    env.set("_rand_flow_seed", rand_flow_seed_fn)
+    env.set("_rand_int_flow_seed", rand_int_flow_seed_fn)
+    env.set("_rand_int_flow_bound", rand_int_flow_bound_fn)
     env.set("_rand", rand_fn)
     env.set("_rand_seeded", seeded_rand_fn)
     env.set("_rand_int", rand_int_fn)
@@ -3102,6 +3126,8 @@ def make_global_env(
     env.register_autoload("map_values", 1, "std/prelude/map.genia")
     env.register_autoload("pairs", 2, "std/prelude/map.genia")
     env.register_autoload("rng", 1, "std/prelude/random.genia")
+    env.register_autoload("rand_flow", 1, "std/prelude/random.genia")
+    env.register_autoload("rand_int_flow", 2, "std/prelude/random.genia")
     env.register_autoload("rand", 0, "std/prelude/random.genia")
     env.register_autoload("rand", 1, "std/prelude/random.genia")
     env.register_autoload("rand_int", 1, "std/prelude/random.genia")

--- a/src/genia/std/prelude/random.genia
+++ b/src/genia/std/prelude/random.genia
@@ -27,3 +27,27 @@ rand_int(n) = _rand_int(n)
 The integer is deterministic for a given seed and is always in `[0, n)`.
 """
 rand_int(rng_state, n) = _rand_int_seeded(rng_state, n)
+
+@doc """Return a lazy seeded Flow of floats in `[0, 1)`.
+
+The same seed produces the same bounded output in the Python reference host.
+Use `take` or another limiter before `collect` or `run`.
+"""
+rand_flow(seed) = rand_flow_from(_rand_flow_seed(seed))
+
+rand_flow_from(state) =
+  evolve([state, nil], ([s, _]) -> rand(s))
+    |> drop(1)
+    |> map(([_, v]) -> v)
+
+@doc """Return a lazy seeded Flow of integers in `[0, n)`.
+
+The same seed and `n` produce the same bounded output in the Python reference host.
+Use `take` or another limiter before `collect` or `run`.
+"""
+rand_int_flow(seed, n) = rand_int_flow_from(_rand_int_flow_seed(seed), _rand_int_flow_bound(n))
+
+rand_int_flow_from(state, n) =
+  evolve([state, nil], ([s, _]) -> rand_int(s, n))
+    |> drop(1)
+    |> map(([_, v]) -> v)

--- a/tests/unit/test_simulation_primitives.py
+++ b/tests/unit/test_simulation_primitives.py
@@ -116,3 +116,86 @@ def test_seeded_rng_rejects_invalid_seed_and_state_inputs(run):
         run("rand(1)")
     with pytest.raises(TypeError, match="rand_int expected an rng state"):
         run("rand_int(1, 5)")
+
+
+def test_rand_flow_is_deterministic_bounded_and_unit_interval(run):
+    first = run("rand_flow(42) |> take(8) |> collect")
+    second = run("rand_flow(42) |> take(8) |> collect")
+
+    assert first == second
+    assert len(first) == 8
+    assert all(isinstance(x, float) for x in first)
+    assert all(0.0 <= x < 1.0 for x in first)
+
+
+def test_rand_flow_distinct_seeds_and_empty_take(run):
+    assert run("rand_flow(1) |> take(6) |> collect") != run(
+        "rand_flow(2) |> take(6) |> collect"
+    )
+    assert run("rand_flow(42) |> take(0) |> collect") == []
+
+
+def test_rand_int_flow_is_deterministic_bounded_and_composable(run):
+    source = """
+    rand_int_flow(123, 6)
+      |> map((n) -> n + 1)
+      |> take(10)
+      |> collect
+    """
+
+    first = run(source)
+    second = run(source)
+
+    assert first == second
+    assert len(first) == 10
+    assert all(isinstance(x, int) for x in first)
+    assert all(1 <= x <= 6 for x in first)
+
+
+def test_rand_int_flow_n_one_and_empty_take(run):
+    assert run("rand_int_flow(9, 1) |> take(5) |> collect") == [0, 0, 0, 0, 0]
+    assert run("rand_int_flow(9, 7) |> take(0) |> collect") == []
+
+
+def test_rand_flow_and_rand_int_flow_are_single_use(run):
+    with pytest.raises(RuntimeError, match="Flow has already been consumed"):
+        run(
+            """
+            flow = rand_flow(7)
+            flow |> take(1) |> collect
+            flow |> take(1) |> collect
+            """
+        )
+
+    with pytest.raises(RuntimeError, match="Flow has already been consumed"):
+        run(
+            """
+            flow = rand_int_flow(7, 10)
+            flow |> take(1) |> collect
+            flow |> take(1) |> collect
+            """
+        )
+
+
+def test_rand_flow_rejects_invalid_seed(run):
+    with pytest.raises(TypeError, match="rand_flow seed must be a non-negative integer"):
+        run('rand_flow("oops")')
+    with pytest.raises(ValueError, match="rand_flow seed must be a non-negative integer"):
+        run("rand_flow(-1)")
+
+
+def test_rand_int_flow_rejects_invalid_seed_and_n_eagerly(run):
+    with pytest.raises(
+        TypeError, match="rand_int_flow seed must be a non-negative integer"
+    ):
+        run('rand_int_flow("oops", 6)')
+    with pytest.raises(
+        ValueError, match="rand_int_flow seed must be a non-negative integer"
+    ):
+        run("rand_int_flow(-1, 6)")
+    with pytest.raises(TypeError, match="rand_int_flow n must be a positive integer"):
+        run('rand_int_flow(1, "6")')
+    with pytest.raises(ValueError, match="rand_int_flow n must be a positive integer"):
+        run("rand_int_flow(1, 0)")
+    with pytest.raises(ValueError, match="rand_int_flow n must be a positive integer"):
+        run("rand_int_flow(1, -1)")


### PR DESCRIPTION
## Summary

Implements issue #262 by adding deterministic seeded lazy Flow sources:

- `rand_flow(seed)`
- `rand_int_flow(seed, n)`

These helpers provide reproducible, bounded lazy sequence behavior for tests, demos, and future simulation work while preserving the existing Flow model.

## What changed

- Added `rand_flow(seed)` to produce a lazy single-use Flow of floats in `[0, 1)`.
- Added `rand_int_flow(seed, n)` to produce a lazy single-use Flow of integers in `[0, n)`.
- Implemented both helpers through existing Flow/RNG primitives rather than introducing new syntax or a broader Seq redesign.
- Added autoload/validation support.
- Added shared Flow spec coverage for deterministic bounded output.
- Added unit tests for determinism, output ranges, `take(0)`, single-use behavior, composition, and invalid argument diagnostics.
- Updated:
  - `GENIA_STATE.md`
  - `GENIA_RULES.md`
  - `README.md`
  - `GENIA_REPL_README.md`

## Validation

```bash
PYTHONPATH=src pytest -q tests/unit/test_simulation_primitives.py
# 17 passed

PYTHONPATH=src python3 -m tools.spec_runner
# Summary: total=209 passed=209 failed=0 invalid=0

PYTHONPATH=src pytest -q tests/unit/test_flow_shared_spec_runner.py
# 5 passed