### PR TITLE
Feature/issue 170 representation add debug format mode

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -189,7 +189,7 @@ CLI contract summary (actual behavior):
     - `debug_repr(value)` returns the debug representation string without writing output
     - these entry points are minimal #185 surface area; #166 owns the broader Representation System model
   - public prelude-backed string formatting helper:
-    - `format(template_or_format, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; it supports escaped braces with `{{` and `}}`
+    - `format(template_or_format, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; `{name:?}` and `{0:?}` use debug rendering; it supports escaped braces with `{{` and `}}`
     - `format` accepts either a raw string template or a `Format` value as its first argument
     - `Format(template)` constructs a first-class representation value from a string template (**Experimental**, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
   - public flow helpers are prelude-backed wrappers: `lines`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, plus `rule_*` compatibility constructors and preferred `step_*` constructors

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -988,6 +988,7 @@ Representation System entry points (#185, implemented):
   - named placeholders such as `{name}`, looked up in a map by string key
   - positional placeholders such as `{0}`, looked up in a list by zero-based index
   - escaped braces `{{` and `}}`
+  - debug placeholders (**Partial**, #170): `{name:?}` and `{0:?}` render the resolved value with the same debug representation as `debug_repr(value)`
   - field format specs (**Experimental**, #169): a limited set of display specifiers after `:` inside a placeholder:
     - `<N` — left-align in width N using spaces
     - `>N` — right-align in width N using spaces
@@ -996,10 +997,10 @@ Representation System entry points (#185, implemented):
     - `0N` — zero-pad numeric output to width N; negative values keep the sign before the zeros
     - `,` — comma-group numeric output (integer portion only, ASCII commas, no localization)
   - `bool` values are not numeric for spec purposes; numeric specs (`0N`, `,`) applied to bools fail deterministically
-  - combined specs, bare width specs (e.g. `{n:10}`), and any spec not listed above are unsupported and fail with a `format-error:` prefixed error
-- Placeholder replacements use the same user-facing display representation as `display(value)`, except where a field spec applies.
+  - combined specs, bare width specs (e.g. `{n:10}`), debug spec combinations (e.g. `{x:?>10}`), and any spec not listed above are unsupported and fail with a `format-error:` prefixed error
+- Placeholder replacements use the same user-facing display representation as `display(value)`, except where the exact debug spec `?` or another listed field spec applies.
 - Missing fields and invalid placeholders raise deterministic errors.
-- `format` does not support field paths, interpolation string syntax, localization, tagged formats, debug rendering, custom formatter protocols, or spec combinations beyond the listed subset.
+- `format` does not support field paths, interpolation string syntax, localization, tagged formats, custom formatter protocols, or spec combinations beyond the listed subset.
 - `Format(template)` is a first-class Representation System constructor (**Experimental**, #168):
   - `Format(template)` accepts a string template and returns a first-class `Format` value.
   - A `Format` value is representation-only: it is not a Value Template and does not participate in shape/refinement/contract/variant semantics.
@@ -1029,6 +1030,7 @@ Representation System entry points (#185, implemented):
 - Examples:
   - `display("hello")` evaluates to the string `hello`
   - `debug_repr("hello")` evaluates to the string `"hello"`
+  - `format("display={x} debug={x:?}", {x: "hello"})` evaluates to the string `display=hello debug="hello"`
   - `display(none("missing-key", {key: "name"}))` evaluates to the string `none("missing-key", {key: "name"})`
   - `debug_repr([some("x"), false])` evaluates to the string `[some("x"), false]`
 - Runtime capability values and function-like values may have host-specific opaque debug/display text in this phase unless a later contract explicitly stabilizes them.

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Current consistency note:
 - `help()` now points users toward the public prelude-backed stdlib surface, while raw host-backed runtime names remain intentionally generic
 - REPL/debug output now renders structured absence with visible context metadata, for example `none("missing-key", {key: "name"})`
 - `display(value)` and `debug_repr(value)` are the first public Representation System entry points: they return display/debug representation strings without writing output
-- `format(template_or_format, values)` is a public prelude-backed string helper: it returns a string, uses `display(value)` for replacements, supports `{name}`, `{0}`, `{{`, `}}`, and a limited set of field format specs (Experimental, #169: alignment `<N`/`>N`/`^N`, precision `.N`, zero-pad `0N`, comma-group `,`); its first argument is a raw string template or a `Format` value
+- `format(template_or_format, values)` is a public prelude-backed string helper: it returns a string, uses `display(value)` for ordinary replacements, supports debug placeholders `{name:?}` / `{0:?}` using `debug_repr(value)`, supports `{name}`, `{0}`, `{{`, `}}`, and a limited set of field format specs (Experimental, #169: alignment `<N`/`>N`/`^N`, precision `.N`, zero-pad `0N`, comma-group `,`); its first argument is a raw string template or a `Format` value
 - `Format(template)` constructs a first-class representation value from a string template (Experimental, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
 - `some(pattern)`, `none(reason)`, and `none(reason, context)` are supported in pattern matching for Option values
 - new `?`-suffixed APIs are boolean-returning; `get?` remains the current compatibility exception and `get` is the preferred maybe-aware lookup name
@@ -903,7 +903,7 @@ flush(stdout)
 - `flush(sink)` flushes a sink and returns `none("nil")`
 - `print(...)` writes to `stdout`, and `log(...)` writes to `stderr`
 - `display(value)` and `debug_repr(value)` return representation strings and do not write output
-- `format(template_or_format, values)` returns a string built from named or positional placeholders and does not write output; accepts a raw string or a `Format` value
+- `format(template_or_format, values)` returns a string built from named or positional placeholders and does not write output; ordinary placeholders use display rendering, exact `:?` placeholders use debug rendering; accepts a raw string or a `Format` value
 - `input()` remains independent of `stdin`
 - broken pipe on `stdout` output in Unix pipelines is treated as normal downstream termination
 - flow-driven stdout writes use the same quiet broken-pipe path

--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -69,7 +69,7 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 | debug string | `debug_repr(value)` |
 | template string | `format(template, values)` |
 
-`display`, `debug_repr`, and `format` return strings. They do not write output. `format` supports named placeholders (`{name}`), positional placeholders (`{0}`), escaped braces (`{{`, `}}`), and an experimental limited set of field specs (#169): `{field:<N}` left-align, `{field:>N}` right-align, `{field:^N}` center, `{n:.N}` precision, `{n:0N}` zero-pad, `{n:,}` comma-group. Replacements use display rendering.
+`display`, `debug_repr`, and `format` return strings. They do not write output. `format` supports named placeholders (`{name}`), positional placeholders (`{0}`), debug placeholders (`{name:?}`, `{0:?}`), escaped braces (`{{`, `}}`), and an experimental limited set of field specs (#169): `{field:<N}` left-align, `{field:>N}` right-align, `{field:^N}` center, `{n:.N}` precision, `{n:0N}` zero-pad, `{n:,}` comma-group. Ordinary replacements use display rendering; exact `:?` replacements use debug rendering.
 
 <!-- [case: core-format-named] -->
 ```genia

--- a/spec/error/error-format-debug-composed-spec.yaml
+++ b/spec/error/error-format-debug-composed-spec.yaml
@@ -1,0 +1,10 @@
+name: error-format-debug-composed-spec
+category: error
+input:
+  source: |
+    format("{x:?>10}", {x: 1})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format-error: unsupported format spec '?>10'
+  exit_code: 1

--- a/spec/eval/format-debug-mode-170.yaml
+++ b/spec/eval/format-debug-mode-170.yaml
@@ -1,0 +1,17 @@
+name: format-debug-mode-170
+category: eval
+input:
+  source: |
+    value = {name: "Ada", scores: [1, 2, none("missing-score")]}
+    print(format("display={x} debug={x:?}", {x: "hi"}))
+    print(format("{0} {0:?}", ["hi"]))
+    print(format("{x:?}", {x: value}))
+    print(format(Format("{x:?}"), {x: Format("{a}")}))
+expected:
+  stdout: |
+    display=hi debug="hi"
+    hi "hi"
+    {name: "Ada", scores: [1, 2, none("missing-score")]}
+    <format>
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-debug-mode-170.yaml
+++ b/spec/eval/format-debug-mode-170.yaml
@@ -13,5 +13,6 @@ expected:
     hi "hi"
     {name: "Ada", scores: [1, 2, none("missing-score")]}
     <format>
+    "<format>"
   stderr: ""
   exit_code: 0

--- a/src/genia/_format_engine.py
+++ b/src/genia/_format_engine.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 
-from genia.utf8 import format_display
+from genia.utf8 import format_debug, format_display
 from genia.values import GeniaMap
 
 
@@ -152,6 +152,9 @@ def apply_format_spec(value: Any, spec: str) -> str:
     """Apply a format field spec (e.g. '<5', '.2', '03', ',') to a resolved value."""
     if not spec:
         raise ValueError("format-error: invalid format spec ''")
+
+    if spec == "?":
+        return format_debug(value)
 
     if spec[0] in "<>^":
         rest = spec[1:]

--- a/tests/unit/test_format_debug_mode_170.py
+++ b/tests/unit/test_format_debug_mode_170.py
@@ -1,0 +1,93 @@
+import io
+
+import pytest
+
+from genia import make_global_env, run_source
+
+
+def _env():
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    return make_global_env(stdout_stream=stdout, stderr_stream=stderr), stdout, stderr
+
+
+def test_format_debug_mode_distinguishes_display_and_debug_strings():
+    env, _, _ = _env()
+    result = run_source('format("display={x} debug={x:?}", {x: "hi"})', env)
+    assert result == 'display=hi debug="hi"'
+
+
+def test_format_debug_mode_uses_debug_repr_for_compound_values():
+    env, _, _ = _env()
+    result = run_source(
+        'format("{x:?}", {x: {name: "Ada", scores: [1, some("ok"), none("missing-score")]}})',
+        env,
+    )
+    assert result == '{name: "Ada", scores: [1, some("ok"), none("missing-score")]}'
+
+
+def test_format_debug_mode_covers_primitives_options_and_format_values():
+    env, _, _ = _env()
+    result = run_source(
+        'format("n={n:?} b={b:?} missing={missing:?} opt={opt:?} fmt={fmt:?}", '
+        '{n: 42, b: true, missing: none, opt: some("Ada"), fmt: Format("{a}")})',
+        env,
+    )
+    assert result == 'n=42 b=true missing=none("nil") opt=some("Ada") fmt=<format>'
+
+
+def test_format_debug_mode_supports_positional_placeholders():
+    env, _, _ = _env()
+    result = run_source('format("{0} {0:?}", ["hi"])', env)
+    assert result == 'hi "hi"'
+
+
+def test_format_debug_mode_raw_string_and_format_value_are_equivalent():
+    env, _, _ = _env()
+    raw = run_source('format("{x:?}", {x: "hi"})', env)
+    env2, _, _ = _env()
+    via_format = run_source('format(Format("{x:?}"), {x: "hi"})', env2)
+    assert raw == via_format == '"hi"'
+
+
+def test_format_debug_mode_keeps_escaped_braces_behavior():
+    env, _, _ = _env()
+    result = run_source('format("{{x}} {x:?}", {x: "hi"})', env)
+    assert result == '{x} "hi"'
+
+
+def test_format_no_spec_still_uses_display_representation():
+    env, _, _ = _env()
+    result = run_source('format("{x}", {x: "hi"})', env)
+    assert result == "hi"
+
+
+@pytest.mark.parametrize("spec", ["debug", "!", "??", "?>10"])
+def test_format_debug_like_unsupported_specs_still_raise(spec):
+    env, _, _ = _env()
+    with pytest.raises(ValueError, match="format-error: unsupported format spec"):
+        run_source(f'format("{{x:{spec}}}", {{x: 1}})', env)
+
+
+def test_format_debug_mode_missing_named_field_uses_existing_resolution_error():
+    env, _, _ = _env()
+    with pytest.raises(ValueError, match="format missing field: x"):
+        run_source('format("{x:?}", {})', env)
+
+
+def test_format_debug_mode_missing_positional_field_uses_existing_resolution_error():
+    env, _, _ = _env()
+    with pytest.raises(ValueError, match="format missing field: 1"):
+        run_source('format("{1:?}", ["only zero"])', env)
+
+
+def test_format_debug_mode_named_field_still_requires_map_values():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format expected a map for named placeholder: x"):
+        run_source('format("{x:?}", [1])', env)
+
+
+def test_format_debug_mode_positional_field_still_requires_list_values():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format expected a list for positional placeholder: 0"):
+        run_source('format("{0:?}", {x: 1})', env)


### PR DESCRIPTION
## Summary

Adds debug formatting mode to `format(...)` placeholders for issue #170.

This introduces exact `:?` placeholder support:

```genia
format("{x:?}", {x: value})
format("{0:?}", [value])
```

Behavior:

* `{x}` / `{0}` continue to use display rendering.
* `{x:?}` / `{0:?}` use the same debug representation as `debug_repr(value)`.
* Raw string templates and `Format(template)` values behave equivalently.
* Debug output is diagnostic only, not serialization or round-trip Genia source.
* Unsupported composed/debug-like specs such as `{x:?>10}`, `{x:debug}`, `{x:!}`, and `{x:??}` remain errors.

## Changes

* Updated `src/genia/_format_engine.py` to route exact `?` format specs through debug rendering.
* Added unit coverage for debug formatting behavior and failure boundaries.
* Added shared spec coverage for observable eval behavior and unsupported composed debug specs.
* Updated canonical docs and quick-reference text:

  * `GENIA_STATE.md`
  * `GENIA_REPL_README.md`
  * `README.md`
  * `docs/cheatsheet/core.md`

## Tests / Validation

Passing:

```bash
uv run pytest -q tests/unit/test_format_debug_mode_170.py tests/unit/test_format_first_class_168.py tests/unit/test_format_field_specs_169.py
# 64 passed
```

```bash
uv run python -m tools.spec_runner --verbose
# Summary: total=284 passed=284 failed=0 invalid=0
```

```bash
uv run pytest -q
# 2247 passed
```

```bash
uv tool run ruff check src/genia/_format_engine.py
# All checks passed!
```

Audit validation:

```bash
git diff --check HEAD~3..HEAD
# PASS
```

```bash
uv run pytest -q tests/unit/test_format_debug_mode_170.py tests/unit/test_format_first_class_168.py tests/unit/test_format_field_specs_169.py tests/unit/test_cheatsheet_core.py tests/doc/test_semantic_doc_sync.py
# 145 passed
```

Docs/cheatsheet validation:

```bash
uv run pytest -q tests/unit/test_cheatsheet_core.py tests/doc/test_semantic_doc_sync.py
# 81 passed
```

```bash
uv run pytest -q tests/unit/test_cheatsheet_core.py tests/unit/test_cheatsheet_quick_reference.py tests/unit/test_cheatsheet_pipeline_flow_vs_value.py tests/unit/test_cheatsheet_unix_power_mode.py tests/unit/test_cheatsheet_unix_to_genia.py
# 92 passed
```

Known unrelated validation issue:

```bash
uv run mkdocs build --strict
```

This failed due to pre-existing strict-mode nav warnings for missing configured pages:

* `design/pipeline-semantics.md`
* `host-interop/capabilities.md`
* `host-interop/capability-registry-design.md`
* `host-interop/capability-registry-spec.md`

Those warnings are unrelated to the files changed for issue #170.

## Audit

Audit verdict: PASS

Ready to merge: YES

## Notes

Process handoff artifacts for this change are temporary and should not be committed:

```text
.genia/process/tmp/handoffs/issue-170-representation-add-debug-format-mode/
```
