### PR TITLE
feat(representation): add format template accessor issue #294

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -192,6 +192,7 @@ CLI contract summary (actual behavior):
     - `format(template_or_format, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; `{name:?}` and `{0:?}` use debug rendering; it supports escaped braces with `{{` and `}}`
     - `format` accepts either a raw string template or a `Format` value as its first argument
     - `Format(template)` constructs a first-class representation value from a string template (**Experimental**, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
+    - `format_template(fmt)` returns the original source template string from a `Format` value (**Experimental**, #294); `display(Format(...))` and `debug_repr(Format(...))` remain opaque as `<format>`
   - public flow helpers are prelude-backed wrappers: `lines`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, plus `rule_*` compatibility constructors and preferred `step_*` constructors
   - public sink helpers are prelude-backed wrappers: `write`, `writeln`, `flush`
   - raw CLI primitive: `argv`

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1012,6 +1012,17 @@ Representation System entry points (#185, implemented):
   - `format(non_string_non_format, values)` fails with `TypeError: format expected a string template or Format value, received <type>`.
   - No parser syntax such as `Format "..."` is introduced; `Format("...")` is the only accepted call form.
   - `Format` is Experimental. The wrapped template, display/debug text, and constructor surface may change before stabilization.
+- `format_template(fmt)` is a public Representation System helper (**Experimental**, #294):
+  - `format_template(fmt)` returns the original source template string supplied to `Format(...)`.
+  - Accepted: a `Format` value created by `Format(template)`.
+  - Rejected: raw strings, numbers, lists, maps, booleans, flow values, and any other non-Format value.
+  - `format_template(fmt)` returns the template string exactly: no normalization, no unescaping, no placeholder parsing.
+  - `format_template("{a}")` fails with `TypeError: format_template expected a format, received string`.
+  - `format_template(non_format)` fails with `TypeError: format_template expected a format, received <type>`.
+  - `display(Format(...))` and `debug_repr(Format(...))` remain opaque; `format_template` is the only approved way to recover the source template string.
+  - `format_template` does not expose compiled template internals, placeholder metadata, or parsed template structure.
+  - `format_template` is not explicitly none-aware; ordinary none propagation applies in pipelines.
+  - `format_template` is Experimental. The accessor name and behavior may change before stabilization.
 - These helpers do not write to `stdout` or `stderr`.
 - These helpers do not mutate runtime state.
 - These helpers do not change `print`, `log`, `write`, `writeln`, REPL result display, CLI final-result rendering, or pipeline semantics.
@@ -1033,6 +1044,8 @@ Representation System entry points (#185, implemented):
   - `format("display={x} debug={x:?}", {x: "hello"})` evaluates to the string `display=hello debug="hello"`
   - `display(none("missing-key", {key: "name"}))` evaluates to the string `none("missing-key", {key: "name"})`
   - `debug_repr([some("x"), false])` evaluates to the string `[some("x"), false]`
+  - `format_template(Format("{a} {b}"))` evaluates to the string `{a} {b}`
+  - `format_template(Format("{{escaped}}"))` evaluates to the string `{{escaped}}`
 - Runtime capability values and function-like values may have host-specific opaque debug/display text in this phase unless a later contract explicitly stabilizes them.
 - #185 does not define the full Representation System.
 - #166 owns the broader representation model, including naming boundaries beyond `display` and `debug_repr`, extension points, user-defined representations, registry/strategy behavior, and cross-host treatment of opaque runtime values.

--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ Current consistency note:
 - `display(value)` and `debug_repr(value)` are the first public Representation System entry points: they return display/debug representation strings without writing output
 - `format(template_or_format, values)` is a public prelude-backed string helper: it returns a string, uses `display(value)` for ordinary replacements, supports debug placeholders `{name:?}` / `{0:?}` using `debug_repr(value)`, supports `{name}`, `{0}`, `{{`, `}}`, and a limited set of field format specs (Experimental, #169: alignment `<N`/`>N`/`^N`, precision `.N`, zero-pad `0N`, comma-group `,`); its first argument is a raw string template or a `Format` value
 - `Format(template)` constructs a first-class representation value from a string template (Experimental, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
+- `format_template(fmt)` returns the source template string from a first-class `Format` value (Experimental, #294); `display(Format(...))` and `debug_repr(Format(...))` remain opaque as `<format>`; non-Format input fails with a deterministic `TypeError`
 - `some(pattern)`, `none(reason)`, and `none(reason, context)` are supported in pattern matching for Option values
 - new `?`-suffixed APIs are boolean-returning; `get?` remains the current compatibility exception and `get` is the preferred maybe-aware lookup name
 - Flow, MetaEnv, Ref, and Process handles are runtime values, but they are not plain data in the same sense as numbers/lists/maps

--- a/spec/error/error-format-template-number-input.yaml
+++ b/spec/error/error-format-template-number-input.yaml
@@ -1,0 +1,10 @@
+name: error-format-template-number-input
+category: error
+input:
+  source: |
+    format_template(123)
+expected:
+  stdout: ""
+  stderr: |
+    Error: format_template expected a format, received int
+  exit_code: 1

--- a/spec/error/error-format-template-string-input.yaml
+++ b/spec/error/error-format-template-string-input.yaml
@@ -1,0 +1,10 @@
+name: error-format-template-string-input
+category: error
+input:
+  source: |
+    format_template("{a}")
+expected:
+  stdout: ""
+  stderr: |
+    Error: format_template expected a format, received string
+  exit_code: 1

--- a/spec/eval/format-template-basic.yaml
+++ b/spec/eval/format-template-basic.yaml
@@ -1,0 +1,10 @@
+name: format-template-basic
+category: eval
+input:
+  source: |
+    format_template(Format("{a}"))
+expected:
+  stdout: |
+    "{a}"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-template-debug-placeholder.yaml
+++ b/spec/eval/format-template-debug-placeholder.yaml
@@ -1,0 +1,10 @@
+name: format-template-debug-placeholder
+category: eval
+input:
+  source: |
+    format_template(Format("{a:?}"))
+expected:
+  stdout: |
+    "{a:?}"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-template-empty.yaml
+++ b/spec/eval/format-template-empty.yaml
@@ -1,0 +1,10 @@
+name: format-template-empty
+category: eval
+input:
+  source: |
+    format_template(Format(""))
+expected:
+  stdout: |
+    ""
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-template-escaped-braces.yaml
+++ b/spec/eval/format-template-escaped-braces.yaml
@@ -1,0 +1,10 @@
+name: format-template-escaped-braces
+category: eval
+input:
+  source: |
+    format_template(Format("{{a}}"))
+expected:
+  stdout: |
+    "{{a}}"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-template-named-value.yaml
+++ b/spec/eval/format-template-named-value.yaml
@@ -1,0 +1,11 @@
+name: format-template-named-value
+category: eval
+input:
+  source: |
+    BoardRow = Format("{a} {b} {c}")
+    format_template(BoardRow)
+expected:
+  stdout: |
+    "{a} {b} {c}"
+  stderr: ""
+  exit_code: 0

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -497,6 +497,13 @@ def make_global_env(
             )
         return GeniaFormat(template)
 
+    def format_template_fn(fmt: Any) -> str:
+        if not isinstance(fmt, GeniaFormat):
+            raise TypeError(
+                f"format_template expected a format, received {_runtime_type_name(fmt)}"
+            )
+        return fmt.template
+
     def _ensure_string(value: Any, name: str) -> str:
         if not isinstance(value, str):
             raise TypeError(f"{name} expected a string, received {_runtime_type_name(value)}")
@@ -2899,6 +2906,7 @@ def make_global_env(
     env.set("display", display_fn)
     env.set("debug_repr", debug_repr_fn)
     env.set("Format", format_constructor)
+    env.set("format_template", format_template_fn)
     env.set("input", input_fn)
     env.set("stdin", stdin_source)
     env.set("stdin_keys", stdin_keys_flow)


### PR DESCRIPTION
## Summary

Adds `format_template(fmt)` for issue #294.

This introduces a narrow Representation System accessor that returns the original source template string from a first-class `Format` value.

## What changed

- Added public `format_template(fmt)` helper.
- Added shared eval specs for:
  - basic `Format` template introspection
  - named `Format` values
  - empty templates
  - escaped braces
  - debug placeholders
- Added shared error specs for rejecting non-`Format` input.
- Updated docs:
  - `GENIA_STATE.md`
  - `GENIA_REPL_README.md`
  - `README.md`

## Guardrails preserved

- `Format` remains a representation value, not a value template.
- `display(Format(...))` remains opaque as `<format>`.
- `debug_repr(Format(...))` remains opaque as `<format>`.
- `format(Format(...), values)` behavior is unchanged.
- No compiled-template internals, parsed placeholder metadata, mutation hooks, parser syntax, or Core IR changes were added.

## Validation

- `uv run python -m tools.spec_runner --verbose`
  - `291 passed, 0 failed`
- `uv run pytest -q`
  - `2247 passed, 0 failed`

## Notes

The temporary handoff directory under `.genia/process/tmp/handoffs/issue-294-representation-consider-template-introspection-for-format-values/` is intentionally not included.