### PR TITLE
feat(seq): add explicit as_seq adapter issue #308

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -237,6 +237,7 @@ CLI contract summary (actual behavior):
   - binding `stdin` into a flow does not read all input up front
   - `stdin()` still returns cached full stdin lines for compatibility
   - `_seq_transform(initial_state, step, source)` is an internal kernel primitive for shared list/Flow transformation mechanics; it preserves source kind, is not an ordinary user-callable Genia name, and does not create a public Seq surface
+  - explicit adapter: `as_seq(list_or_string)` — converts a list or string into a Seq-compatible ordered source; strings remain atomic unless passed to `as_seq`
   - transforms: `lines`, `tee`, `merge`, `zip`, `scan`, `keep_some`, `keep_some_else`, `map`, `filter`, `take`, `rules`
   - stdlib aliases: `head(flow)`, `head(n, flow)`
   - Seq-compatible sinks/materialization: `each`, `run`, `collect` accept list or Flow; raw `stdin` is not directly Seq-compatible and must be adapted through `stdin |> lines` first

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -883,7 +883,8 @@ When changing syntax/semantics/runtime behavior, update together:
   - `halt: true` emits the current result and stops the whole transform without pulling later source items
   - invalid result shape, invalid `emit`, and invalid `halt` raise runtime errors prefixed with `invalid-seq-transform-result:`
 - `_seq_transform` must not introduce syntax, a Core IR node, a public Seq value/type/helper, implicit list-to-Flow conversion, or implicit Flow-to-list conversion.
-- `_seq_transform`, `_seq_reduce`, and related underscore sequence kernels must not be ordinary user-callable Genia names; public code uses prelude helpers such as `map`, `filter`, `take`, `scan`, `each`, `collect`, `run`, `reduce`, `count`, and `evolve`.
+- `_seq_transform`, `_seq_reduce`, and related underscore sequence kernels must not be ordinary user-callable Genia names; public code uses prelude helpers such as `map`, `filter`, `take`, `scan`, `each`, `collect`, `run`, `reduce`, `count`, `evolve`, and `as_seq`.
+- `as_seq(value)` is the only public explicit adapter for converting values into Seq-compatible ordered sources; strings remain atomic and are not implicitly Seq-compatible; `as_seq` does not introduce a `Char` type, scalar auto-lifting, or a public Seq runtime value beyond itself.
 
 ## `rules(..fns)`
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -435,7 +435,15 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - Invalid `_seq_transform` step results raise runtime errors prefixed with `invalid-seq-transform-result:`.
   - PYTHON REFERENCE HOST: adjacent Flow `map` / `filter` stages may be represented by an internal fused Flow object that composes callbacks over one upstream source. This is an implementation optimization only; it adds no public Seq value, no fusion API, no new syntax, no Core IR node, no runtime flags, and no observable `trace` / display label change.
   - PYTHON REFERENCE HOST: `_ensure_seq_compatible(name, source)` is an internal kernel primitive that validates a value is a Seq-compatible source and returns it unchanged; it accepts list and GeniaFlow only, raises a Seq-compatible TypeError for all other values, and does not consume or pull from a Flow during validation. It is registered via `env.set_internal` and is not accessible from ordinary Genia user code.
