### PR TITLE
feat(representation): add first-class Format values issue #168

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -189,7 +189,9 @@ CLI contract summary (actual behavior):
     - `debug_repr(value)` returns the debug representation string without writing output
     - these entry points are minimal #185 surface area; #166 owns the broader Representation System model
   - public prelude-backed string formatting helper:
-    - `format(template, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; it supports escaped braces with `{{` and `}}`
+    - `format(template_or_format, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; it supports escaped braces with `{{` and `}}`
+    - `format` accepts either a raw string template or a `Format` value as its first argument
+    - `Format(template)` constructs a first-class representation value from a string template (**Experimental**, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
   - public flow helpers are prelude-backed wrappers: `lines`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, plus `rule_*` compatibility constructors and preferred `step_*` constructors
   - public sink helpers are prelude-backed wrappers: `write`, `writeln`, `flush`
   - raw CLI primitive: `argv`
@@ -333,7 +335,7 @@ CLI contract summary (actual behavior):
 - output routing:
   - `print(...)` writes to `stdout`
   - `log(...)` writes to `stderr`
-  - `display(value)`, `debug_repr(value)`, and `format(template, values)` return strings and do not write to `stdout` or `stderr`
+  - `display(value)`, `debug_repr(value)`, and `format(template_or_format, values)` return strings and do not write to `stdout` or `stderr`
   - `write(sink, value)` / `writeln(sink, value)` are public prelude-backed wrappers over the host sink bridge
   - `flush(sink)` is a public prelude-backed wrapper over the host sink bridge
   - broken pipe on `stdout` output in command/file execution is treated as normal downstream termination without a Python traceback

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -970,8 +970,9 @@ Representation System entry points (#185, implemented):
 - They are entry points into that system, not independent formatting utilities.
 - `display(value)` returns a string containing the user-facing display representation of `value`.
 - `debug_repr(value)` returns a string containing the debug representation of `value`.
-- `format(template, values)` is a public prelude-backed helper for building strings from a small placeholder template.
-- `format(template, values)` returns a string and does not write output.
+- `format(template_or_format, values)` is a public prelude-backed helper for building strings from a small placeholder template.
+- `format(template_or_format, values)` returns a string and does not write output.
+- The first argument to `format` is either a raw string template or a `Format` value (see below).
 - `format` supports only:
   - named placeholders such as `{name}`, looked up in a map by string key
   - positional placeholders such as `{0}`, looked up in a list by zero-based index
@@ -979,6 +980,17 @@ Representation System entry points (#185, implemented):
 - Placeholder replacements use the same user-facing display representation as `display(value)`.
 - Missing fields and invalid placeholders raise deterministic errors.
 - `format` does not support field paths, interpolation string syntax, width/alignment/precision specifiers, localization, tagged formats, or debug rendering.
+- `Format(template)` is a first-class Representation System constructor (**Experimental**, #168):
+  - `Format(template)` accepts a string template and returns a first-class `Format` value.
+  - A `Format` value is representation-only: it is not a Value Template and does not participate in shape/refinement/contract/variant semantics.
+  - `format(Format(template), values)` produces the same result as `format(template, values)` for the same template and values.
+  - A `Format` value can be assigned to a name, passed as an argument, stored in a list or map, and returned from a function.
+  - `display(Format(...))` returns `<format>`; the wrapped template is not exposed.
+  - `debug_repr(Format(...))` returns `<format>`; the wrapped template is not exposed.
+  - `Format(non_string)` fails with `TypeError: Format expected a string template, received <type>`.
+  - `format(non_string_non_format, values)` fails with `TypeError: format expected a string template or Format value, received <type>`.
+  - No parser syntax such as `Format "..."` is introduced; `Format("...")` is the only accepted call form.
+  - `Format` is Experimental. The wrapped template, display/debug text, and constructor surface may change before stabilization.
 - These helpers do not write to `stdout` or `stderr`.
 - These helpers do not mutate runtime state.
 - These helpers do not change `print`, `log`, `write`, `writeln`, REPL result display, CLI final-result rendering, or pipeline semantics.

--- a/README.md
+++ b/README.md
@@ -577,7 +577,8 @@ Current consistency note:
 - `help()` now points users toward the public prelude-backed stdlib surface, while raw host-backed runtime names remain intentionally generic
 - REPL/debug output now renders structured absence with visible context metadata, for example `none("missing-key", {key: "name"})`
 - `display(value)` and `debug_repr(value)` are the first public Representation System entry points: they return display/debug representation strings without writing output
-- `format(template, values)` is a public prelude-backed string helper: it returns a string, uses `display(value)` for replacements, and supports only `{name}`, `{0}`, `{{`, and `}}`
+- `format(template_or_format, values)` is a public prelude-backed string helper: it returns a string, uses `display(value)` for replacements, and supports only `{name}`, `{0}`, `{{`, and `}}`; its first argument is a raw string template or a `Format` value
+- `Format(template)` constructs a first-class representation value from a string template (Experimental, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
 - `some(pattern)`, `none(reason)`, and `none(reason, context)` are supported in pattern matching for Option values
 - new `?`-suffixed APIs are boolean-returning; `get?` remains the current compatibility exception and `get` is the preferred maybe-aware lookup name
 - Flow, MetaEnv, Ref, and Process handles are runtime values, but they are not plain data in the same sense as numbers/lists/maps
@@ -901,7 +902,7 @@ flush(stdout)
 - `flush(sink)` flushes a sink and returns `none("nil")`
 - `print(...)` writes to `stdout`, and `log(...)` writes to `stderr`
 - `display(value)` and `debug_repr(value)` return representation strings and do not write output
-- `format(template, values)` returns a string built from named or positional placeholders and does not write output
+- `format(template_or_format, values)` returns a string built from named or positional placeholders and does not write output; accepts a raw string or a `Format` value
 - `input()` remains independent of `stdin`
 - broken pipe on `stdout` output in Unix pipelines is treated as normal downstream termination
 - flow-driven stdout writes use the same quiet broken-pipe path

--- a/spec/error/error-format-first-class-constructor-non-string.yaml
+++ b/spec/error/error-format-first-class-constructor-non-string.yaml
@@ -1,0 +1,10 @@
+name: error-format-first-class-constructor-non-string
+category: error
+input:
+  source: |
+    Format(123)
+expected:
+  stdout: ""
+  stderr: |
+    Error: Format expected a string template, received int
+  exit_code: 1

--- a/spec/error/error-format-first-class-non-string-non-format.yaml
+++ b/spec/error/error-format-first-class-non-string-non-format.yaml
@@ -1,8 +1,8 @@
-name: error-format-non-string-template
+name: error-format-first-class-non-string-non-format
 category: error
 input:
   source: |
-    format(42, {})
+    format(123, {})
 expected:
   stdout: ""
   stderr: |

--- a/spec/eval/format-first-class-format-debug-repr.yaml
+++ b/spec/eval/format-first-class-format-debug-repr.yaml
@@ -1,0 +1,10 @@
+name: format-first-class-format-debug-repr
+category: eval
+input:
+  source: |
+    debug_repr(Format("{a}"))
+expected:
+  stdout: |
+    "<format>"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-first-class-format-display.yaml
+++ b/spec/eval/format-first-class-format-display.yaml
@@ -1,0 +1,10 @@
+name: format-first-class-format-display
+category: eval
+input:
+  source: |
+    display(Format("{a}"))
+expected:
+  stdout: |
+    "<format>"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-first-class-format-empty-template.yaml
+++ b/spec/eval/format-first-class-format-empty-template.yaml
@@ -1,0 +1,10 @@
+name: format-first-class-format-empty-template
+category: eval
+input:
+  source: |
+    format(Format(""), {})
+expected:
+  stdout: |
+    ""
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-first-class-format-no-placeholders.yaml
+++ b/spec/eval/format-first-class-format-no-placeholders.yaml
@@ -1,0 +1,10 @@
+name: format-first-class-format-no-placeholders
+category: eval
+input:
+  source: |
+    format(Format("hello world"), {})
+expected:
+  stdout: |
+    "hello world"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-first-class-format-positional.yaml
+++ b/spec/eval/format-first-class-format-positional.yaml
@@ -1,0 +1,10 @@
+name: format-first-class-format-positional
+category: eval
+input:
+  source: |
+    format(Format("{0} {1}"), ["hello", "world"])
+expected:
+  stdout: |
+    "hello world"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-first-class-format-value-backward-compat.yaml
+++ b/spec/eval/format-first-class-format-value-backward-compat.yaml
@@ -1,0 +1,10 @@
+name: format-first-class-format-value-backward-compat
+category: eval
+input:
+  source: |
+    format("{a} {b} {c}", {a: "X", b: "O", c: " "})
+expected:
+  stdout: |
+    "X O  "
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-first-class-format-value-inline.yaml
+++ b/spec/eval/format-first-class-format-value-inline.yaml
@@ -1,0 +1,10 @@
+name: format-first-class-format-value-inline
+category: eval
+input:
+  source: |
+    format(Format("{a} {b} {c}"), {a: "X", b: "O", c: " "})
+expected:
+  stdout: |
+    "X O  "
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-first-class-format-value-named.yaml
+++ b/spec/eval/format-first-class-format-value-named.yaml
@@ -1,0 +1,11 @@
+name: format-first-class-format-value-named
+category: eval
+input:
+  source: |
+    BoardRow = Format("{a} {b} {c}")
+    format(BoardRow, {a: "X", b: "O", c: " "})
+expected:
+  stdout: |
+    "X O  "
+  stderr: ""
+  exit_code: 0

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -69,6 +69,7 @@ if __package__ in (None, ""):
         GeniaBytes,
         GeniaCell,
         GeniaFlow,
+        GeniaFormat,
         GeniaMap,
         GeniaOptionNone,
         GeniaOptionSome,
@@ -131,6 +132,7 @@ else:
         GeniaBytes,
         GeniaCell,
         GeniaFlow,
+        GeniaFormat,
         GeniaMap,
         GeniaOptionNone,
         GeniaOptionSome,
@@ -474,6 +476,13 @@ def make_global_env(
     def debug_repr_fn(value: Any) -> str:
         return format_debug(value)
 
+    def format_constructor(template: Any) -> GeniaFormat:
+        if not isinstance(template, str):
+            raise TypeError(
+                f"Format expected a string template, received {_runtime_type_name(template)}"
+            )
+        return GeniaFormat(template)
+
     def _ensure_string(value: Any, name: str) -> str:
         if not isinstance(value, str):
             raise TypeError(f"{name} expected a string, received {_runtime_type_name(value)}")
@@ -581,8 +590,12 @@ def make_global_env(
         return separator.join(xs)
 
     def format_fn(template: Any, values: Any) -> str:
-        if not isinstance(template, str):
-            raise TypeError("format expected a string template")
+        if isinstance(template, GeniaFormat):
+            template = template.template
+        elif not isinstance(template, str):
+            raise TypeError(
+                f"format expected a string template or Format value, received {_runtime_type_name(template)}"
+            )
 
         def _is_named_placeholder(body: str) -> bool:
             if body == "":
@@ -2868,6 +2881,7 @@ def make_global_env(
     env.set("print", print_fn)
     env.set("display", display_fn)
     env.set("debug_repr", debug_repr_fn)
+    env.set("Format", format_constructor)
     env.set("input", input_fn)
     env.set("stdin", stdin_source)
     env.set("stdin_keys", stdin_keys_flow)

--- a/src/genia/utf8.py
+++ b/src/genia/utf8.py
@@ -43,6 +43,8 @@ def format_display(value: Any) -> str:
         return _format_pair(value, format_display)
     if _is_map(value):
         return _format_map(value, format_display)
+    if _is_format(value):
+        return "<format>"
     if isinstance(value, str):
         return value
     if isinstance(value, list):
@@ -75,6 +77,8 @@ def format_debug(value: Any) -> str:
         return _format_pair(value, format_debug)
     if _is_map(value):
         return _format_map(value, format_debug)
+    if _is_format(value):
+        return "<format>"
     if isinstance(value, str):
         return f'"{_escape_for_debug(value)}"'
     if isinstance(value, list):
@@ -108,6 +112,10 @@ def _is_option_none(value: Any) -> bool:
 
 def _is_option_some(value: Any) -> bool:
     return value.__class__.__name__ == "GeniaOptionSome" and hasattr(value, "value")
+
+
+def _is_format(value: Any) -> bool:
+    return value.__class__.__name__ == "GeniaFormat" and hasattr(value, "template")
 
 
 def _format_pair(value: Any, formatter) -> str:

--- a/src/genia/values.py
+++ b/src/genia/values.py
@@ -49,6 +49,8 @@ def _runtime_type_name(value: Any) -> str:
         return "pair"
     if isinstance(value, GeniaStdinSource):
         return "stdin"
+    if isinstance(value, GeniaFormat):
+        return "format"
     if value.__class__.__name__ == "GeniaMetaEnv":
         return "meta_env"
     if value.__class__.__name__ == "GeniaPromise":
@@ -511,6 +513,14 @@ class GeniaProcess:
                 return "<process failed>"
         status = "alive" if self.is_alive() else "dead"
         return f"<process {status}>"
+
+
+class GeniaFormat:
+    def __init__(self, template: str):
+        self.template = template
+
+    def __repr__(self) -> str:
+        return "<format>"
 
 
 class GeniaBytes:

--- a/tests/spec/test_spec_ir_runner_blackbox.py
+++ b/tests/spec/test_spec_ir_runner_blackbox.py
@@ -242,6 +242,14 @@ def test_ir_spec_fixture(fname: str) -> None:
         "pairs-empty-both.yaml",
         "pairs-strings.yaml",
         "pairs-pattern-match.yaml",
+        "format-first-class-format-value-named.yaml",
+        "format-first-class-format-value-inline.yaml",
+        "format-first-class-format-value-backward-compat.yaml",
+        "format-first-class-format-display.yaml",
+        "format-first-class-format-debug-repr.yaml",
+        "format-first-class-format-empty-template.yaml",
+        "format-first-class-format-no-placeholders.yaml",
+        "format-first-class-format-positional.yaml",
     ],
 )
 @pytest.mark.spec
@@ -317,6 +325,9 @@ def test_flow_spec_fixture(fname: str) -> None:
         "error-pattern-miss.yaml",
         "error-pattern-guard-all-fail.yaml",
         "error-pattern-glob-malformed.yaml",
+        "error-format-non-string-template.yaml",
+        "error-format-first-class-constructor-non-string.yaml",
+        "error-format-first-class-non-string-non-format.yaml",
     ],
 )
 @pytest.mark.spec

--- a/tests/unit/test_format_first_class_168.py
+++ b/tests/unit/test_format_first_class_168.py
@@ -1,0 +1,105 @@
+import io
+
+import pytest
+
+from genia import make_global_env, run_source
+
+
+def _env():
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    return make_global_env(stdout_stream=stdout, stderr_stream=stderr), stdout, stderr
+
+
+# --- Happy path: construction and use ---
+
+def test_format_value_named_formats_correctly():
+    env, _, _ = _env()
+    result = run_source('BoardRow = Format("{a} {b} {c}")\nformat(BoardRow, {a: "X", b: "O", c: " "})', env)
+    assert result == "X O  "
+
+
+def test_format_value_inline_formats_correctly():
+    env, _, _ = _env()
+    result = run_source('format(Format("{a} {b} {c}"), {a: "X", b: "O", c: " "})', env)
+    assert result == "X O  "
+
+
+def test_format_value_matches_raw_string_output():
+    env, _, _ = _env()
+    raw = run_source('format("{a} {b} {c}", {a: "X", b: "O", c: " "})', env)
+    env2, _, _ = _env()
+    via_format = run_source('format(Format("{a} {b} {c}"), {a: "X", b: "O", c: " "})', env2)
+    assert raw == via_format
+
+
+def test_format_value_is_first_class_assignable():
+    env, _, _ = _env()
+    result = run_source('f = Format("{x}")\nformat(f, {x: "hello"})', env)
+    assert result == "hello"
+
+
+def test_format_value_empty_template():
+    env, _, _ = _env()
+    result = run_source('format(Format(""), {})', env)
+    assert result == ""
+
+
+def test_format_value_no_placeholders():
+    env, _, _ = _env()
+    result = run_source('format(Format("hello world"), {})', env)
+    assert result == "hello world"
+
+
+def test_format_value_positional_placeholders():
+    env, _, _ = _env()
+    result = run_source('format(Format("{0} {1}"), ["hello", "world"])', env)
+    assert result == "hello world"
+
+
+# --- Display and debug rendering ---
+
+def test_format_value_display_returns_format_tag():
+    env, _, _ = _env()
+    result = run_source('display(Format("{a}"))', env)
+    assert result == "<format>"
+
+
+def test_format_value_debug_repr_returns_format_tag():
+    env, _, _ = _env()
+    result = run_source('debug_repr(Format("{a}"))', env)
+    assert result == "<format>"
+
+
+def test_format_value_display_does_not_expose_template():
+    env, _, _ = _env()
+    result = run_source('display(Format("{secret_key}"))', env)
+    assert "{secret_key}" not in result
+
+
+# --- Error cases ---
+
+def test_format_constructor_rejects_non_string():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="Format expected a string template"):
+        run_source("Format(123)", env)
+
+
+def test_format_rejects_non_string_non_format_first_arg():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format expected a string template or Format value"):
+        run_source("format(123, {})", env)
+
+
+def test_format_constructor_rejects_list():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="Format expected a string template"):
+        run_source('Format(["a", "b"])', env)
+
+
+# --- Backward compatibility ---
+
+def test_raw_string_format_unchanged():
+    env, _, _ = _env()
+    result = run_source('format("Hello {name}!", {name: "Alice"})', env)
+    assert result == "Hello Alice!"


### PR DESCRIPTION
## Summary

Implements issue #168: first-class `Format` values for the Representation System.

This adds:

- `Format(template)` as a first-class representation value constructor
- `format(Format(t), values)` support
- backward-compatible `format(raw_string, values)` behavior
- display/debug rendering for Format values as `<format>`
- focused eval/error specs and unit coverage
- docs sync for `GENIA_STATE.md`, `GENIA_REPL_README.md`, and `README.md`

`Format("{a} {b} {c}")` now works as a first-class value, and:

```genia
format(Format(t), values)

is equivalent to:

format(t, values)
Scope

Included:

GeniaFormat runtime value
Format(template) constructor
format(...) accepts raw strings or Format values
display/debug rendering as <format>
error diagnostics for invalid constructor and invalid first argument
eval/error specs and unit tests
docs sync

Excluded:

no Format "..." syntax
no parser changes
no Core IR changes
no format composition
no debug formatting mode
no width/alignment/precision specifiers
no field paths
no localization
no tagged formats
no value-template behavior
Validation

From audit handoff:

python -m pytest tests/unit/test_format_first_class_168.py -v → 14 passed
python -m pytest tests/spec/test_spec_ir_runner_blackbox.py -k "format" → 11 passed
python -m pytest tests/unit/test_representation_entrypoints_185.py → 4 passed
python -m pytest tests/ → 2098 passed
Docs

Updated:

GENIA_STATE.md
GENIA_REPL_README.md
README.md

Maturity is documented as Experimental.

Follow-up

No blocking follow-up issues for this PR.

Optional future Representation System issues are listed separately:

width/alignment/precision specifiers
debug formatting mode
field paths
localization
tagged formats
format composition
optional template introspection