### PR TITLE
Feature/issue 286 seq protect bridge boundary

### DIFF
--- a/docs/contract/semantic_facts.json
+++ b/docs/contract/semantic_facts.json
@@ -5,6 +5,7 @@
   "pipeline_option_results_preserved": "Option results are preserved as-is.",
   "direct_call_option_behavior": "In direct calls, `some(x)` is still a normal value and is passed explicitly.",
   "pipe_wrapper": "runs the stage expression over `stdin |> lines`, then consumes the final Flow automatically",
+  "stdin_bridge_only": "`stdin` is a host-backed input capability, not a direct Seq-compatible public value; adapt it with `stdin |> lines` before using Flow/Seq terminals.",
   "main_dispatch": "call `main(argv())` when `main/1` exists, otherwise call `main()` when `main/0` exists",
   "pipe_bypasses_main": "pipe mode bypasses `main`",
   "flow_single_use": "Flow values are lazy, pull-based, source-bound, and single-use.",

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -42,6 +42,7 @@ def test_semantic_facts_file_stays_small_and_complete() -> None:
         "pipeline_option_results_preserved",
         "direct_call_option_behavior",
         "pipe_wrapper",
+        "stdin_bridge_only",
         "main_dispatch",
         "pipe_bypasses_main",
         "flow_single_use",
@@ -68,6 +69,49 @@ def test_authoritative_docs_capture_pipeline_option_contract() -> None:
     assert "when that lifted stage returns a non-Option value `y`, the pipeline wraps it back as `some(y)`" in rules
     assert "when that lifted stage returns `some(...)` or `none(...)`, that Option result is used as-is" in rules
     assert FACTS["direct_call_option_behavior"] in rules
+
+
+def test_authoritative_docs_capture_stdin_bridge_only_contract() -> None:
+    state = read_text("GENIA_STATE.md")
+    normalized = normalize(state)
+
+    required = [
+        "`stdin` is a host-backed input capability, not a Seq-compatible public value",
+        "it must be adapted through `lines(stdin)` before participating in Flow-style ordered processing",
+        "Direct use of `stdin` as a source to `each`, `collect`, or `run` fails",
+        "`stdin |> lines`",
+    ]
+    for excerpt in required:
+        assert normalize(excerpt) in normalized
+
+
+@pytest.mark.parametrize(
+    "relpath",
+    [
+        "GENIA_STATE.md",
+        "GENIA_REPL_README.md",
+        "README.md",
+        "docs/ai/LLM_CONTRACT.md",
+        ".github/copilot-instructions.md",
+    ],
+)
+def test_docs_do_not_widen_raw_stdin_into_seq_compatible_value(relpath: str) -> None:
+    text = normalize(read_text(relpath))
+    forbidden = [
+        "stdin is seq-compatible",
+        "`stdin` is seq-compatible",
+        "stdin is a seq-compatible public value",
+        "`stdin` is a seq-compatible public value",
+        "each accepts stdin directly",
+        "collect accepts stdin directly",
+        "run accepts stdin directly",
+        "each(print, stdin)",
+        "collect(stdin)",
+        "run(stdin)",
+        "stdin |> each(print)",
+    ]
+    for excerpt in forbidden:
+        assert normalize(excerpt) not in text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Protect the existing stdin bridge-only boundary as a semantic fact.

This PR adds `stdin_bridge_only` to `docs/contract/semantic_facts.json` and extends semantic doc sync coverage so future docs or LLM instruction surfaces do not accidentally describe raw `stdin` as a direct Seq-compatible public value.

The protected invariant is:

> `stdin` is a host-backed input capability, not a direct Seq-compatible public value; adapt it with `stdin |> lines` before using Flow/Seq terminals.

## Scope

Included:

* Added the `stdin_bridge_only` protected semantic fact.
* Added semantic doc sync coverage for the stdin bridge-only boundary.
* Added guardrails against known drift patterns such as documenting `stdin |> each(print)`, `collect(stdin)`, or `run(stdin)` as valid current behavior.
* Verified authoritative docs already describe the boundary correctly.

Excluded:

* No runtime behavior changes.
* No parser changes.
* No CLI or pipe-mode redesign.
* No new Seq public value/type/helper/syntax.
* No widening of raw `stdin` into a Seq-compatible public value.

## Files changed

* `docs/contract/semantic_facts.json`

  * Added `stdin_bridge_only`.
* `tests/doc/test_semantic_doc_sync.py`

  * Added the new expected semantic fact key.
  * Added coverage that `GENIA_STATE.md` preserves the stdin bridge-only boundary.
  * Added negative drift checks across public docs / LLM instruction surfaces.

## Validation

```bash
uv run pytest -q tests/doc/test_semantic_doc_sync.py
```

Result:

```text
66 passed in 0.20s
```

## Notes

This PR intentionally keeps the change small: one semantic fact plus targeted doc-sync tests. The existing authoritative docs already described the behavior correctly, so no prose doc updates were required.
