### PR TITLE
Feature/issue 277 seq narrow flow fusion

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -429,6 +429,7 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - Missing `state` keeps the current state, missing `emit` emits `[]`, and missing `halt` means `false`.
   - `emit` must be a list of zero, one, or many output values; `halt: true` emits the current step's values and then stops the whole transform without pulling later source items.
   - Invalid `_seq_transform` step results raise runtime errors prefixed with `invalid-seq-transform-result:`.
+  - PYTHON REFERENCE HOST: adjacent Flow `map` / `filter` stages may be represented by an internal fused Flow object that composes callbacks over one upstream source. This is an implementation optimization only; it adds no public Seq value, no fusion API, no new syntax, no Core IR node, no runtime flags, and no observable `trace` / display label change.
   - Maturity: Partial; list and Flow behavior is implemented, while Seq remains semantic terminology rather than a separate public surface.
 - pipeline debugging helpers are implemented as prelude-level identity stages:
   - `inspect(value)` logs and returns `value` unchanged
@@ -1046,6 +1047,12 @@ Representation System entry points (#185, implemented):
   - invalid step result shape, non-list `emit`, and non-boolean `halt` raise runtime errors prefixed with `invalid-seq-transform-result:`
   - `_seq_transform` is available only to trusted prelude/runtime code and Python reference-host tests; ordinary Genia user code must use public helpers such as `map`, `filter`, `take`, `scan`, `each`, `collect`, `run`, and `evolve`
   - `_seq_transform` introduces no syntax, no Core IR node, no public Seq value/type/helper, and no implicit list/Flow conversion
+- PYTHON REFERENCE HOST: adjacent Flow `map` / `filter` stages may be fused into one internal Flow wrapper before downstream consumption:
+  - fusion applies only to Flow inputs and only to adjacent `map` / `filter` stages in this phase
+  - list-side `map` / `filter` behavior remains eager and reusable, with no list fusion in this phase
+  - non-fusable Flow stages and consumers (`take`, `drop`, `scan`, `each`, `collect`, `run`, rules/refine helpers, and option-routing helpers) continue to consume a normal Flow-compatible value
+  - the fused wrapper is internal Python host machinery, not a public runtime value or portable Core IR contract
+  - observable behavior must remain unchanged: item order, callback order, side-effect order, laziness, bounded pulling, upstream close behavior, single-use enforcement, errors, stdout/stderr/exit code, and Flow display labels
 - flow transforms:
   - `lines(flow_or_source)`
   - `evolve(init, f)` (experimental unbounded progression flow; emits `init` first, then repeatedly emits `f(previous_value)`)

--- a/src/genia/callable.py
+++ b/src/genia/callable.py
@@ -113,6 +113,62 @@ def _finalize_iterable(iterable: Any, *, primary_error: bool) -> None:
     _maybe_close_iterable(iterable)
 
 
+class _FusedStage:
+    pass
+
+
+@dataclass(frozen=True)
+class _MapStage(_FusedStage):
+    mapper: Callable[[Any], Any]
+    label = "map"
+
+
+@dataclass(frozen=True)
+class _FilterStage(_FusedStage):
+    predicate: Callable[[Any], Any]
+    label = "filter"
+
+
+class _FusedFlow(GeniaFlow):
+    def __init__(self, upstream: GeniaFlow, stages: list[_FusedStage]):
+        self._upstream = upstream
+        self._stages = list(stages)
+
+        def _iterator() -> Any:
+            items = upstream.consume()
+            primary_error = False
+            try:
+                for item in items:
+                    current = item
+                    keep = True
+                    for stage in self._stages:
+                        if isinstance(stage, _MapStage):
+                            current = stage.mapper(current)
+                        elif isinstance(stage, _FilterStage) and not truthy(stage.predicate(current)):
+                            keep = False
+                            break
+                    if keep:
+                        yield current
+            except Exception:
+                primary_error = True
+                raise
+            finally:
+                if upstream.close_on_early_termination:
+                    _finalize_iterable(items, primary_error=primary_error)
+
+        super().__init__(
+            _iterator,
+            label=self._stages[-1].label,
+            close_on_early_termination=upstream.close_on_early_termination,
+        )
+
+
+def _append_fused_stage(source: GeniaFlow, stage: _FusedStage) -> _FusedFlow:
+    if isinstance(source, _FusedFlow):
+        return _FusedFlow(source._upstream, source._stages + [stage])
+    return _FusedFlow(source, [stage])
+
+
 # ---------------------------------------------------------------------------
 # Callable value types
 # ---------------------------------------------------------------------------
@@ -545,41 +601,32 @@ def invoke_callable(
             if callee_node.name == "map" and len(args) == 2:
                 mapper = args[0]
                 source = args[1]
-
-                def _map_iterator() -> Any:
-                    items = source.consume()
-                    primary_error = False
-                    try:
-                        for item in items:
-                            yield invoke_callable(mapper, [item], tail_position=False, autoload_resolver=autoload_resolver)
-                    except Exception:
-                        primary_error = True
-                        raise
-                    finally:
-                        if source.close_on_early_termination:
-                            _finalize_iterable(items, primary_error=primary_error)
-
-                return GeniaFlow(_map_iterator, label="map", close_on_early_termination=source.close_on_early_termination)
+                return _append_fused_stage(
+                    source,
+                    _MapStage(
+                        lambda item: invoke_callable(
+                            mapper,
+                            [item],
+                            tail_position=False,
+                            autoload_resolver=autoload_resolver,
+                        )
+                    ),
+                )
 
             if callee_node.name == "filter" and len(args) == 2:
                 predicate = args[0]
                 source = args[1]
-
-                def _filter_iterator() -> Any:
-                    items = source.consume()
-                    primary_error = False
-                    try:
-                        for item in items:
-                            if truthy(invoke_callable(predicate, [item], tail_position=False, autoload_resolver=autoload_resolver)):
-                                yield item
-                    except Exception:
-                        primary_error = True
-                        raise
-                    finally:
-                        if source.close_on_early_termination:
-                            _finalize_iterable(items, primary_error=primary_error)
-
-                return GeniaFlow(_filter_iterator, label="filter", close_on_early_termination=source.close_on_early_termination)
+                return _append_fused_stage(
+                    source,
+                    _FilterStage(
+                        lambda item: invoke_callable(
+                            predicate,
+                            [item],
+                            tail_position=False,
+                            autoload_resolver=autoload_resolver,
+                        )
+                    ),
+                )
 
             if callee_node.name == "take" and len(args) == 2:
                 count = args[0]

--- a/tests/unit/test_flow_fusion_277.py
+++ b/tests/unit/test_flow_fusion_277.py
@@ -1,0 +1,101 @@
+from genia import make_global_env, run_source
+from genia.interpreter import GeniaFlow
+
+
+def test_adjacent_flow_map_filter_map_chain_is_represented_as_one_fused_flow():
+    env = make_global_env()
+
+    flow = run_source(
+        """
+        ["a", "bb", "ccc"]
+          |> lines
+          |> map((x) -> concat(x, "!"))
+          |> filter((x) -> x != "bb!")
+          |> map((x) -> concat(x, "?"))
+        """,
+        env,
+    )
+
+    assert isinstance(flow, GeniaFlow)
+    assert flow.__class__.__name__ == "_FusedFlow"
+    assert len(flow._stages) == 3
+    assert repr(flow._upstream) == "<flow lines ready>"
+    assert list(flow.consume()) == ["a!?", "ccc!?"]
+
+
+def test_flow_map_filter_fusion_preserves_bounded_pulling_and_close():
+    env = make_global_env()
+    state = {"pulled": 0, "closed": 0}
+
+    class ClosableCounter:
+        def __init__(self):
+            self._next = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            value = self._next
+            self._next += 1
+            state["pulled"] += 1
+            return value
+
+        def close(self):
+            state["closed"] += 1
+
+    def ticks():
+        return GeniaFlow(lambda: ClosableCounter(), label="ticks")
+
+    env.set("ticks", ticks)
+
+    assert run_source(
+        """
+        ticks()
+          |> map((x) -> x + 1)
+          |> filter((x) -> x % 2 == 0)
+          |> map((x) -> x * 10)
+          |> take(3)
+          |> collect
+        """,
+        env,
+    ) == [20, 40, 60]
+    assert state == {"pulled": 6, "closed": 1}
+
+
+def test_fused_flow_still_enforces_single_use():
+    env = make_global_env()
+
+    flow = run_source(
+        """
+        ["1", "2", "3"]
+          |> lines
+          |> map((x) -> concat(x, "!"))
+          |> filter((x) -> x != "2!")
+        """,
+        env,
+    )
+
+    assert flow.__class__.__name__ == "_FusedFlow"
+    assert list(flow.consume()) == ["1!", "3!"]
+
+    try:
+        list(flow.consume())
+    except RuntimeError as exc:
+        assert str(exc) == "Flow has already been consumed"
+    else:  # pragma: no cover - assertion path
+        raise AssertionError("fused Flow was consumed twice without an error")
+
+
+def test_list_map_filter_chain_remains_eager_reusable_list_behavior():
+    env = make_global_env()
+
+    result = run_source(
+        """
+        xs = [1, 2, 3]
+        ys = xs |> map((x) -> x + 1) |> filter((x) -> x > 2)
+        [ys, ys]
+        """,
+        env,
+    )
+
+    assert result == [[3, 4], [3, 4]]


### PR DESCRIPTION
## Summary

Implements issue #277: narrow internal Flow fusion for adjacent `map` / `filter` stages over Flow inputs.

This adds a Python reference-host-only internal fused Flow representation so chains like `flow |> map(...) |> filter(...) |> map(...)` can accumulate stages over the original upstream Flow instead of building nested intermediate Flow wrappers.

This is intentionally **not** a public feature. It adds no user-facing API, syntax, Core IR node, CLI flag, runtime flag, or public Seq value. Public behavior remains unchanged.

## What changed

- Added internal fused Flow machinery in `src/genia/callable.py`:
  - `_FusedStage`
  - `_MapStage`
  - `_FilterStage`
  - `_FusedFlow`
  - `_append_fused_stage`
- Updated the public Flow `map` / `filter` fast path so adjacent Flow stages append to the fused wrapper.
- Preserved existing Flow behavior:
  - lazy
  - pull-based
  - source-bound
  - single-use
  - finalization-aware
  - same public `trace` / `repr` labels
- Updated `GENIA_STATE.md` to record this as an internal Python reference-host implementation detail only.

## Scope

Included:

- Flow-input fusion for adjacent `map` / `filter` stages.
- Behavior-preservation tests for fused Flow chains.
- Documentation in `GENIA_STATE.md` only, because this is not user-facing behavior.

Not included:

- No list-side fusion.
- No public Seq API.
- No public fusion API.
- No new syntax.
- No Core IR changes.
- No general optimizer.
- No multi-host implementation.
- No fusion for `scan`, `take`, `drop`, `each`, `collect`, `run`, `rules`, `refine`, or option-routing helpers.

## Behavior guarantees

This PR preserves observable behavior for:

- item order
- side-effect order
- callback count
- laziness
- bounded pulling
- upstream close/finalization
- single-use Flow enforcement
- stdout/stderr/exit behavior
- public trace/display labels
- list `map` / `filter` eager reusable behavior

Fusion is internal plumbing only: same Genia behavior, less wrapper lasagna.

## Tests

New tests:

- `tests/unit/test_flow_fusion_277.py`

Validated:

```sh
PYTHONPATH=src pytest -q tests/unit/test_flow_fusion_277.py
# 4 passed