### PR TITLE
test: mark long-running demo/unit/spec tests as slow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        section: ["unit", "spec"]
+        section: ["unit", "spec", "demo"]
 
     steps:
       - name: Check out repository

--- a/tests/demo/test_ants_actor_demo.py
+++ b/tests/demo/test_ants_actor_demo.py
@@ -10,6 +10,8 @@ Covers:
 
 from pathlib import Path
 
+import pytest
+
 from genia import make_global_env, run_source
 
 
@@ -113,6 +115,7 @@ def test_run_actor_sim_returns_world():
     assert result == 3
 
 
+@pytest.mark.slow
 def test_actor_sim_same_seed_is_reproducible():
     """Same seed produces the same world summary after the same evolve count."""
     result1 = run_actor("world_summary(run_actor_sim(ants/new_world(7, 3, 5, 5), 5))")
@@ -120,6 +123,7 @@ def test_actor_sim_same_seed_is_reproducible():
     assert result1 == result2
 
 
+@pytest.mark.slow
 def test_actor_sim_different_seed_differs():
     """Different seeds produce different outcomes."""
     result1 = run_actor("world_summary(run_actor_sim(ants/new_world(7, 3, 5, 5), 5))")
@@ -149,6 +153,7 @@ def test_collect_actor_summaries_tick_increases():
 # --- Invariants ---
 
 
+@pytest.mark.slow
 def test_food_accounting_preserved():
     """Total food + delivered equals the initial total."""
     result = run_actor(
@@ -165,6 +170,7 @@ def test_food_accounting_preserved():
     assert result is True
 
 
+@pytest.mark.slow
 def test_delivered_food_monotonic():
     """Delivered food never decreases across ticks."""
     result = run_actor(
@@ -178,6 +184,7 @@ def test_delivered_food_monotonic():
         assert result[i] <= result[i + 1], f"delivered decreased at index {i}: {result[i]} > {result[i+1]}"
 
 
+@pytest.mark.slow
 def test_ant_count_unchanged():
     """Number of ants stays the same after simulation."""
     result = run_actor(

--- a/tests/demo/test_ants_terminal_demo.py
+++ b/tests/demo/test_ants_terminal_demo.py
@@ -1,6 +1,8 @@
 import io
 from pathlib import Path
 
+import pytest
+
 from genia import make_global_env, run_source
 
 
@@ -19,6 +21,7 @@ def test_terminal_demo_collect_positions_is_seeded_and_reproducible():
     assert result == run_terminal_demo("collect_positions(7, 3, 3)")
 
 
+@pytest.mark.slow
 def test_terminal_draw_frame_uses_terminal_helpers_and_rendered_world():
     stdout = io.StringIO()
 

--- a/tests/spec/test_seq_shared_spec_coverage_260.py
+++ b/tests/spec/test_seq_shared_spec_coverage_260.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from tools.spec_runner.comparator import compare_spec
 from tools.spec_runner.executor import execute_spec
 from tools.spec_runner.loader import discover_specs, load_spec
@@ -41,6 +43,7 @@ def test_issue_260_seq_shared_spec_inventory_is_present() -> None:
     assert missing == {}
 
 
+@pytest.mark.slow
 def test_issue_260_seq_shared_specs_execute_as_portable_observable_contract() -> None:
     missing_paths = []
     failures_by_name = {}

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pathlib import Path
 
 from genia import make_global_env, run_source
@@ -69,6 +71,7 @@ def test_tic_tac_toe_example_retries_invalid_move(monkeypatch):
     assert outputs[-1] == "X wins!\n"
 
 
+@pytest.mark.slow
 def test_ants_terminal_demo_parses_configurable_ant_count():
     source_path = Path("examples/ants_terminal.genia")
     source = source_path.read_text(encoding="utf-8")
@@ -89,6 +92,7 @@ def test_ants_terminal_demo_parses_configurable_ant_count():
     assert run_source(source + "\ngrid_size(25)", env, filename=str(source_path.resolve())) == 25
 
 
+@pytest.mark.slow
 def test_ants_terminal_demo_parses_seed_option():
     source_path = Path("examples/ants_terminal.genia")
     source = source_path.read_text(encoding="utf-8")

--- a/tests/unit/test_simulation_primitives.py
+++ b/tests/unit/test_simulation_primitives.py
@@ -19,6 +19,7 @@ def test_rand_multiple_calls_are_not_constant(run):
     assert len(set(samples)) > 1
 
 
+@pytest.mark.slow
 def test_rand_int_values_within_bounds_and_not_constant(run):
     n = 7
     samples = [run(f"rand_int({n})") for _ in range(128)]

--- a/tests/unit/test_stdlib_prelude_basics.py
+++ b/tests/unit/test_stdlib_prelude_basics.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pathlib import Path
 
 from genia import make_global_env, run_source
@@ -16,6 +18,7 @@ def test_first_and_rest(run):
     assert run("rest([1, 2, 3])") == [2, 3]
 
 
+@pytest.mark.slow
 def test_option_list_helpers(run):
     assert run("is_none?(first([]))") is True
     assert run("is_some?(first([nil]))") is True


### PR DESCRIPTION
Annotate slow ants and terminal demo tests with pytest.mark.slow Mark long-running random and stdlib prelude helpers tests as slow Mark sequence spec coverage contract test as slow