### PR TITLE
feat(examples): modernize tic-tac-toe example issue #299

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1902,7 +1902,7 @@ Core IR shape currently includes:
 
 ## 11) Example demos shipped in-repo
 
-- `examples/tic-tac-toe.genia`: interactive text game example
+- `examples/tic-tac-toe.genia`: canonical Format + Seq-compatible style example — two-player console tic-tac-toe using `Format`/`format(...)` for board rendering and list-side sequence helpers for data-driven winner detection
 - `examples/ants.genia`: canonical pure deterministic ants colony simulation demo with optional CLI seed for reproducible runs
 - `examples/ants_terminal.genia`: blocking terminal developer UI over the same colony simulation with CLI-configurable seed, ant count, step count, delay, world size, and pure/actor mode selection
 - `examples/ants_actor.genia`: actor/coordinator version of the ants simulation — same colony rules, different execution structure

--- a/examples/tic-tac-toe.genia
+++ b/examples/tic-tac-toe.genia
@@ -11,7 +11,8 @@
 #
 # Features demonstrated:
 #   * case-expression pattern matching with literal and tuple patterns
-#   * duplicate-variable patterns for equality checks (winner detection)
+#   * Format values with format(...) for display rows
+#   * data-driven winner detection with list-side sequence helpers
 #   * guards (`?`) for conditional clause selection
 #   * list destructuring across all nine board cells
 #   * rest patterns (`..`) in list spreads
@@ -40,21 +41,58 @@ nextPlayer(player) =
 @doc "Render one square as display text."
 showSquare(square) = square
 
+@doc "Return the board row Format value."
+rowFormat() = Format("{a} {b} {c}")
+
+@doc "Render three board squares as one display row."
+formatRow(a, b, c) = format(rowFormat(), {
+  a: showSquare(a),
+  b: showSquare(b),
+  c: showSquare(c)
+})
+
 # Case expression with list destructuring: bind each cell by position.
 @doc "Print the board as three rows."
 printBoard(board) =
   [a, b, c, d, e, f, g, h, i] -> {
     print("")
-    print(showSquare(a) + " " + showSquare(b) + " " + showSquare(c))
-    print(showSquare(d) + " " + showSquare(e) + " " + showSquare(f))
-    print(showSquare(g) + " " + showSquare(h) + " " + showSquare(i))
+    print(formatRow(a, b, c))
+    print(formatRow(d, e, f))
+    print(formatRow(g, h, i))
     print("")
   }
 
 # == Win detection =========================================================
-# Each clause checks one winning line.  Duplicate variable `p` in a pattern
-# means all matched positions must hold the same value.  The guard
-# `? p != "_"` prevents an all-empty line from being counted as a win.
+# Winning lines are represented as board indexes.  The winner helper maps
+# those lines to Option values, then unwraps the first actual winner.
+
+@doc "Return the eight board index triples that can win tic-tac-toe."
+winningLines() = [
+  [0, 1, 2],
+  [3, 4, 5],
+  [6, 7, 8],
+  [0, 3, 6],
+  [1, 4, 7],
+  [2, 5, 8],
+  [0, 4, 8],
+  [2, 4, 6]
+]
+
+@doc "Read one board square by index for a known winning line."
+lineSquare(board, index) = nth(index, board) |> unwrap_or("_")
+
+@doc "Return some(marker) when three squares form a non-empty line."
+lineWinnerValue(a, b, c) =
+  (p, p, p) ? p != "_" -> some(p) |
+  (_, _, _) -> none("no-winner")
+
+@doc "Return the winner for one line as some(marker) or none."
+lineWinner(board, line) =
+  (board, [a, b, c]) -> lineWinnerValue(
+    lineSquare(board, a),
+    lineSquare(board, b),
+    lineSquare(board, c)
+  )
 
 @doc """
 Detect whether X or O has a winning line.
@@ -63,16 +101,11 @@ Detect whether X or O has a winning line.
 - "X" or "O" when that player has three in a row
 - "_" when no winner exists yet
 """
-winner(board) =
-  [p, p, p, .._]              ? p != "_" -> p |  # row 1
-  [_, _, _, p, p, p, _, _, _]  ? p != "_" -> p |  # row 2
-  [_, _, _, _, _, _, p, p, p]  ? p != "_" -> p |  # row 3
-  [p, _, _, p, _, _, p, _, _]  ? p != "_" -> p |  # col 1
-  [_, p, _, _, p, _, _, p, _]  ? p != "_" -> p |  # col 2
-  [_, _, p, _, _, p, _, _, p]  ? p != "_" -> p |  # col 3
-  [p, _, _, _, p, _, _, _, p]  ? p != "_" -> p |  # diagonal ↘
-  [_, _, p, _, p, _, p, _, _]  ? p != "_" -> p |  # diagonal ↙
-  _                                        -> "_"
+winner(board) = {
+  candidates = map((line) -> lineWinner(board, line), winningLines())
+  match = find_opt((candidate) -> is_some?(candidate), candidates)
+  unwrap_or("_", flat_map_some((candidate) -> candidate, match))
+}
 
 # == Board queries =========================================================
 

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -5,6 +5,15 @@ from pathlib import Path
 from genia import make_global_env, run_source
 
 