-  - Maturity: Partial; list and Flow behavior is implemented, while Seq remains semantic terminology rather than a separate public surface.
+  - `as_seq(value)` is a public explicit adapter that converts supported values into Seq-compatible ordered sources; it does not introduce a public Seq runtime type or constructor.
+    - `as_seq(list)` returns the list value unchanged; list reusability is preserved.
+    - `as_seq(string)` returns a list of one-character strings in iteration order; strings remain atomic unless passed to `as_seq`.
+    - `as_seq("")` returns an empty list.
+    - Unsupported inputs (e.g., number, boolean, map) fail with `TypeError: as_seq expected a list or string, received <type>.`
+    - Flow input is not supported in this phase; Flow remains Seq-compatible through existing `each`, `collect`, `run`, `map`, `filter`, `scan`, `reduce` without `as_seq`.
+    - `as_seq` does not make strings implicitly Seq-compatible; `collect("abc")` and similar remain invalid.
+    - `as_seq` does not introduce a `Char` type; each emitted element is a one-character Genia string value.
+  - Maturity: Partial; list and Flow behavior is implemented, while Seq remains semantic terminology rather than a separate public surface. `as_seq` for list and string input is implemented and tested.
 - pipeline debugging helpers are implemented as prelude-level identity stages:
   - `inspect(value)` logs and returns `value` unchanged
   - `trace(label, value)` logs `label` plus `value` and returns `value` unchanged
@@ -1156,6 +1164,7 @@ Flow semantics:
   - Flow functions (flow in, flow out): `keep_some`, `keep_some_else`, `rules`, `tee`, `merge`, `zip`, `head`
   - Polymorphic functions (work on both lists and flows, same-kind return): `map`, `filter`, `take`, `drop`, `scan`
   - Seq-compatible helpers (list or Flow): `each`, `collect`, `run`, `reduce`, `count`
+  - Explicit adapter (value → Seq-compatible): `as_seq` (list or string → list; does not produce Flow)
   - Bridge: source (value → flow): `lines`, `evolve`, `stdin_keys`
   - Bridge: materialize (flow → value): `collect`
   - Bridge: consume (flow → effect): `run`

--- a/README.md
+++ b/README.md
@@ -854,7 +854,8 @@ stdin |> lines |> take(2) |> each(print) |> run
 
 - `stdin |> lines` creates a lazy, pull-based, single-use Flow
 - Flow is a runtime value produced/consumed by flow builtins; it is not a separate syntax category
-- public flow helpers from `src/genia/std/prelude/flow.genia`: `lines`, `evolve` (experimental), `tee`, `merge`, `zip`, `scan`, `keep_some`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, plus `rule_*` compatibility constructors and preferred `step_*` constructors
+- public flow helpers from `src/genia/std/prelude/flow.genia`: `lines`, `evolve` (experimental), `tee`, `merge`, `zip`, `scan`, `keep_some`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, `as_seq`, plus `rule_*` compatibility constructors and preferred `step_*` constructors
+- `as_seq(value)` explicitly adapts a list or string into a Seq-compatible ordered source; lists are returned unchanged, strings are decomposed into one-character strings; strings remain atomic unless passed to `as_seq`
 - the host Flow kernel stays intentionally small:
   - lazy pull/consume and single-use enforcement
   - source-bound stdin integration

--- a/spec/eval/as-seq-empty-list-collect.yaml
+++ b/spec/eval/as-seq-empty-list-collect.yaml
@@ -1,0 +1,9 @@
+name: as-seq-empty-list-collect
+category: eval
+input:
+  source: |
+    as_seq([]) |> collect
+expected:
+  stdout: "[]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/as-seq-empty-string-collect.yaml
+++ b/spec/eval/as-seq-empty-string-collect.yaml
@@ -1,0 +1,9 @@
+name: as-seq-empty-string-collect
+category: eval
+input:
+  source: |
+    as_seq("") |> collect
+expected:
+  stdout: "[]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/as-seq-list-collect.yaml
+++ b/spec/eval/as-seq-list-collect.yaml
@@ -1,0 +1,9 @@
+name: as-seq-list-collect
+category: eval
+input:
+  source: |
+    as_seq([1, 2, 3]) |> collect
+expected:
+  stdout: "[1, 2, 3]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/as-seq-list-reusable.yaml
+++ b/spec/eval/as-seq-list-reusable.yaml
@@ -1,0 +1,10 @@
+name: as-seq-list-reusable
+category: eval
+input:
+  source: |
+    xs = as_seq([1, 2, 3])
+    [xs |> collect, xs |> collect]
+expected:
+  stdout: "[[1, 2, 3], [1, 2, 3]]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/as-seq-nested-list-preserves-inner-list.yaml
+++ b/spec/eval/as-seq-nested-list-preserves-inner-list.yaml
@@ -1,0 +1,9 @@
+name: as-seq-nested-list-preserves-inner-list
+category: eval
+input:
+  source: |
+    as_seq([[1, 2, 3]]) |> collect
+expected:
+  stdout: "[[1, 2, 3]]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/as-seq-rejects-number.yaml
+++ b/spec/eval/as-seq-rejects-number.yaml
@@ -1,0 +1,9 @@
+name: as-seq-rejects-number
+category: eval
+input:
+  source: |
+    as_seq(42)
+expected:
+  stdout: ""
+  stderr: "Error: as_seq expected a list or string, received int.\n"
+  exit_code: 1

