### PR TITLE
Refactor format engine for issue #298

### DIFF
--- a/spec/eval/format-pipeline-map-named.yaml
+++ b/spec/eval/format-pipeline-map-named.yaml
@@ -1,0 +1,13 @@
+name: format-pipeline-map-named
+category: eval
+input:
+  source: |
+    range(3)
+    |> map((x) -> {n:x})
+    |> map((x) -> format("number:{n}", x))
+    |> collect
+expected:
+  stdout: |
+    ["number:0", "number:1", "number:2"]
+  stderr: ""
+  exit_code: 0

--- a/src/genia/_format_engine.py
+++ b/src/genia/_format_engine.py
@@ -1,0 +1,228 @@
+"""Internal format engine for issue #298 format-refactor.
+
+Exposes three testable, module-level helpers extracted from format_fn:
+  - parse_format_template  — template string → list of TemplateParts
+  - resolve_format_placeholder — (Genia value, field name) → resolved value
+  - render_format_value    — Genia value → display string
+
+Also exposes apply_format_spec (used by format_fn for field-spec rendering).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any
+
+from genia.utf8 import format_display
+from genia.values import GeniaMap
+
+
+# ---------------------------------------------------------------------------
+# Template part types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TemplateLiteral:
+    text: str
+
+
+@dataclass(frozen=True)
+class TemplatePlaceholder:
+    field: str
+    spec: str | None
+
+
+TemplatePart = TemplateLiteral | TemplatePlaceholder
+
+
+# ---------------------------------------------------------------------------
+# parse_format_template
+# ---------------------------------------------------------------------------
+
+
+def parse_format_template(template: str) -> list[TemplatePart]:
+    """Parse a format template string into a list of TemplateLiteral / TemplatePlaceholder parts."""
+    parts: list[TemplatePart] = []
+    i = 0
+    while i < len(template):
+        ch = template[i]
+        if ch == "{":
+            if i + 1 < len(template) and template[i + 1] == "{":
+                parts.append(TemplateLiteral("{"))
+                i += 2
+                continue
+            close = template.find("}", i + 1)
+            if close < 0:
+                raise ValueError("format invalid placeholder")
+            body = template[i + 1 : close]
+            if ":" in body:
+                colon = body.index(":")
+                field = body[:colon]
+                spec: str | None = body[colon + 1 :]
+            else:
+                field = body
+                spec = None
+            if not _is_valid_field(field):
+                raise ValueError("format invalid placeholder")
+            parts.append(TemplatePlaceholder(field, spec))
+            i = close + 1
+            continue
+        if ch == "}":
+            if i + 1 < len(template) and template[i + 1] == "}":
+                parts.append(TemplateLiteral("}"))
+                i += 2
+                continue
+            raise ValueError("format invalid placeholder")
+        # accumulate literal characters
+        start = i
+        while i < len(template) and template[i] not in "{}":
+            i += 1
+        parts.append(TemplateLiteral(template[start:i]))
+    return parts
+
+
+def _is_valid_field(field: str) -> bool:
+    if field == "":
+        return False
+    if _is_positional_field(field):
+        return True
+    return _is_named_field(field)
+
+
+def _is_named_field(field: str) -> bool:
+    if not field:
+        return False
+    first = field[0]
+    if not (first == "_" or ("A" <= first <= "Z") or ("a" <= first <= "z")):
+        return False
+    return all(
+        ch == "_"
+        or ("A" <= ch <= "Z")
+        or ("a" <= ch <= "z")
+        or ("0" <= ch <= "9")
+        for ch in field[1:]
+    )
+
+
+def _is_positional_field(field: str) -> bool:
+    return field != "" and all("0" <= ch <= "9" for ch in field)
+
+
+# ---------------------------------------------------------------------------
+# resolve_format_placeholder
+# ---------------------------------------------------------------------------
+
+
+def resolve_format_placeholder(value: Any, field: str) -> Any:
+    """Resolve a named or positional field from a Genia value."""
+    if _is_positional_field(field):
+        if not isinstance(value, list):
+            raise TypeError(f"format expected a list for positional placeholder: {field}")
+        index = int(field, 10)
+        if index >= len(value):
+            raise ValueError(f"format missing field: {index}")
+        return value[index]
+    if _is_named_field(field):
+        if not isinstance(value, GeniaMap):
+            raise TypeError(f"format expected a map for named placeholder: {field}")
+        if not value.has(field):
+            raise ValueError(f"format missing field: {field}")
+        return value.get(field)
+    raise ValueError("format invalid placeholder")
+
+
+# ---------------------------------------------------------------------------
+# render_format_value
+# ---------------------------------------------------------------------------
+
+
+def render_format_value(value: Any) -> str:
+    """Render a Genia value to its display string."""
+    return format_display(value)
+
+
+# ---------------------------------------------------------------------------
+# apply_format_spec (internal, used by format_fn)
+# ---------------------------------------------------------------------------
+
+
+def apply_format_spec(value: Any, spec: str) -> str:
+    """Apply a format field spec (e.g. '<5', '.2', '03', ',') to a resolved value."""
+    if not spec:
+        raise ValueError("format-error: invalid format spec ''")
+
+    if spec[0] in "<>^":
+        rest = spec[1:]
+        if not rest or not rest.isdigit():
+            raise ValueError(f"format-error: invalid format spec {spec!r}")
+        width = int(rest)
+        text = format_display(value)
+        if len(text) >= width:
+            return text
+        pad = width - len(text)
+        if spec[0] == "<":
+            return text + " " * pad
+        if spec[0] == ">":
+            return " " * pad + text
+        left = pad // 2
+        return " " * left + text + " " * (pad - left)
+
+    if spec[0] == ".":
+        rest = spec[1:]
+        if not rest or not rest.isdigit():
+            raise ValueError(f"format-error: invalid format spec {spec!r}")
+        n = int(rest)
+        if isinstance(value, bool):
+            raise ValueError(f"format-error: format spec {spec!r} requires string or numeric value")
+        if isinstance(value, str):
+            return value[:n]
+        if isinstance(value, (int, float)):
+            return _format_numeric_precision(value, n)
+        raise ValueError(f"format-error: format spec {spec!r} requires string or numeric value")
+
+    if spec[0] == "0" and len(spec) > 1 and spec[1:].isdigit():
+        width = int(spec)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"format-error: format spec {spec!r} requires numeric value")
+        text = format_display(value)
+        if len(text) >= width:
+            return text
+        if text.startswith("-"):
+            return "-" + "0" * (width - len(text)) + text[1:]
+        return "0" * (width - len(text)) + text
+
+    if spec == ",":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("format-error: format spec ',' requires numeric value")
+        return _format_grouping(value)
+
+    raise ValueError(f"format-error: unsupported format spec {spec!r}")
+
+
+def _format_numeric_precision(value: int | float, n: int) -> str:
+    d = Decimal(repr(value))
+    if n == 0:
+        return str(d.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    quantize_str = "0." + "0" * n
+    return str(d.quantize(Decimal(quantize_str), rounding=ROUND_HALF_UP))
+
+
+def _format_grouping(value: int | float) -> str:
+    text = format_display(value)
+    negative = text.startswith("-")
+    if negative:
+        text = text[1:]
+    if "." in text:
+        int_part, frac_part = text.split(".", 1)
+    else:
+        int_part, frac_part = text, None
+    n = len(int_part)
+    grouped = ""
+    for i, ch in enumerate(int_part):
+        if i > 0 and (n - i) % 3 == 0:
+            grouped += ","
+        grouped += ch
+    result = grouped if frac_part is None else grouped + "." + frac_part
+    return "-" + result if negative else result

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -47,7 +47,6 @@ if __package__ in (None, ""):
         render_format_value,
         resolve_format_placeholder,
         TemplateLiteral,
-        TemplatePlaceholder,
     )
     from genia.docstrings import render_markdown_docstring
     from genia.lexer import SourceSpan
@@ -118,7 +117,6 @@ else:
         render_format_value,
         resolve_format_placeholder,
         TemplateLiteral,
-        TemplatePlaceholder,
     )
     from .docstrings import render_markdown_docstring
     from .lexer import SourceSpan

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import json
 import math
 import os
-from decimal import Decimal, ROUND_HALF_UP
 import io
 import shutil
 import sys
@@ -41,6 +40,14 @@ if __package__ in (None, ""):
         format_debug,
         format_display,
         utf8_byte_length,
+    )
+    from genia._format_engine import (
+        apply_format_spec,
+        parse_format_template,
+        render_format_value,
+        resolve_format_placeholder,
+        TemplateLiteral,
+        TemplatePlaceholder,
     )
     from genia.docstrings import render_markdown_docstring
     from genia.lexer import SourceSpan
@@ -104,6 +111,14 @@ else:
         format_debug,
         format_display,
         utf8_byte_length,
+    )
+    from ._format_engine import (
+        apply_format_spec,
+        parse_format_template,
+        render_format_value,
+        resolve_format_placeholder,
+        TemplateLiteral,
+        TemplatePlaceholder,
     )
     from .docstrings import render_markdown_docstring
     from .lexer import SourceSpan
@@ -598,162 +613,17 @@ def make_global_env(
                 f"format expected a string template or Format value, received {_runtime_type_name(template)}"
             )
 
-        def _is_named_placeholder(body: str) -> bool:
-            if body == "":
-                return False
-            first = body[0]
-            if not (first == "_" or ("A" <= first <= "Z") or ("a" <= first <= "z")):
-                return False
-            return all(
-                ch == "_"
-                or ("A" <= ch <= "Z")
-                or ("a" <= ch <= "z")
-                or ("0" <= ch <= "9")
-                for ch in body[1:]
-            )
-
-        def _is_positional_placeholder(body: str) -> bool:
-            return body != "" and all("0" <= ch <= "9" for ch in body)
-
-        def _format_numeric_precision(value: int | float, n: int) -> str:
-            d = Decimal(repr(value))
-            if n == 0:
-                return str(d.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
-            quantize_str = "0." + "0" * n
-            return str(d.quantize(Decimal(quantize_str), rounding=ROUND_HALF_UP))
-
-        def _format_grouping(value: int | float) -> str:
-            text = format_display(value)
-            negative = text.startswith("-")
-            if negative:
-                text = text[1:]
-            if "." in text:
-                int_part, frac_part = text.split(".", 1)
-            else:
-                int_part, frac_part = text, None
-            n = len(int_part)
-            grouped = ""
-            for i, ch in enumerate(int_part):
-                if i > 0 and (n - i) % 3 == 0:
-                    grouped += ","
-                grouped += ch
-            result = grouped if frac_part is None else grouped + "." + frac_part
-            return "-" + result if negative else result
-
-        def _apply_format_spec(value: Any, spec: str) -> str:
-            if not spec:
-                raise ValueError("format-error: invalid format spec ''")
-
-            if spec[0] in "<>^":
-                rest = spec[1:]
-                if not rest or not rest.isdigit():
-                    raise ValueError(f"format-error: invalid format spec {spec!r}")
-                width = int(rest)
-                text = format_display(value)
-                if len(text) >= width:
-                    return text
-                pad = width - len(text)
-                if spec[0] == "<":
-                    return text + " " * pad
-                if spec[0] == ">":
-                    return " " * pad + text
-                left = pad // 2
-                return " " * left + text + " " * (pad - left)
-
-            if spec[0] == ".":
-                rest = spec[1:]
-                if not rest or not rest.isdigit():
-                    raise ValueError(f"format-error: invalid format spec {spec!r}")
-                n = int(rest)
-                if isinstance(value, bool):
-                    raise ValueError(
-                        f"format-error: format spec {spec!r} requires string or numeric value"
-                    )
-                if isinstance(value, str):
-                    return value[:n]
-                if isinstance(value, (int, float)):
-                    return _format_numeric_precision(value, n)
-                raise ValueError(
-                    f"format-error: format spec {spec!r} requires string or numeric value"
-                )
-
-            if spec[0] == "0" and len(spec) > 1 and spec[1:].isdigit():
-                width = int(spec)
-                if isinstance(value, bool) or not isinstance(value, (int, float)):
-                    raise ValueError(
-                        f"format-error: format spec {spec!r} requires numeric value"
-                    )
-                text = format_display(value)
-                if len(text) >= width:
-                    return text
-                if text.startswith("-"):
-                    return "-" + "0" * (width - len(text)) + text[1:]
-                return "0" * (width - len(text)) + text
-
-            if spec == ",":
-                if isinstance(value, bool) or not isinstance(value, (int, float)):
-                    raise ValueError(
-                        "format-error: format spec ',' requires numeric value"
-                    )
-                return _format_grouping(value)
-
-            if spec.isdigit():
-                raise ValueError(f"format-error: unsupported format spec {spec!r}")
-
-            raise ValueError(f"format-error: unsupported format spec {spec!r}")
-
-        def _resolve_field(field: str) -> Any:
-            if _is_positional_placeholder(field):
-                if not isinstance(values, list):
-                    raise TypeError(
-                        f"format expected a list for positional placeholder: {field}"
-                    )
-                index = int(field, 10)
-                if index >= len(values):
-                    raise ValueError(f"format missing field: {index}")
-                return values[index]
-            if _is_named_placeholder(field):
-                if not isinstance(values, GeniaMap):
-                    raise TypeError(f"format expected a map for named placeholder: {field}")
-                if not values.has(field):
-                    raise ValueError(f"format missing field: {field}")
-                return values.get(field)
-            raise ValueError("format invalid placeholder")
-
-        def _format_placeholder(body: str) -> str:
-            if ":" in body:
-                colon = body.index(":")
-                field = body[:colon]
-                spec = body[colon + 1 :]
-                value = _resolve_field(field)
-                return _apply_format_spec(value, spec)
-            value = _resolve_field(body)
-            return format_display(value)
-
+        parts = parse_format_template(template)
         pieces: list[str] = []
-        i = 0
-        while i < len(template):
-            ch = template[i]
-            if ch == "{":
-                if i + 1 < len(template) and template[i + 1] == "{":
-                    pieces.append("{")
-                    i += 2
-                    continue
-                close = template.find("}", i + 1)
-                if close < 0:
-                    raise ValueError("format invalid placeholder")
-                pieces.append(_format_placeholder(template[i + 1 : close]))
-                i = close + 1
-                continue
-            if ch == "}":
-                if i + 1 < len(template) and template[i + 1] == "}":
-                    pieces.append("}")
-                    i += 2
-                    continue
-                raise ValueError("format invalid placeholder")
-            pieces.append(ch)
-            i += 1
-
+        for part in parts:
+            if isinstance(part, TemplateLiteral):
+                pieces.append(part.text)
+            else:
+                resolved = resolve_format_placeholder(values, part.field)
+                if part.spec is not None:
+                    pieces.append(apply_format_spec(resolved, part.spec))
+                else:
+                    pieces.append(render_format_value(resolved))
         return "".join(pieces)
 
     def trim_fn(value: Any) -> str:

--- a/tests/spec/test_spec_ir_runner_blackbox.py
+++ b/tests/spec/test_spec_ir_runner_blackbox.py
@@ -272,6 +272,7 @@ def test_ir_spec_fixture(fname: str) -> None:
         "format-field-format-value-parity-align.yaml",
         "format-field-format-value-parity-numeric.yaml",
         "format-field-escaped-braces-spec-text.yaml",
+        "format-pipeline-map-named.yaml",
     ],
 )
 @pytest.mark.spec

--- a/tests/unit/test_format_refactor_298.py
+++ b/tests/unit/test_format_refactor_298.py
@@ -1,0 +1,177 @@
+"""
+Failing tests for issue #298 format-refactor.
+
+These tests define the interface for the extracted format engine helpers:
+  - parse_format_template: parses a template string into TemplateLiteral / TemplatePlaceholder parts
+  - resolve_format_placeholder: resolves a field name from a Genia value
+  - render_format_value: renders a Genia value to its display string
+
+All imports fail with ModuleNotFoundError until src/genia/_format_engine.py is created.
+"""
+
+import pytest
+
+from genia._format_engine import (  # type: ignore[import-not-found]
+    TemplateLiteral,
+    TemplatePlaceholder,
+    parse_format_template,
+    render_format_value,
+    resolve_format_placeholder,
+)
+from genia.values import GeniaMap
+
+
+# ---------------------------------------------------------------------------
+# parse_format_template — structural parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_literal_only():
+    parts = parse_format_template("hello world")
+    assert parts == [TemplateLiteral("hello world")]
+
+
+def test_parse_single_named_placeholder():
+    parts = parse_format_template("{name}")
+    assert parts == [TemplatePlaceholder("name", None)]
+
+
+def test_parse_mixed_literal_and_placeholder():
+    parts = parse_format_template("Hello {name}!")
+    assert parts == [
+        TemplateLiteral("Hello "),
+        TemplatePlaceholder("name", None),
+        TemplateLiteral("!"),
+    ]
+
+
+def test_parse_multiple_placeholders():
+    parts = parse_format_template("{first} {last}")
+    assert parts == [
+        TemplatePlaceholder("first", None),
+        TemplateLiteral(" "),
+        TemplatePlaceholder("last", None),
+    ]
+
+
+def test_parse_positional_placeholder():
+    parts = parse_format_template("{0} {1}")
+    assert parts == [
+        TemplatePlaceholder("0", None),
+        TemplateLiteral(" "),
+        TemplatePlaceholder("1", None),
+    ]
+
+
+def test_parse_placeholder_with_spec():
+    parts = parse_format_template("{name:<5}")
+    assert parts == [TemplatePlaceholder("name", "<5")]
+
+
+def test_parse_empty_template():
+    assert parse_format_template("") == []
+
+
+def test_parse_escaped_left_brace():
+    parts = parse_format_template("{{")
+    assert parts == [TemplateLiteral("{")]
+
+
+def test_parse_escaped_right_brace():
+    parts = parse_format_template("}}")
+    assert parts == [TemplateLiteral("}")]
+
+
+def test_parse_escaped_braces_mixed():
+    parts = parse_format_template("{{{name}}}")
+    assert parts == [
+        TemplateLiteral("{"),
+        TemplatePlaceholder("name", None),
+        TemplateLiteral("}"),
+    ]
+
+
+def test_parse_unmatched_left_brace_raises():
+    with pytest.raises(ValueError):
+        parse_format_template("{unclosed")
+
+
+def test_parse_unmatched_right_brace_raises():
+    with pytest.raises(ValueError):
+        parse_format_template("bad}")
+
+
+def test_parse_empty_placeholder_raises():
+    with pytest.raises(ValueError):
+        parse_format_template("{}")
+
+
+# ---------------------------------------------------------------------------
+# resolve_format_placeholder — field resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_named_field_from_map():
+    m = GeniaMap().put("name", "Alice")
+    assert resolve_format_placeholder(m, "name") == "Alice"
+
+
+def test_resolve_named_field_integer_value():
+    m = GeniaMap().put("age", 30)
+    assert resolve_format_placeholder(m, "age") == 30
+
+
+def test_resolve_positional_field_from_list():
+    assert resolve_format_placeholder(["a", "b", "c"], "0") == "a"
+    assert resolve_format_placeholder(["a", "b", "c"], "2") == "c"
+
+
+def test_resolve_missing_named_field_raises():
+    m = GeniaMap()
+    with pytest.raises((ValueError, TypeError)):
+        resolve_format_placeholder(m, "missing")
+
+
+def test_resolve_missing_positional_field_raises():
+    with pytest.raises((ValueError, TypeError)):
+        resolve_format_placeholder(["a"], "5")
+
+
+def test_resolve_named_requires_map_raises():
+    with pytest.raises(TypeError):
+        resolve_format_placeholder(["a", "b"], "name")
+
+
+def test_resolve_positional_requires_list_raises():
+    m = GeniaMap().put("0", "val")
+    with pytest.raises(TypeError):
+        resolve_format_placeholder(m, "0")
+
+
+# ---------------------------------------------------------------------------
+# render_format_value — value-to-string rendering
+# ---------------------------------------------------------------------------
+
+
+def test_render_string_returns_as_is():
+    assert render_format_value("hello") == "hello"
+
+
+def test_render_integer():
+    assert render_format_value(42) == "42"
+
+
+def test_render_float():
+    assert render_format_value(3.14) == "3.14"
+
+
+def test_render_bool_true():
+    assert render_format_value(True) == "true"
+
+
+def test_render_bool_false():
+    assert render_format_value(False) == "false"
+
+
+def test_render_empty_string():
+    assert render_format_value("") == ""


### PR DESCRIPTION

## Summary

Refactors the existing `format(...)` implementation for issue #298 by extracting the formatting internals into a dedicated engine module while preserving the public formatting contract.

This change keeps `format(...)` as the stable public surface and moves parsing, placeholder resolution, rendering, and spec application into `src/genia/_format_engine.py`. The goal is to make formatting easier to test, reason about, and evolve without turning it into the broader Representation System or Value Template work.

## What changed

- Added `src/genia/_format_engine.py`
  - `parse_format_template`
  - `resolve_format_placeholder`
  - `render_format_value`
  - `apply_format_spec`
  - `TemplateLiteral`
  - `TemplatePlaceholder`

- Simplified `src/genia/builtins.py`
  - Reduced `format_fn` from a large nested implementation to a small delegating wrapper
  - Removed unused `Decimal` / `ROUND_HALF_UP` import

- Added pipeline regression coverage
  - `spec/eval/format-pipeline-map-named.yaml`
  - registered in `tests/spec/test_spec_ir_runner_blackbox.py`

- Added focused unit coverage
  - `tests/unit/test_format_refactor_298.py`
  - 26 tests for the extracted format engine

## Scope

This PR is a refactor only.

It does **not** add new formatting syntax, new representation behavior, new value-template behavior, or new user-facing formatting semantics.

The public `format(...)` behavior remains aligned with the current Genia source-of-truth model: docs must describe only implemented behavior, and implementation must stay aligned with `GENIA_STATE.md`. The repo’s AGENTS guidance identifies `GENIA_STATE.md` as final authority and requires docs/tests/implementation alignment. :contentReference[oaicite:0]{index=0}

## Validation

Ran:

```bash
python -m pytest tests/unit/test_format_refactor_298.py -q
python -m pytest tests/spec/test_spec_ir_runner_blackbox.py -k "format-pipeline-map-named" -q
python -m pytest tests/ --ignore=tests/slow -q
````

Results reported from handoff:

* 117 format tests passed
* 1996 non-slow suite tests passed
* Audit verdict: PASS

## Notes

* No docs changes were needed because this refactor does not change public behavior.
* Handoff directory can be deleted after merge:

  * `.genia/process/tmp/handoffs/issue-298-format-refactor/`

````

A tighter title would be:

```text
Refactor format engine for issue #298
````
