### PR TITLE
issue-306: add internal seq-compatible boundary

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -433,6 +433,7 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - `emit` must be a list of zero, one, or many output values; `halt: true` emits the current step's values and then stops the whole transform without pulling later source items.
   - Invalid `_seq_transform` step results raise runtime errors prefixed with `invalid-seq-transform-result:`.
   - PYTHON REFERENCE HOST: adjacent Flow `map` / `filter` stages may be represented by an internal fused Flow object that composes callbacks over one upstream source. This is an implementation optimization only; it adds no public Seq value, no fusion API, no new syntax, no Core IR node, no runtime flags, and no observable `trace` / display label change.
+  - PYTHON REFERENCE HOST: `_ensure_seq_compatible(name, source)` is an internal kernel primitive that validates a value is a Seq-compatible source and returns it unchanged; it accepts list and GeniaFlow only, raises a Seq-compatible TypeError for all other values, and does not consume or pull from a Flow during validation. It is registered via `env.set_internal` and is not accessible from ordinary Genia user code.
   - Maturity: Partial; list and Flow behavior is implemented, while Seq remains semantic terminology rather than a separate public surface.
 - pipeline debugging helpers are implemented as prelude-level identity stages:
   - `inspect(value)` logs and returns `value` unchanged
@@ -1071,6 +1072,13 @@ Representation System entry points (#185, implemented):
   - invalid step result shape, non-list `emit`, and non-boolean `halt` raise runtime errors prefixed with `invalid-seq-transform-result:`
   - `_seq_transform` is available only to trusted prelude/runtime code and Python reference-host tests; ordinary Genia user code must use public helpers such as `map`, `filter`, `take`, `scan`, `each`, `collect`, `run`, and `evolve`
   - `_seq_transform` introduces no syntax, no Core IR node, no public Seq value/type/helper, and no implicit list/Flow conversion
+- `_ensure_seq_compatible(name, source)` is the Python reference-host internal boundary primitive for validating Seq-compatible source values:
+  - accepts list → returns the list unchanged
+  - accepts GeniaFlow → returns the Flow unchanged without pulling any items
+  - rejects all other values → raises `TypeError` via the Seq-compatible diagnostic: `"<name> expected a Seq-compatible value (list or Flow); received <type>."`
+  - for direct `stdin` capability values, the diagnostic appends: `" Use stdin |> lines to adapt stdin into a Flow."`
+  - `_ensure_seq_compatible` is available only to trusted prelude/runtime code; ordinary Genia user code cannot call it
+  - it introduces no public Seq surface, no Core IR node, no new syntax, and no implicit list/Flow conversion
 - PYTHON REFERENCE HOST: adjacent Flow `map` / `filter` stages may be fused into one internal Flow wrapper before downstream consumption:
   - fusion applies only to Flow inputs and only to adjacent `map` / `filter` stages in this phase
   - list-side `map` / `filter` behavior remains eager and reusable, with no list fusion in this phase

--- a/spec/eval/issue-306-seq-boundary-bool-collect-error.yaml
+++ b/spec/eval/issue-306-seq-boundary-bool-collect-error.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-bool-collect-error
+category: eval
+input:
+  source: |
+    true |> collect
+expected:
+  stdout: ""
+  stderr: "Error: pipeline stage 1 failed in Value mode at collect [<command>:1]: stage received bool; collect expected a Seq-compatible value (list or Flow); received bool.\n"
+  exit_code: 1

--- a/spec/eval/issue-306-seq-boundary-list-drop.yaml
+++ b/spec/eval/issue-306-seq-boundary-list-drop.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-list-drop
+category: eval
+input:
+  source: |
+    [1, 2, 3, 4] |> drop(2) |> collect
+expected:
+  stdout: "[3, 4]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/issue-306-seq-boundary-map-collect-error.yaml
+++ b/spec/eval/issue-306-seq-boundary-map-collect-error.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-map-collect-error
+category: eval
+input:
+  source: |
+    {a: 1} |> collect
+expected:
+  stdout: ""
+  stderr: "Error: pipeline stage 1 failed in Value mode at collect [<command>:1]: stage received map; collect expected a Seq-compatible value (list or Flow); received map.\n"
+  exit_code: 1

--- a/spec/eval/issue-306-seq-boundary-plain-list-three-items.yaml
+++ b/spec/eval/issue-306-seq-boundary-plain-list-three-items.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-plain-list-three-items
+category: eval
+input:
+  source: |
+    [1, 2, 3] |> each(print) |> run
+expected:
+  stdout: "1\n2\n3\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/issue-306-seq-boundary-string-collect-error.yaml
+++ b/spec/eval/issue-306-seq-boundary-string-collect-error.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-string-collect-error
+category: eval
+input:
+  source: |
+    "abc" |> collect
+expected:
+  stdout: ""
+  stderr: "Error: pipeline stage 1 failed in Value mode at collect [<command>:1]: stage received string; collect expected a Seq-compatible value (list or Flow); received string.\n"
+  exit_code: 1

--- a/spec/eval/issue-306-seq-boundary-string-each-error.yaml
+++ b/spec/eval/issue-306-seq-boundary-string-each-error.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-string-each-error
+category: eval
+input:
+  source: |
+    "abc" |> each(print) |> run
+expected:
+  stdout: ""
+  stderr: "Error: pipeline stage 1 failed in Value mode at each(print) [<command>:1]: stage received string; each expected a Seq-compatible value (list or Flow); received string.\n"
+  exit_code: 1

--- a/spec/eval/issue-306-seq-boundary-string-map-error.yaml
+++ b/spec/eval/issue-306-seq-boundary-string-map-error.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-string-map-error
+category: eval
+input:
+  source: |
+    "abc" |> map((x) -> x)
+expected:
+  stdout: ""
+  stderr: "Error: pipeline stage 1 failed in Value mode at map((x) -> ...) [<command>:1]: stage received string; map expected a Seq-compatible value (list or Flow); received string.\n"
+  exit_code: 1

--- a/spec/eval/issue-306-seq-boundary-string-run-error.yaml
+++ b/spec/eval/issue-306-seq-boundary-string-run-error.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-string-run-error
+category: eval
+input:
+  source: |
+    "abc" |> run
+expected:
+  stdout: ""
+  stderr: "Error: pipeline stage 1 failed in Value mode at run [<command>:1]: stage received string; run expected a Seq-compatible value (list or Flow); received string.\n"
+  exit_code: 1

--- a/spec/eval/issue-306-seq-boundary-wrapped-list-one-item.yaml
+++ b/spec/eval/issue-306-seq-boundary-wrapped-list-one-item.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-wrapped-list-one-item
+category: eval
+input:
+  source: |
+    [[1, 2, 3]] |> each(print) |> run
+expected:
+  stdout: "[1, 2, 3]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/flow/issue-306-seq-boundary-flow-collect.yaml
+++ b/spec/flow/issue-306-seq-boundary-flow-collect.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-flow-collect
+category: flow
+input:
+  source: |
+    evolve(0, (n) -> n + 1) |> take(3) |> collect
+expected:
+  stdout: "[0, 1, 2]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/flow/issue-306-seq-boundary-flow-drop.yaml
+++ b/spec/flow/issue-306-seq-boundary-flow-drop.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-flow-drop
+category: flow
+input:
+  source: |
+    evolve(0, (n) -> n + 1) |> drop(2) |> take(3) |> collect
+expected:
+  stdout: "[2, 3, 4]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/flow/issue-306-seq-boundary-flow-each.yaml
+++ b/spec/flow/issue-306-seq-boundary-flow-each.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-flow-each
+category: flow
+input:
+  source: |
+    evolve(0, (n) -> n + 1) |> take(3) |> each(print) |> run
+expected:
+  stdout: "0\n1\n2\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/flow/issue-306-seq-boundary-flow-run.yaml
+++ b/spec/flow/issue-306-seq-boundary-flow-run.yaml
@@ -1,0 +1,9 @@
+name: issue-306-seq-boundary-flow-run
+category: flow
+input:
+  source: |
+    evolve(0, (n) -> n + 1) |> take(3) |> run
+expected:
+  stdout: ""
+  stderr: ""
+  exit_code: 0

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -784,6 +784,11 @@ def make_global_env(
             msg += " Use stdin |> lines to adapt stdin into a Flow."
         raise TypeError(msg)
 
+    def ensure_seq_compatible_fn(name: Any, source: Any) -> Any:
+        if isinstance(source, list) or isinstance(source, GeniaFlow):
+            return source
+        _seq_compatible_error(str(name), source)
+
     def flow_predicate_fn(value: Any) -> bool:
         return isinstance(value, GeniaFlow)
 
@@ -2874,6 +2879,7 @@ def make_global_env(
     env.set("_merge", merge_flow_fn)
     env.set("_zip", zip_flow_fn)
     env.set_internal("_seq_transform", seq_transform_fn)
+    env.set_internal("_ensure_seq_compatible", ensure_seq_compatible_fn)
     env.set_internal("_scan", scan_fn)
     env.set("_seq_type_error", seq_type_error_fn)
     env.set("_keep_some", keep_some_fn)

--- a/tests/unit/test_seq_as_seq_boundary_306.py
+++ b/tests/unit/test_seq_as_seq_boundary_306.py
@@ -1,0 +1,157 @@
+"""Unit tests for issue #306: explicit Seq-compatible boundary.
+
+These tests verify the internal `_ensure_seq_compatible` boundary helper
+that centralizes validation for the sequence helper family.
+
+Contract invariants:
+- list is accepted and returned unchanged
+- GeniaFlow is accepted without consumption
+- All other values raise TypeError with the Seq-compatible diagnostic
+- The diagnostic names the helper and both accepted source kinds
+"""
+from __future__ import annotations
+
+import pytest
+
+from genia import make_global_env
+from genia.values import GeniaFlow, GeniaMap  # noqa: F401 (GeniaMap used in test_rejects_map_value)
+
+
+def _get_ensure_seq_compatible():
+    """Obtain the internal _ensure_seq_compatible helper via internal_values."""
+    env = make_global_env()
+    root = env.root()
+    fn = root.internal_values.get("_ensure_seq_compatible")
+    assert fn is not None, (
+        "_ensure_seq_compatible must be registered via env.set_internal — "
+        "implementation missing for issue #306"
+    )
+    return fn
+
+
+class TestEnsureSeqCompatibleExists:
+    """The centralized boundary helper must exist as an internal builtin."""
+
+    def test_ensure_seq_compatible_is_registered_as_internal(self):
+        env = make_global_env()
+        root = env.root()
+        assert "_ensure_seq_compatible" in root.internal_values, (
+            "_ensure_seq_compatible must be registered via env.set_internal"
+        )
+
+    def test_ensure_seq_compatible_is_callable(self):
+        env = make_global_env()
+        root = env.root()
+        fn = root.internal_values.get("_ensure_seq_compatible")
+        assert callable(fn), "_ensure_seq_compatible must be a callable"
+
+    def test_ensure_seq_compatible_is_not_public(self):
+        env = make_global_env()
+        # Must not be accessible as a regular public name.
+        with pytest.raises(NameError):
+            env.get("_ensure_seq_compatible")
+
+
+class TestEnsureSeqCompatibleAcceptsSeqValues:
+    """Accepted source kinds: list and GeniaFlow."""
+
+    def test_accepts_list_and_returns_it_unchanged(self):
+        fn = _get_ensure_seq_compatible()
+        source = [1, 2, 3]
+        result = fn("each", source)
+        assert result is source, "list must be returned as-is"
+
+    def test_accepts_empty_list(self):
+        fn = _get_ensure_seq_compatible()
+        source = []
+        result = fn("collect", source)
+        assert result is source
+
+    def test_accepts_flow_and_returns_it_unchanged(self):
+        fn = _get_ensure_seq_compatible()
+
+        def iterator():
+            yield 1
+            yield 2
+
+        flow = GeniaFlow(iterator, label="test")
+        result = fn("each", flow)
+        assert result is flow, "GeniaFlow must be returned as-is"
+
+    def test_accepting_flow_does_not_consume_it(self):
+        fn = _get_ensure_seq_compatible()
+        consumed = []
+
+        def iterator():
+            consumed.append("consumed")
+            yield 1
+
+        flow = GeniaFlow(iterator, label="test")
+        fn("collect", flow)
+        assert consumed == [], "accepting a Flow must not pull any items from it"
+
+
+class TestEnsureSeqCompatibleRejectsNonSeqValues:
+    """Rejected source kinds produce a deterministic Seq-compatible diagnostic."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected_type"),
+        [
+            (42, "int"),
+            (3.14, "float"),
+            ("abc", "string"),
+            (True, "bool"),
+            (False, "bool"),
+        ],
+    )
+    def test_rejects_scalar_with_seq_compatible_diagnostic(self, value, expected_type):
+        fn = _get_ensure_seq_compatible()
+        with pytest.raises(TypeError) as exc_info:
+            fn("each", value)
+        msg = str(exc_info.value)
+        assert "each" in msg
+        assert "Seq-compatible" in msg
+        assert "list or Flow" in msg
+        assert expected_type in msg
+
+    def test_rejects_map_value(self):
+        fn = _get_ensure_seq_compatible()
+        with pytest.raises(TypeError) as exc_info:
+            fn("collect", GeniaMap())
+        msg = str(exc_info.value)
+        assert "collect" in msg
+        assert "Seq-compatible" in msg
+        assert "map" in msg
+
+    def test_diagnostic_names_the_caller_helper(self):
+        fn = _get_ensure_seq_compatible()
+        for helper in ("map", "filter", "take", "drop", "scan", "each", "collect", "run"):
+            with pytest.raises(TypeError) as exc_info:
+                fn(helper, 99)
+            assert helper in str(exc_info.value)
+
+    def test_diagnostic_mentions_both_accepted_kinds(self):
+        fn = _get_ensure_seq_compatible()
+        with pytest.raises(TypeError) as exc_info:
+            fn("run", "bad-value")
+        msg = str(exc_info.value)
+        assert "list" in msg
+        assert "Flow" in msg
+
+
+class TestEnsureSeqCompatibleBoundaryInvariant:
+    """Behavioral invariants that must hold after centralization."""
+
+    def test_list_input_does_not_become_flow(self):
+        fn = _get_ensure_seq_compatible()
+        source = [1, 2, 3]
+        result = fn("map", source)
+        assert isinstance(result, list)
+        assert not isinstance(result, GeniaFlow)
+
+    def test_flow_input_does_not_become_list(self):
+        fn = _get_ensure_seq_compatible()
+        flow = GeniaFlow(lambda: iter([1, 2]), label="test")
+        result = fn("scan", flow)
+        assert isinstance(result, GeniaFlow)
+        assert not isinstance(result, list)


### PR DESCRIPTION
## Summary

Implements issue #306 by adding an internal Seq-compatible boundary primitive for the Python reference host.

This change adds `_ensure_seq_compatible(name, source)` as an internal runtime helper that validates supported Seq-compatible sources without introducing a public `Seq` API.

The helper:

- accepts `list` and returns it unchanged
- accepts `GeniaFlow` and returns it unchanged
- does not consume or pull from Flow during validation
- rejects all other values with the existing Seq-compatible diagnostic
- is registered internally only via `env.set_internal`
- introduces no public `Seq`, `seq`, `seq?`, `as_seq`, syntax, or Core IR node

## Files Changed

- `src/genia/builtins.py`
  - Added `ensure_seq_compatible_fn`
  - Registered it as internal `_ensure_seq_compatible`

- `GENIA_STATE.md`
  - Documented `_ensure_seq_compatible` as a Python reference-host internal primitive
  - Clarified accepted values, rejection behavior, no-consumption invariant, and internal-only status

- `spec/eval/*issue-306*.yaml`
  - Added shared eval specs for list behavior and rejection cases

- `spec/flow/*issue-306*.yaml`
  - Added shared flow specs for Flow behavior

- `tests/unit/test_seq_as_seq_boundary_306.py`
  - Added unit tests for the internal helper

## Validation

- 2215 tests pass
- 17 new unit tests added and passing
- 13 shared spec YAML files added and passing
- Audit verdict: PASS

## Scope Notes

This is intentionally narrow.

This PR does **not**:

- add a public Seq type/value/helper
- add `seq`, `seq?`, or public `as_seq`
- add syntax
- add Core IR nodes
- add arbitrary iterable support
- expose Python generators/iterators
- change CLI pipe-mode behavior
- change public sequence helper semantics

The handoff directory is process-only and safe to delete after merge.