+TIC_TAC_TOE_PATH = Path("examples/tic-tac-toe.genia")
+
+
+def run_tic_tac_toe_expression(expression: str):
+    source = TIC_TAC_TOE_PATH.read_text(encoding="utf-8")
+    env = make_global_env([], output_handler=lambda _text: None)
+    return run_source(source + f"\n{expression}", env, filename=str(TIC_TAC_TOE_PATH.resolve()))
+
+
 def test_sum_5th_example_refine_works():
     source = Path("examples/sum-5th.genia").read_text(encoding="utf-8")
     env = make_global_env(
@@ -32,7 +41,7 @@ def test_sum_5th_example_uses_autoloaded_fields_and_structured_absence():
 
 
 def test_tic_tac_toe_example_runs_to_x_win(monkeypatch):
-    source_path = Path("examples/tic-tac-toe.genia")
+    source_path = TIC_TAC_TOE_PATH
     source = source_path.read_text(encoding="utf-8")
     outputs: list[str] = []
     prompts: list[str] = []
@@ -56,7 +65,7 @@ def test_tic_tac_toe_example_runs_to_x_win(monkeypatch):
 
 
 def test_tic_tac_toe_example_retries_invalid_move(monkeypatch):
-    source_path = Path("examples/tic-tac-toe.genia")
+    source_path = TIC_TAC_TOE_PATH
     source = source_path.read_text(encoding="utf-8")
     outputs: list[str] = []
     moves = iter(["oops", "0", "3", "1", "4", "2"])
@@ -68,6 +77,87 @@ def test_tic_tac_toe_example_retries_invalid_move(monkeypatch):
     transcript = "".join(outputs)
 
     assert transcript.count("That square is not available. Try again.\n") == 1
+    assert outputs[-1] == "X wins!\n"
+
+
+def test_tic_tac_toe_example_uses_format_for_rows():
+    source = TIC_TAC_TOE_PATH.read_text(encoding="utf-8")
+
+    assert "Format(" in source
+    assert "format(" in source
+    assert "showSquare(a) + \" \" + showSquare(b)" not in source
+    assert run_tic_tac_toe_expression('formatRow("X", "_", "O")') == "X _ O"
+
+
+def test_tic_tac_toe_winning_lines_are_explicit_data():
+    assert run_tic_tac_toe_expression("winningLines()") == [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6, 7, 8],
+        [0, 3, 6],
+        [1, 4, 7],
+        [2, 5, 8],
+        [0, 4, 8],
+        [2, 4, 6],
+    ]
+
+
+def test_tic_tac_toe_winner_contract_covers_empty_rows_columns_and_diagonals():
+    assert run_tic_tac_toe_expression("winner(newBoard())") == "_"
+    assert run_tic_tac_toe_expression('winner(["X", "X", "X", "_", "_", "_", "_", "_", "_"])') == "X"
+    assert run_tic_tac_toe_expression('winner(["_", "O", "_", "_", "O", "_", "_", "O", "_"])') == "O"
+    assert run_tic_tac_toe_expression('winner(["_", "_", "O", "_", "O", "_", "O", "_", "_"])') == "O"
+
+
+def test_tic_tac_toe_example_runs_to_o_win(monkeypatch):
+    source = TIC_TAC_TOE_PATH.read_text(encoding="utf-8")
+    outputs: list[str] = []
+    moves = iter(["0", "3", "1", "4", "8", "5"])
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(moves))
+    env = make_global_env([], output_handler=outputs.append)
+
+    result = run_source(source + "\nmain()", env, filename=str(TIC_TAC_TOE_PATH.resolve()))
+
+    assert result == "O wins!"
+    assert outputs[-1] == "O wins!\n"
+
+
+def test_tic_tac_toe_example_runs_to_draw(monkeypatch):
+    source = TIC_TAC_TOE_PATH.read_text(encoding="utf-8")
+    outputs: list[str] = []
+    moves = iter(["0", "1", "2", "4", "3", "5", "7", "6", "8"])
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(moves))
+    env = make_global_env([], output_handler=outputs.append)
+
+    result = run_source(source + "\nmain()", env, filename=str(TIC_TAC_TOE_PATH.resolve()))
+
+    assert result == "Draw!"
+    assert outputs[-1] == "Draw!\n"
+
+
+def test_tic_tac_toe_example_occupied_square_retries_same_player(monkeypatch):
+    source = TIC_TAC_TOE_PATH.read_text(encoding="utf-8")
+    outputs: list[str] = []
+    prompts: list[str] = []
+    moves = iter(["0", "0", "3", "1", "4", "2"])
+
+    def fake_input(prompt=""):
+        prompts.append(prompt)
+        return next(moves)
+
+    monkeypatch.setattr("builtins.input", fake_input)
+    env = make_global_env([], output_handler=outputs.append)
+
+    run_source(source + "\nmain()", env, filename=str(TIC_TAC_TOE_PATH.resolve()))
+
+    assert "That square is not available. Try again.\n" in outputs
+    assert prompts[:3] == [
+        "Player X, enter a move from 0 to 8:",
+        "Player O, enter a move from 0 to 8:",
+        "Player O, enter a move from 0 to 8:",
+    ]
     assert outputs[-1] == "X wins!\n"
 
 


### PR DESCRIPTION
## Summary

Modernizes `examples/tic-tac-toe.genia` into the canonical small example for current Format + Seq-compatible style.

Changes include:

- Uses `Format("{a} {b} {c}")` and `format(...)` for board row rendering.
- Adds explicit `winningLines()` data for the eight tic-tac-toe win paths.
- Refactors winner detection through list-side sequence helpers while preserving `winner(board)` returning `"X"`, `"O"`, or `"_"`.
- Keeps gameplay behavior unchanged: X/O turns, invalid move retry, win detection, draw detection, and value-first board updates.
- Updates `GENIA_STATE.md` to describe the example’s new canonical role.

## Tests

```bash
uv run pytest -q tests/unit/test_examples.py -k tic_tac_toe
# 8 passed, 4 deselected

uv run pytest -q tests/unit/test_examples.py
# 12 passed

uv run pytest -q
# 2232 passed