--- a/spec/eval/as-seq-string-collect.yaml
+++ b/spec/eval/as-seq-string-collect.yaml
@@ -1,0 +1,9 @@
+name: as-seq-string-collect
+category: eval
+input:
+  source: |
+    as_seq("abc") |> collect
+expected:
+  stdout: "[\"a\", \"b\", \"c\"]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/as-seq-string-each-run.yaml
+++ b/spec/eval/as-seq-string-each-run.yaml
@@ -1,0 +1,9 @@
+name: as-seq-string-each-run
+category: eval
+input:
+  source: |
+    as_seq("abc") |> each(print) |> run
+expected:
+  stdout: "a\nb\nc\n"
+  stderr: ""
+  exit_code: 0

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -789,6 +789,13 @@ def make_global_env(
             return source
         _seq_compatible_error(str(name), source)
 
+    def as_seq_fn(value: Any) -> list[Any]:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            return list(value)
+        raise TypeError(f"as_seq expected a list or string, received {_runtime_type_name(value)}.")
+
     def flow_predicate_fn(value: Any) -> bool:
         return isinstance(value, GeniaFlow)
 
@@ -2901,6 +2908,7 @@ def make_global_env(
     env.set("_tee", tee_fn)
     env.set("_merge", merge_flow_fn)
     env.set("_zip", zip_flow_fn)
+    env.set_internal("_as_seq", as_seq_fn)
     env.set_internal("_seq_transform", seq_transform_fn)
     env.set_internal("_ensure_seq_compatible", ensure_seq_compatible_fn)
     env.set_internal("_seq_reduce", _seq_reduce_fn)
@@ -3063,6 +3071,7 @@ def make_global_env(
     env.register_autoload("merge", 2, "std/prelude/flow.genia")
     env.register_autoload("zip", 1, "std/prelude/flow.genia")
     env.register_autoload("zip", 2, "std/prelude/flow.genia")
+    env.register_autoload("as_seq", 1, "std/prelude/flow.genia")
     env.register_autoload("scan", 2, "std/prelude/flow.genia")
     env.register_autoload("scan", 3, "std/prelude/flow.genia")
     env.register_autoload("keep_some", 1, "std/prelude/flow.genia")

--- a/src/genia/std/prelude/flow.genia
+++ b/src/genia/std/prelude/flow.genia
@@ -52,6 +52,13 @@ The output stops when either input flow is exhausted.
 """
 zip(pair) = _zip(pair)
 
+@doc """Explicitly adapt a list or string into a Seq-compatible ordered source.
+
+Lists are returned as ordered elements without flattening.
+Strings are decomposed into one-character strings only through this helper.
+"""
+as_seq(value) = _as_seq(value)
+
 @doc """Stateful flow transform.
 
 `step(state, item)` must return `[next_state, output]`.

--- a/tests/spec/test_seq_as_seq_shared_spec_308.py
+++ b/tests/spec/test_seq_as_seq_shared_spec_308.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.spec_runner.comparator import compare_spec
+from tools.spec_runner.executor import execute_spec
+from tools.spec_runner.loader import discover_specs, load_spec
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+REQUIRED_AS_SEQ_SHARED_SPECS = {
+    "as-seq-list-collect",
+    "as-seq-nested-list-preserves-inner-list",
+    "as-seq-empty-list-collect",
+    "as-seq-list-reusable",
+    "as-seq-string-collect",
+    "as-seq-empty-string-collect",
+    "as-seq-string-each-run",
+    "as-seq-rejects-number",
+    "issue-306-seq-boundary-string-collect-error",
+    "issue-306-seq-boundary-string-each-error",
+    "issue-306-seq-boundary-string-map-error",
+    "issue-306-seq-boundary-string-run-error",
+}
+
+
+def test_issue_308_as_seq_shared_spec_inventory_is_present() -> None:
+    specs, invalid_specs = discover_specs()
+
+    assert not invalid_specs
+    eval_names = {spec.name for spec in specs if spec.category == "eval"}
+
+    missing = sorted(REQUIRED_AS_SEQ_SHARED_SPECS - eval_names)
+
+    assert missing == []
+
+
+@pytest.mark.slow
+def test_issue_308_as_seq_shared_specs_execute_as_portable_observable_contract() -> None:
+    failures_by_name = {}
+
+    for name in sorted(REQUIRED_AS_SEQ_SHARED_SPECS):
+        spec = load_spec(REPO / "spec" / "eval" / f"{name}.yaml")
+        actual = execute_spec(spec)
+        failures = compare_spec(spec, actual)
+        if failures:
+            failures_by_name[name] = [
+                (failure.field, failure.expected, failure.actual)
+                for failure in failures
+            ]
+
+    assert failures_by_name == {}


### PR DESCRIPTION
````md
## Summary

Implements issue #308 by adding `as_seq(value)` as the explicit adapter for list/string values into Seq-compatible ordered sources.

This change keeps Seq explicit and narrow:

- `as_seq(list)` returns the list unchanged, preserving eager reusable list behavior
- `as_seq(string)` returns a list of one-character strings
- `as_seq("")` returns `[]`
- unsupported inputs fail with a deterministic diagnostic
- strings remain atomic unless explicitly adapted with `as_seq`

## Behavior added

```genia
as_seq([1, 2, 3]) |> collect
# [1, 2, 3]

as_seq([[1, 2, 3]]) |> collect
# [[1, 2, 3]]

as_seq("abc") |> collect
# ["a", "b", "c"]

as_seq("") |> collect
# []

as_seq("abc") |> each(print) |> run
# prints:
# a
# b
# c
````

Unsupported scalar input now fails clearly:

```genia
as_seq(42)
# Error: as_seq expected a list or string, received int.
```

## Scope guardrails

This PR does **not**:

* add public `seq(...)`
* make strings implicitly Seq-compatible
* add a `Char` type
* expose host iterators/generators
* add scalar auto-lifting
* change Core IR
* change `lines`
* make raw `stdin` Seq-compatible
* change Option pipeline behavior
* add Flow support for `as_seq` in this phase

## Tests

Validated with:

```bash
uv run pytest -q tests/spec/test_seq_as_seq_shared_spec_308.py
uv run pytest -q tests/spec/test_seq_shared_spec_coverage_260.py tests/spec/test_spec_ir_runner_blackbox.py::test_eval_spec_fixture
uv run pytest -q tests/unit/test_doc_style_sync.py tests/unit/test_docs_truth_model.py
uv run python -m tools.spec_runner
uv run pytest -q
```

Observed results from the handoff/audit:

* focused issue #308 specs: passing
* related shared spec coverage: passing
* doc truth/style checks: passing
* full shared spec suite: `282 passed`
* full pytest suite: `2220 passed`

## Docs

Updated:

* `GENIA_STATE.md`
* `GENIA_RULES.md`
* `GENIA_REPL_README.md`
* `README.md`

Docs now describe `as_seq` as an explicit list/string adapter only, with string atomicity preserved by default.

```
```
