### PR TITLE
Fix fused Flow callback error propagation

### DIFF
--- a/src/genia/callable.py
+++ b/src/genia/callable.py
@@ -129,6 +129,13 @@ class _FilterStage(_FusedStage):
     label = "filter"
 
 
+def _preserve_fused_callback_error(exc: Exception) -> None:
+    try:
+        setattr(exc, "_genia_preserve_pipeline_error", True)
+    except Exception:
+        pass
+
+
 class _FusedFlow(GeniaFlow):
     def __init__(self, upstream: GeniaFlow, stages: list[_FusedStage]):
         self._upstream = upstream
@@ -143,10 +150,19 @@ class _FusedFlow(GeniaFlow):
                     keep = True
                     for stage in self._stages:
                         if isinstance(stage, _MapStage):
-                            current = stage.mapper(current)
-                        elif isinstance(stage, _FilterStage) and not truthy(stage.predicate(current)):
-                            keep = False
-                            break
+                            try:
+                                current = stage.mapper(current)
+                            except Exception as exc:
+                                _preserve_fused_callback_error(exc)
+                                raise
+                        elif isinstance(stage, _FilterStage):
+                            try:
+                                keep = truthy(stage.predicate(current))
+                            except Exception as exc:
+                                _preserve_fused_callback_error(exc)
+                                raise
+                            if not keep:
+                                break
                     if keep:
                         yield current
             except Exception:

--- a/src/genia/evaluator.py
+++ b/src/genia/evaluator.py
@@ -844,6 +844,8 @@ class Evaluator:
         return f"{span.filename}:{span.line}"
 
     def _wrap_pipeline_stage_error(self, exc: Exception, stage_index: int, node: IrNode, stage_input: Any) -> Exception:
+        if getattr(exc, "_genia_preserve_pipeline_error", False):
+            return exc
         message = str(exc)
         if message.startswith("pipeline stage ") and " failed in " in message:
             return exc

--- a/tests/unit/test_flow_fusion_277.py
+++ b/tests/unit/test_flow_fusion_277.py
@@ -1,3 +1,5 @@
+import pytest
+
 from genia import make_global_env, run_source
 from genia.interpreter import GeniaFlow
 
@@ -60,6 +62,102 @@ def test_flow_map_filter_fusion_preserves_bounded_pulling_and_close():
         env,
     ) == [20, 40, 60]
     assert state == {"pulled": 6, "closed": 1}
+
+
+def test_fused_flow_map_callback_error_propagates_and_closes_upstream():
+    env = make_global_env()
+    state = {"pulled": [], "closed": 0}
+    mapper_error = RuntimeError("boom from mapper")
+
+    class ClosableCounter:
+        def __init__(self):
+            self._next = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            value = self._next
+            self._next += 1
+            state["pulled"].append(value)
+            return value
+
+        def close(self):
+            state["closed"] += 1
+
+    def ticks():
+        return GeniaFlow(lambda: ClosableCounter(), label="ticks")
+
+    def boom_on_three(value):
+        if value == 3:
+            raise mapper_error
+        return value
+
+    env.set("ticks", ticks)
+    env.set("boom_on_three", boom_on_three)
+
+    with pytest.raises(RuntimeError, match="boom from mapper") as exc_info:
+        run_source(
+            """
+            ticks()
+              |> map((x) -> x + 1)
+              |> filter((x) -> x < 10)
+              |> map(boom_on_three)
+              |> collect
+            """,
+            env,
+        )
+
+    assert exc_info.value is mapper_error
+    assert state == {"pulled": [0, 1, 2], "closed": 1}
+
+
+def test_fused_flow_filter_callback_error_propagates_and_closes_upstream():
+    env = make_global_env()
+    state = {"pulled": [], "closed": 0}
+    predicate_error = RuntimeError("boom from predicate")
+
+    class ClosableCounter:
+        def __init__(self):
+            self._next = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            value = self._next
+            self._next += 1
+            state["pulled"].append(value)
+            return value
+
+        def close(self):
+            state["closed"] += 1
+
+    def ticks():
+        return GeniaFlow(lambda: ClosableCounter(), label="ticks")
+
+    def boom_predicate_on_three(value):
+        if value == 3:
+            raise predicate_error
+        return True
+
+    env.set("ticks", ticks)
+    env.set("boom_predicate_on_three", boom_predicate_on_three)
+
+    with pytest.raises(RuntimeError, match="boom from predicate") as exc_info:
+        run_source(
+            """
+            ticks()
+              |> map((x) -> x + 1)
+              |> filter(boom_predicate_on_three)
+              |> map((x) -> x * 10)
+              |> collect
+            """,
+            env,
+        )
+
+    assert exc_info.value is predicate_error
+    assert state == {"pulled": [0, 1, 2], "closed": 1}
 
 
 def test_fused_flow_still_enforces_single_use():


### PR DESCRIPTION
## Summary

- Add regression coverage for callback errors raised inside internally fused Flow `map` / `filter` chains
- Preserve original fused mapper/predicate callback exceptions instead of replacing them with pipeline-stage wrapper errors
- Keep the exception preservation marker private to Python reference-host fusion machinery

## Validation

From the handoff audit:

```sh
uv run pytest -q tests/unit/test_flow_fusion_277.py
# 6 passed

uv run pytest -q tests/unit/test_flow_phase1.py tests/unit/test_seq_transform_256.py tests/unit/test_flow_shared_spec_runner.py tests/unit/test_pipeline_debug_utils.py
# 94 passed

uv run pytest -q
# 2066 passed
```

## Docs

No canonical docs changed. This restores the existing documented invariant that internal Flow fusion preserves observable behavior and does not create public syntax, a public fusion API, a public Seq value, a Core IR node, runtime flags, or display-label changes.

Closes #279