### PR TITLE
Feature/issue 292 representation add tagged format values

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -191,8 +191,10 @@ CLI contract summary (actual behavior):
   - public prelude-backed string formatting helper:
     - `format(template_or_format, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; `{name:?}` and `{0:?}` use debug rendering; it supports escaped braces with `{{` and `}}`
     - `format` accepts either a raw string template or a `Format` value as its first argument
-    - `Format(template)` constructs a first-class representation value from a string template (**Experimental**, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
+    - `Format(template)` constructs an untagged first-class representation value from a string template (**Experimental**, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
+    - `Format(template, tag)` constructs a tagged first-class representation value; `tag` must be a non-empty string; the tag is metadata only and does not affect rendering or display/debug output (**Experimental**, #292)
     - `format_template(fmt)` returns the original source template string from a `Format` value (**Experimental**, #294); `display(Format(...))` and `debug_repr(Format(...))` remain opaque as `<format>`
+    - `format_tag(fmt)` returns `some(tag)` for a tagged `Format` value or `none("missing-format-tag")` for an untagged `Format` value (**Experimental**, #292)
   - public flow helpers are prelude-backed wrappers: `lines`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, plus `rule_*` compatibility constructors and preferred `step_*` constructors
   - public sink helpers are prelude-backed wrappers: `write`, `writeln`, `flush`
   - raw CLI primitive: `argv`

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1000,18 +1000,24 @@ Representation System entry points (#185, implemented):
   - combined specs, bare width specs (e.g. `{n:10}`), debug spec combinations (e.g. `{x:?>10}`), and any spec not listed above are unsupported and fail with a `format-error:` prefixed error
 - Placeholder replacements use the same user-facing display representation as `display(value)`, except where the exact debug spec `?` or another listed field spec applies.
 - Missing fields and invalid placeholders raise deterministic errors.
-- `format` does not support field paths, interpolation string syntax, localization, tagged formats, custom formatter protocols, or spec combinations beyond the listed subset.
-- `Format(template)` is a first-class Representation System constructor (**Experimental**, #168):
-  - `Format(template)` accepts a string template and returns a first-class `Format` value.
+- `format` does not support field paths, interpolation string syntax, localization, tag-based format selection, custom formatter protocols, or spec combinations beyond the listed subset.
+- `Format(template)` and `Format(template, tag)` are first-class Representation System constructors (**Experimental**, #168, #292):
+  - `Format(template)` accepts a string template and returns an untagged first-class `Format` value.
+  - `Format(template, tag)` accepts a string template and a non-empty string tag and returns a tagged first-class `Format` value.
   - A `Format` value is representation-only: it is not a Value Template and does not participate in shape/refinement/contract/variant semantics.
-  - `format(Format(template), values)` produces the same result as `format(template, values)` for the same template and values.
+  - The tag is representation metadata attached to the `Format` value only. It does not affect placeholder parsing, placeholder resolution, field-spec rendering, debug field specs, or the identity of values being formatted.
+  - `format(Format(template), values)` and `format(Format(template, tag), values)` produce the same result as `format(template, values)` for the same template and values.
   - A `Format` value can be assigned to a name, passed as an argument, stored in a list or map, and returned from a function.
-  - `display(Format(...))` returns `<format>`; the wrapped template is not exposed.
-  - `debug_repr(Format(...))` returns `<format>`; the wrapped template is not exposed.
-  - `Format(non_string)` fails with `TypeError: Format expected a string template, received <type>`.
+  - `display(Format(...))` returns `<format>`; the wrapped template and tag are not exposed.
+  - `debug_repr(Format(...))` returns `<format>`; the wrapped template and tag are not exposed.
+  - `Format()` fails with `TypeError: Format expected 1 or 2 args, got 0`.
+  - `Format(template, tag, extra)` fails with `TypeError: Format expected 1 or 2 args, got 3`.
+  - `Format(non_string)` fails with `TypeError: Format expected template string, received <type>`.
+  - `Format(template, non_string_tag)` fails with `TypeError: Format expected tag string, received <type>`.
+  - `Format(template, "")` fails with `TypeError: Format expected non-empty tag string`.
   - `format(non_string_non_format, values)` fails with `TypeError: format expected a string template or Format value, received <type>`.
-  - No parser syntax such as `Format "..."` is introduced; `Format("...")` is the only accepted call form.
-  - `Format` is Experimental. The wrapped template, display/debug text, and constructor surface may change before stabilization.
+  - No parser syntax such as `Format "..."` is introduced; `Format("...")` and `Format("...", "tag")` are the only accepted call forms.
+  - `Format` is Experimental. The wrapped template, tag, display/debug text, and constructor surface may change before stabilization.
 - `format_template(fmt)` is a public Representation System helper (**Experimental**, #294):
   - `format_template(fmt)` returns the original source template string supplied to `Format(...)`.
   - Accepted: a `Format` value created by `Format(template)`.
@@ -1023,6 +1029,16 @@ Representation System entry points (#185, implemented):
   - `format_template` does not expose compiled template internals, placeholder metadata, or parsed template structure.
   - `format_template` is not explicitly none-aware; ordinary none propagation applies in pipelines.
   - `format_template` is Experimental. The accessor name and behavior may change before stabilization.
+- `format_tag(fmt)` is a public Representation System helper (**Experimental**, #292):
+  - `format_tag(fmt)` returns `some(tag)` for a tagged `Format` value created with `Format(template, tag)`.
+  - `format_tag(fmt)` returns `none("missing-format-tag")` for an untagged `Format` value created with `Format(template)`.
+  - Accepted: a `Format` value created by `Format(template)` or `Format(template, tag)`.
+  - Rejected: raw strings, numbers, lists, maps, booleans, flow values, and any other non-Format value.
+  - `format_tag()` fails with `TypeError: format_tag expected 1 arg, got 0`.
+  - `format_tag(fmt, extra)` fails with `TypeError: format_tag expected 1 arg, got 2`.
+  - `format_tag(non_format)` fails with `TypeError: format_tag expected a format value, received <type>`.
+  - `format_tag` does not expose the template, alter rendering, or cause tag-based format dispatch.
+  - `format_tag` is Experimental. The helper name and behavior may change before stabilization.
 - These helpers do not write to `stdout` or `stderr`.
 - These helpers do not mutate runtime state.
 - These helpers do not change `print`, `log`, `write`, `writeln`, REPL result display, CLI final-result rendering, or pipeline semantics.
@@ -1046,6 +1062,9 @@ Representation System entry points (#185, implemented):
   - `debug_repr([some("x"), false])` evaluates to the string `[some("x"), false]`
   - `format_template(Format("{a} {b}"))` evaluates to the string `{a} {b}`
   - `format_template(Format("{{escaped}}"))` evaluates to the string `{{escaped}}`
+  - `format_tag(Format("{name}", "person-card"))` evaluates to `some("person-card")`
+  - `format_tag(Format("{name}"))` evaluates to `none("missing-format-tag")`
+  - `format(Format("{name}", "person-card"), {name: "Ada"})` evaluates to the string `Ada`
 - Runtime capability values and function-like values may have host-specific opaque debug/display text in this phase unless a later contract explicitly stabilizes them.
 - #185 does not define the full Representation System.
 - #166 owns the broader representation model, including naming boundaries beyond `display` and `debug_repr`, extension points, user-defined representations, registry/strategy behavior, and cross-host treatment of opaque runtime values.

--- a/README.md
+++ b/README.md
@@ -578,8 +578,10 @@ Current consistency note:
 - REPL/debug output now renders structured absence with visible context metadata, for example `none("missing-key", {key: "name"})`
 - `display(value)` and `debug_repr(value)` are the first public Representation System entry points: they return display/debug representation strings without writing output
 - `format(template_or_format, values)` is a public prelude-backed string helper: it returns a string, uses `display(value)` for ordinary replacements, supports debug placeholders `{name:?}` / `{0:?}` using `debug_repr(value)`, supports `{name}`, `{0}`, `{{`, `}}`, and a limited set of field format specs (Experimental, #169: alignment `<N`/`>N`/`^N`, precision `.N`, zero-pad `0N`, comma-group `,`); its first argument is a raw string template or a `Format` value
-- `Format(template)` constructs a first-class representation value from a string template (Experimental, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
+- `Format(template)` constructs an untagged first-class representation value from a string template (Experimental, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
+- `Format(template, tag)` constructs a tagged first-class representation value; `tag` must be a non-empty string; the tag is metadata only and does not affect rendering or display/debug output (Experimental, #292)
 - `format_template(fmt)` returns the source template string from a first-class `Format` value (Experimental, #294); `display(Format(...))` and `debug_repr(Format(...))` remain opaque as `<format>`; non-Format input fails with a deterministic `TypeError`
+- `format_tag(fmt)` returns `some(tag)` for a tagged `Format` value or `none("missing-format-tag")` for an untagged `Format` value (Experimental, #292)
 - `some(pattern)`, `none(reason)`, and `none(reason, context)` are supported in pattern matching for Option values
 - new `?`-suffixed APIs are boolean-returning; `get?` remains the current compatibility exception and `get` is the preferred maybe-aware lookup name
 - Flow, MetaEnv, Ref, and Process handles are runtime values, but they are not plain data in the same sense as numbers/lists/maps

--- a/spec/error/error-format-first-class-constructor-non-string.yaml
+++ b/spec/error/error-format-first-class-constructor-non-string.yaml
@@ -6,5 +6,5 @@ input:
 expected:
   stdout: ""
   stderr: |
-    Error: Format expected a string template, received int
+    Error: Format expected template string, received int
   exit_code: 1

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -490,12 +490,22 @@ def make_global_env(
     def debug_repr_fn(value: Any) -> str:
         return format_debug(value)
 
-    def format_constructor(template: Any) -> GeniaFormat:
+    def format_constructor(*args: Any) -> GeniaFormat:
+        if len(args) not in (1, 2):
+            raise TypeError(f"Format expected 1 or 2 args, got {len(args)}")
+        template = args[0]
         if not isinstance(template, str):
             raise TypeError(
-                f"Format expected a string template, received {_runtime_type_name(template)}"
+                f"Format expected template string, received {_runtime_type_name(template)}"
             )
-        return GeniaFormat(template)
+        tag = None
+        if len(args) == 2:
+            tag = args[1]
+            if not isinstance(tag, str):
+                raise TypeError(f"Format expected tag string, received {_runtime_type_name(tag)}")
+            if tag == "":
+                raise TypeError("Format expected non-empty tag string")
+        return GeniaFormat(template, tag)
 
     def format_template_fn(fmt: Any) -> str:
         if not isinstance(fmt, GeniaFormat):
@@ -503,6 +513,18 @@ def make_global_env(
                 f"format_template expected a format, received {_runtime_type_name(fmt)}"
             )
         return fmt.template
+
+    def format_tag_fn(*args: Any) -> GeniaOptionSome | GeniaOptionNone:
+        if len(args) != 1:
+            raise TypeError(f"format_tag expected 1 arg, got {len(args)}")
+        fmt = args[0]
+        if not isinstance(fmt, GeniaFormat):
+            raise TypeError(
+                f"format_tag expected a format value, received {_runtime_type_name(fmt)}"
+            )
+        if fmt.tag is None:
+            return make_none("missing-format-tag")
+        return GeniaOptionSome(fmt.tag)
 
     def _ensure_string(value: Any, name: str) -> str:
         if not isinstance(value, str):
@@ -2907,6 +2929,7 @@ def make_global_env(
     env.set("debug_repr", debug_repr_fn)
     env.set("Format", format_constructor)
     env.set("format_template", format_template_fn)
+    env.set("format_tag", format_tag_fn)
     env.set("input", input_fn)
     env.set("stdin", stdin_source)
     env.set("stdin_keys", stdin_keys_flow)

--- a/src/genia/values.py
+++ b/src/genia/values.py
@@ -516,8 +516,9 @@ class GeniaProcess:
 
 
 class GeniaFormat:
-    def __init__(self, template: str):
+    def __init__(self, template: str, tag: str | None = None):
         self.template = template
+        self.tag = tag
 
     def __repr__(self) -> str:
         return "<format>"

--- a/tests/unit/test_format_first_class_168.py
+++ b/tests/unit/test_format_first_class_168.py
@@ -81,7 +81,7 @@ def test_format_value_display_does_not_expose_template():
 
 def test_format_constructor_rejects_non_string():
     env, _, _ = _env()
-    with pytest.raises(TypeError, match="Format expected a string template"):
+    with pytest.raises(TypeError, match="Format expected template string, received int"):
         run_source("Format(123)", env)
 
 
@@ -93,7 +93,7 @@ def test_format_rejects_non_string_non_format_first_arg():
 
 def test_format_constructor_rejects_list():
     env, _, _ = _env()
-    with pytest.raises(TypeError, match="Format expected a string template"):
+    with pytest.raises(TypeError, match="Format expected template string, received list"):
         run_source('Format(["a", "b"])', env)
 
 

--- a/tests/unit/test_format_tagged_values_292.py
+++ b/tests/unit/test_format_tagged_values_292.py
@@ -1,0 +1,133 @@
+import io
+
+import pytest
+
+from genia import make_global_env, run_source
+
+
+def _env():
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    return make_global_env(stdout_stream=stdout, stderr_stream=stderr), stdout, stderr
+
+
+def test_tagged_format_formats_like_untagged_format():
+    env, _, _ = _env()
+    untagged = run_source('format(Format("{name}"), {name: "Ada"})', env)
+
+    env2, _, _ = _env()
+    tagged = run_source('format(Format("{name}", "person-card"), {name: "Ada"})', env2)
+
+    assert untagged == tagged == "Ada"
+
+
+def test_tagged_format_supports_positional_placeholders():
+    env, _, _ = _env()
+    result = run_source('format(Format("{0} {1}", "pair-line"), ["hello", "world"])', env)
+
+    assert result == "hello world"
+
+
+def test_tagged_format_preserves_escaped_braces_and_debug_specs():
+    env, _, _ = _env()
+    result = run_source(
+        'format(Format("{{name}} {name:?}", "debug-line"), {name: "Ada"})',
+        env,
+    )
+
+    assert result == '{name} "Ada"'
+
+
+def test_format_tag_returns_none_for_untagged_format():
+    env, _, _ = _env()
+    result = run_source('format_tag(Format("{name}"))', env)
+
+    assert repr(result) == 'none("missing-format-tag")'
+
+
+def test_format_tag_returns_some_for_tagged_format():
+    env, _, _ = _env()
+    result = run_source('format_tag(Format("{name}", "person-card"))', env)
+
+    assert repr(result) == 'some("person-card")'
+
+
+def test_tagged_format_display_and_debug_remain_opaque():
+    env, _, _ = _env()
+    display = run_source('display(Format("{secret}", "person-card"))', env)
+
+    env2, _, _ = _env()
+    debug = run_source('debug_repr(Format("{secret}", "person-card"))', env2)
+
+    assert display == "<format>"
+    assert debug == "<format>"
+    assert "person-card" not in display
+    assert "person-card" not in debug
+    assert "{secret}" not in display
+    assert "{secret}" not in debug
+
+
+def test_tagged_format_missing_named_field_uses_existing_error():
+    env, _, _ = _env()
+    with pytest.raises(ValueError, match="format missing field: name"):
+        run_source('format(Format("{name}", "person-card"), {})', env)
+
+
+def test_tagged_format_missing_positional_field_uses_existing_error():
+    env, _, _ = _env()
+    with pytest.raises(ValueError, match="format missing field: 1"):
+        run_source('format(Format("{1}", "pair-line"), ["only zero"])', env)
+
+
+def test_tagged_format_unsupported_spec_uses_existing_error():
+    env, _, _ = _env()
+    with pytest.raises(ValueError, match="format-error: unsupported format spec"):
+        run_source('format(Format("{name:debug}", "person-card"), {name: "Ada"})', env)
+
+
+def test_format_constructor_rejects_zero_arguments():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="Format expected 1 or 2 args, got 0"):
+        run_source("Format()", env)
+
+
+def test_format_constructor_rejects_more_than_two_arguments():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="Format expected 1 or 2 args, got 3"):
+        run_source('Format("{name}", "person-card", "extra")', env)
+
+
+def test_format_constructor_rejects_non_string_template():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="Format expected template string, received int"):
+        run_source("Format(123)", env)
+
+
+def test_format_constructor_rejects_non_string_tag():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="Format expected tag string, received int"):
+        run_source('Format("{name}", 123)', env)
+
+
+def test_format_constructor_rejects_empty_tag():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="Format expected non-empty tag string"):
+        run_source('Format("{name}", "")', env)
+
+
+def test_format_tag_rejects_zero_arguments():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format_tag expected 1 arg, got 0"):
+        run_source("format_tag()", env)
+
+
+def test_format_tag_rejects_more_than_one_argument():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format_tag expected 1 arg, got 2"):
+        run_source('format_tag(Format("{x}"), Format("{y}"))', env)
+
+
+def test_format_tag_rejects_non_format_value():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format_tag expected a format value, received string"):
+        run_source('format_tag("not-format")', env)

--- a/tests/unit/test_format_tagged_values_292.py
+++ b/tests/unit/test_format_tagged_values_292.py
@@ -3,6 +3,7 @@ import io
 import pytest
 
 from genia import make_global_env, run_source
+from genia.utf8 import format_debug
 
 
 def _env():
@@ -42,14 +43,14 @@ def test_format_tag_returns_none_for_untagged_format():
     env, _, _ = _env()
     result = run_source('format_tag(Format("{name}"))', env)
 
-    assert repr(result) == 'none("missing-format-tag")'
+    assert format_debug(result) == 'none("missing-format-tag")'
 
 
 def test_format_tag_returns_some_for_tagged_format():
     env, _, _ = _env()
     result = run_source('format_tag(Format("{name}", "person-card"))', env)
 
-    assert repr(result) == 'some("person-card")'
+    assert format_debug(result) == 'some("person-card")'
 
 
 def test_tagged_format_display_and_debug_remain_opaque():


### PR DESCRIPTION
````md
## Summary

Adds tagged `Format` values for issue #292.

This change extends first-class `Format` values so they can optionally carry a non-empty string tag as representation metadata:

- `Format(template)` still creates an untagged format.
- `Format(template, tag)` creates a tagged format.
- `format_tag(fmt)` returns:
  - `some(tag)` for tagged formats
  - `none("missing-format-tag")` for untagged formats

Tags are metadata only. They do not affect formatting output, placeholder resolution, field specs, debug specs, or the identity of values being formatted.

## Behavior

Implemented:

- Preserve existing `Format(template)` behavior.
- Add `Format(template, tag)`.
- Add `format_tag(fmt)`.
- Keep display/debug rendering as `<format>` for both tagged and untagged formats.
- Keep `format(...)` tag-blind:
  - `format(Format(t), v) == format(Format(t, tag), v)`

Added deterministic diagnostics for:

- Wrong `Format` arity.
- Non-string template.
- Non-string tag.
- Empty tag.
- Wrong `format_tag` arity.
- Non-`Format` input to `format_tag`.

## Files Changed

- `src/genia/values.py`
- `src/genia/builtins.py`
- `tests/unit/test_format_tagged_values_292.py`
- `tests/unit/test_format_first_class_168.py`
- `spec/error/error-format-first-class-constructor-non-string.yaml`
- `GENIA_STATE.md`
- `GENIA_REPL_README.md`
- `README.md`

## Tests

Ran:

```sh
PYTHONPATH=src pytest -q tests/unit/test_format_tagged_values_292.py
````

Result:

```text
17 passed
```

Ran:

```sh
PYTHONPATH=src pytest -q tests/unit/test_format_debug_mode_170.py tests/unit/test_format_refactor_298.py
```

Result:

```text
49 passed
```

Ran:

```sh
PYTHONPATH=src pytest -q tests/unit/test_format_tagged_values_292.py tests/unit/test_format_first_class_168.py tests/unit/test_format_field_specs_169.py tests/unit/test_format_debug_mode_170.py tests/unit/test_format_refactor_298.py
```

Result:

```text
115 passed
```

Ran:

```sh
uv tool run ruff check src/genia/values.py src/genia/builtins.py tests/unit/test_format_tagged_values_292.py tests/unit/test_format_first_class_168.py
```

Result:

```text
All checks passed!
```

Ran full suite:

```sh
PYTHONPATH=src UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx --with pyyaml pytest -q
```

Result:

```text
2264 passed
```

## Notes

This intentionally does **not** add:

* value-template behavior
* type contracts
* localization
* representation dispatch
* tag-based rendering
* new syntax
* parser changes
* Core IR changes

Tags are just explicit representation metadata. Tiny label, no semantic fireworks.

```
```
