### PR TITLE
Feature/issue 293 representation design format composition

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -195,6 +195,7 @@ CLI contract summary (actual behavior):
     - `Format(template, tag)` constructs a tagged first-class representation value; `tag` must be a non-empty string; the tag is metadata only and does not affect rendering or display/debug output (**Experimental**, #292)
     - `format_template(fmt)` returns the original source template string from a `Format` value (**Experimental**, #294); `display(Format(...))` and `debug_repr(Format(...))` remain opaque as `<format>`
     - `format_tag(fmt)` returns `some(tag)` for a tagged `Format` value or `none("missing-format-tag")` for an untagged `Format` value (**Experimental**, #292)
+    - `format_compose(parts)` creates a composed `Format` from an ordered list of raw string templates and `Format` values; rendering concatenates each piece rendered with the same values map; empty composition is valid; pieces share one input namespace (**Experimental**, #293)
   - public flow helpers are prelude-backed wrappers: `lines`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, plus `rule_*` compatibility constructors and preferred `step_*` constructors
   - public sink helpers are prelude-backed wrappers: `write`, `writeln`, `flush`
   - raw CLI primitive: `argv`

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1027,6 +1027,7 @@ Representation System entry points (#185, implemented):
   - `format_template(non_format)` fails with `TypeError: format_template expected a format, received <type>`.
   - `display(Format(...))` and `debug_repr(Format(...))` remain opaque; `format_template` is the only approved way to recover the source template string.
   - `format_template` does not expose compiled template internals, placeholder metadata, or parsed template structure.
+  - `format_template` does not apply to composed `Format` values created by `format_compose(...)`. Calling `format_template` on a composed format fails with `TypeError: format_template expected an atomic Format value`.
   - `format_template` is not explicitly none-aware; ordinary none propagation applies in pipelines.
   - `format_template` is Experimental. The accessor name and behavior may change before stabilization.
 - `format_tag(fmt)` is a public Representation System helper (**Experimental**, #292):
@@ -1039,6 +1040,23 @@ Representation System entry points (#185, implemented):
   - `format_tag(non_format)` fails with `TypeError: format_tag expected a format value, received <type>`.
   - `format_tag` does not expose the template, alter rendering, or cause tag-based format dispatch.
   - `format_tag` is Experimental. The helper name and behavior may change before stabilization.
+- `format_compose(parts)` is a public Representation System helper (**Experimental**, #293):
+  - `format_compose(parts)` accepts a list of format pieces and returns a new `Format` value.
+  - Each piece in `parts` must be either a raw string template or a `Format` value (including another composed `Format`).
+  - Rendering a composed `Format` with `format(composed_fmt, values)` renders each piece in order with the same `values` map and concatenates the resulting strings.
+  - Empty composition is valid: `format(format_compose([]), {})` returns `""`.
+  - Nested composition is valid: composed `Format` values may be used as pieces in later composition.
+  - Repeated placeholders are allowed and read the same value from the input map.
+  - All placeholders in a composed `Format` share the same input namespace; there is no per-piece namespace.
+  - Composition adds no separators, whitespace, or newlines; separators must be explicit pieces.
+  - `format_compose(parts)` is pure: it does not mutate `parts`, any piece, or any values map.
+  - `display(format_compose(...))` and `debug_repr(format_compose(...))` return `<format>`.
+  - `format_template` does not apply to composed `Format` values; calling it on a composed format fails with a deterministic `TypeError`.
+  - `format_compose(non_list)` fails with `TypeError: format_compose expected list of format pieces, received <type>`.
+  - `format_compose([..., invalid, ...])` fails with `TypeError: format_compose expected string or Format at index <n>, received <type>` (zero-based index).
+  - Missing placeholder behavior during rendering is unchanged: existing missing-placeholder errors apply.
+  - `format_compose` does not add parser syntax, Core IR behavior, control flow, expression evaluation, localization, debug mode, tagged dispatch, field paths, or Value Template behavior.
+  - `format_compose` is Experimental. The helper name and behavior may change before stabilization.
 - These helpers do not write to `stdout` or `stderr`.
 - These helpers do not mutate runtime state.
 - These helpers do not change `print`, `log`, `write`, `writeln`, REPL result display, CLI final-result rendering, or pipeline semantics.
@@ -1065,6 +1083,9 @@ Representation System entry points (#185, implemented):
   - `format_tag(Format("{name}", "person-card"))` evaluates to `some("person-card")`
   - `format_tag(Format("{name}"))` evaluates to `none("missing-format-tag")`
   - `format(Format("{name}", "person-card"), {name: "Ada"})` evaluates to the string `Ada`
+  - `format(format_compose(["Hello, ", Format("{name}"), "!"]), {name: "Matt"})` evaluates to the string `Hello, Matt!`
+  - `format(format_compose([]), {})` evaluates to the string `""`
+  - `format(format_compose(["{x}", " / ", "{x}"]), {x: "go"})` evaluates to the string `go / go`
 - Runtime capability values and function-like values may have host-specific opaque debug/display text in this phase unless a later contract explicitly stabilizes them.
 - #185 does not define the full Representation System.
 - #166 owns the broader representation model, including naming boundaries beyond `display` and `debug_repr`, extension points, user-defined representations, registry/strategy behavior, and cross-host treatment of opaque runtime values.

--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ Current consistency note:
 - `Format(template, tag)` constructs a tagged first-class representation value; `tag` must be a non-empty string; the tag is metadata only and does not affect rendering or display/debug output (Experimental, #292)
 - `format_template(fmt)` returns the source template string from a first-class `Format` value (Experimental, #294); `display(Format(...))` and `debug_repr(Format(...))` remain opaque as `<format>`; non-Format input fails with a deterministic `TypeError`
 - `format_tag(fmt)` returns `some(tag)` for a tagged `Format` value or `none("missing-format-tag")` for an untagged `Format` value (Experimental, #292)
+- `format_compose(parts)` creates a composed `Format` value from an ordered list of raw string templates and `Format` values; rendering concatenates each piece rendered with the same values map; all placeholders share one input namespace; composition is pure with no parser syntax or Value Template behavior (Experimental, #293)
 - `some(pattern)`, `none(reason)`, and `none(reason, context)` are supported in pattern matching for Option values
 - new `?`-suffixed APIs are boolean-returning; `get?` remains the current compatibility exception and `get` is the preferred maybe-aware lookup name
 - Flow, MetaEnv, Ref, and Process handles are runtime values, but they are not plain data in the same sense as numbers/lists/maps

--- a/spec/error/error-format-compose-invalid-piece.yaml
+++ b/spec/error/error-format-compose-invalid-piece.yaml
@@ -1,0 +1,10 @@
+name: error-format-compose-invalid-piece
+category: error
+input:
+  source: |
+    format_compose([Format("{x}"), 42])
+expected:
+  stdout: ""
+  stderr: |
+    Error: format_compose expected string or Format at index 1, received int
+  exit_code: 1

--- a/spec/error/error-format-compose-missing-placeholder.yaml
+++ b/spec/error/error-format-compose-missing-placeholder.yaml
@@ -1,0 +1,11 @@
+name: error-format-compose-missing-placeholder
+category: error
+input:
+  source: |
+    F = format_compose([Format("{missing}")])
+    format(F, {})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format missing field: missing
+  exit_code: 1

--- a/spec/error/error-format-compose-non-list.yaml
+++ b/spec/error/error-format-compose-non-list.yaml
@@ -1,0 +1,10 @@
+name: error-format-compose-non-list
+category: error
+input:
+  source: |
+    format_compose(42)
+expected:
+  stdout: ""
+  stderr: |
+    Error: format_compose expected list of format pieces, received int
+  exit_code: 1

--- a/spec/error/error-format-compose-string-argument.yaml
+++ b/spec/error/error-format-compose-string-argument.yaml
@@ -1,0 +1,10 @@
+name: error-format-compose-string-argument
+category: error
+input:
+  source: |
+    format_compose("{x}")
+expected:
+  stdout: ""
+  stderr: |
+    Error: format_compose expected list of format pieces, received string
+  exit_code: 1

--- a/spec/eval/format-compose-basic.yaml
+++ b/spec/eval/format-compose-basic.yaml
@@ -1,0 +1,11 @@
+name: format-compose-basic
+category: eval
+input:
+  source: |
+    Greeting = format_compose(["Hello ", "{name}", "!"])
+    format(Greeting, {name: "Ada"})
+expected:
+  stdout: |
+    "Hello Ada!"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-compose-empty.yaml
+++ b/spec/eval/format-compose-empty.yaml
@@ -1,0 +1,11 @@
+name: format-compose-empty
+category: eval
+input:
+  source: |
+    Empty = format_compose([])
+    format(Empty, {})
+expected:
+  stdout: |
+    ""
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-compose-mixed-pieces.yaml
+++ b/spec/eval/format-compose-mixed-pieces.yaml
@@ -1,0 +1,13 @@
+name: format-compose-mixed-pieces
+category: eval
+input:
+  source: |
+    Name = Format("{name}")
+    Location = Format("{city}")
+    Line = format_compose([Name, " - ", Location])
+    format(Line, {name: "Matt", city: "Bountiful"})
+expected:
+  stdout: |
+    "Matt - Bountiful"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-compose-nested.yaml
+++ b/spec/eval/format-compose-nested.yaml
@@ -1,0 +1,13 @@
+name: format-compose-nested
+category: eval
+input:
+  source: |
+    Cell = Format("{value}")
+    PaddedCell = format_compose(["[", Cell, "]"])
+    Row = format_compose([PaddedCell, " ", PaddedCell])
+    format(Row, {value: "X"})
+expected:
+  stdout: |
+    "[X] [X]"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-compose-preserves-existing-format.yaml
+++ b/spec/eval/format-compose-preserves-existing-format.yaml
@@ -1,0 +1,11 @@
+name: format-compose-preserves-existing-format
+category: eval
+input:
+  source: |
+    BoardRow = Format("{a} {b} {c}")
+    format(BoardRow, {a: "X", b: "O", c: " "})
+expected:
+  stdout: |
+    "X O  "
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/format-compose-repeated-placeholder.yaml
+++ b/spec/eval/format-compose-repeated-placeholder.yaml
@@ -1,0 +1,11 @@
+name: format-compose-repeated-placeholder
+category: eval
+input:
+  source: |
+    Pair = format_compose(["{x}", " / ", Format("{x}")])
+    format(Pair, {x: "A"})
+expected:
+  stdout: |
+    "A / A"
+  stderr: ""
+  exit_code: 0

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -512,6 +512,8 @@ def make_global_env(
             raise TypeError(
                 f"format_template expected a format, received {_runtime_type_name(fmt)}"
             )
+        if fmt.template is None:
+            raise TypeError("format_template expected an atomic Format value")
         return fmt.template
 
     def format_tag_fn(*args: Any) -> GeniaOptionSome | GeniaOptionNone:
@@ -632,15 +634,17 @@ def make_global_env(
             raise TypeError("join expected a list of strings, received list")
         return separator.join(xs)
 
-    def format_fn(template: Any, values: Any) -> str:
-        if isinstance(template, GeniaFormat):
-            template = template.template
-        elif not isinstance(template, str):
+    def _render_format_piece(piece: Any, values: Any) -> str:
+        if isinstance(piece, GeniaFormat):
+            if piece.pieces is not None:
+                return "".join(_render_format_piece(part, values) for part in piece.pieces)
+            piece = piece.template
+        if not isinstance(piece, str):
             raise TypeError(
-                f"format expected a string template or Format value, received {_runtime_type_name(template)}"
+                f"format expected a string template or Format value, received {_runtime_type_name(piece)}"
             )
 
-        parts = parse_format_template(template)
+        parts = parse_format_template(piece)
         pieces: list[str] = []
         for part in parts:
             if isinstance(part, TemplateLiteral):
@@ -652,6 +656,22 @@ def make_global_env(
                 else:
                     pieces.append(render_format_value(resolved))
         return "".join(pieces)
+
+    def format_fn(template: Any, values: Any) -> str:
+        return _render_format_piece(template, values)
+
+    def format_compose_fn(parts: Any) -> GeniaFormat:
+        if not isinstance(parts, list):
+            raise TypeError(
+                f"format_compose expected list of format pieces, received {_runtime_type_name(parts)}"
+            )
+        for index, part in enumerate(parts):
+            if not isinstance(part, (str, GeniaFormat)):
+                raise TypeError(
+                    "format_compose expected string or Format "
+                    f"at index {index}, received {_runtime_type_name(part)}"
+                )
+        return GeniaFormat(pieces=tuple(parts))
 
     def trim_fn(value: Any) -> str:
         return _ensure_string(value, "trim").strip()
@@ -3049,6 +3069,7 @@ def make_global_env(
     env.set("_split_whitespace", split_whitespace_fn)
     env.set("_join", join_fn)
     env.set("_format", format_fn)
+    env.set("_format_compose", format_compose_fn)
     env.set("_trim", trim_fn)
     env.set("_trim_start", trim_start_fn)
     env.set("_trim_end", trim_end_fn)
@@ -3222,6 +3243,7 @@ def make_global_env(
     env.register_autoload("split_whitespace", 1, "std/prelude/string.genia")
     env.register_autoload("join", 2, "std/prelude/string.genia")
     env.register_autoload("format", 2, "std/prelude/string.genia")
+    env.register_autoload("format_compose", 1, "std/prelude/string.genia")
     env.register_autoload("trim", 1, "std/prelude/string.genia")
     env.register_autoload("trim_start", 1, "std/prelude/string.genia")
     env.register_autoload("trim_end", 1, "std/prelude/string.genia")

--- a/src/genia/std/prelude/string.genia
+++ b/src/genia/std/prelude/string.genia
@@ -31,6 +31,9 @@ join(sep, xs) = _join(sep, xs)
 @doc "Format a string template with named or positional placeholders."
 format(template, values) = _format(template, values)
 
+@doc "Compose an ordered list of string templates and Format values into a reusable Format."
+format_compose(parts) = _format_compose(parts)
+
 @doc "Trim leading and trailing whitespace."
 trim(value) = _trim(value)
 

--- a/src/genia/values.py
+++ b/src/genia/values.py
@@ -516,9 +516,15 @@ class GeniaProcess:
 
 
 class GeniaFormat:
-    def __init__(self, template: str, tag: str | None = None):
+    def __init__(
+        self,
+        template: str | None = None,
+        tag: str | None = None,
+        pieces: Iterable[str | "GeniaFormat"] | None = None,
+    ):
         self.template = template
         self.tag = tag
+        self.pieces = tuple(pieces) if pieces is not None else None
 
     def __repr__(self) -> str:
         return "<format>"

--- a/tests/spec/test_spec_ir_runner_blackbox.py
+++ b/tests/spec/test_spec_ir_runner_blackbox.py
@@ -250,6 +250,12 @@ def test_ir_spec_fixture(fname: str) -> None:
         "format-first-class-format-empty-template.yaml",
         "format-first-class-format-no-placeholders.yaml",
         "format-first-class-format-positional.yaml",
+        "format-compose-basic.yaml",
+        "format-compose-empty.yaml",
+        "format-compose-mixed-pieces.yaml",
+        "format-compose-nested.yaml",
+        "format-compose-repeated-placeholder.yaml",
+        "format-compose-preserves-existing-format.yaml",
         "format-field-align-left.yaml",
         "format-field-align-right.yaml",
         "format-field-align-center-even.yaml",
@@ -359,6 +365,10 @@ def test_flow_spec_fixture(fname: str) -> None:
         "error-format-field-grouping-non-numeric.yaml",
         "error-format-field-precision-non-string-non-numeric.yaml",
         "error-format-field-bool-zero-pad.yaml",
+        "error-format-compose-invalid-piece.yaml",
+        "error-format-compose-missing-placeholder.yaml",
+        "error-format-compose-non-list.yaml",
+        "error-format-compose-string-argument.yaml",
     ],
 )
 @pytest.mark.spec

--- a/tests/unit/test_format_composition_293.py
+++ b/tests/unit/test_format_composition_293.py
@@ -1,0 +1,97 @@
+import io
+
+import pytest
+
+from genia import make_global_env, run_source
+
+
+def _env():
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    return make_global_env(stdout_stream=stdout, stderr_stream=stderr), stdout, stderr
+
+
+def test_format_compose_empty_renders_empty_string():
+    env, _, _ = _env()
+    result = run_source("Empty = format_compose([])\nformat(Empty, {})", env)
+    assert result == ""
+
+
+def test_format_compose_raw_string_parts_render_in_order():
+    env, _, _ = _env()
+    result = run_source(
+        'Greeting = format_compose(["Hello ", "{name}", "!"])\n'
+        'format(Greeting, {name: "Ada"})',
+        env,
+    )
+    assert result == "Hello Ada!"
+
+
+def test_format_compose_accepts_first_class_format_parts():
+    env, _, _ = _env()
+    result = run_source(
+        'Name = Format("{name}")\n'
+        'Location = Format("{city}")\n'
+        'Line = format_compose([Name, " - ", Location])\n'
+        'format(Line, {name: "Matt", city: "Bountiful"})',
+        env,
+    )
+    assert result == "Matt - Bountiful"
+
+
+def test_format_compose_nested_formats_render_recursively():
+    env, _, _ = _env()
+    result = run_source(
+        'Cell = Format("{value}")\n'
+        'PaddedCell = format_compose(["[", Cell, "]"])\n'
+        'Row = format_compose([PaddedCell, " ", PaddedCell])\n'
+        'format(Row, {value: "X"})',
+        env,
+    )
+    assert result == "[X] [X]"
+
+
+def test_format_compose_repeated_placeholders_share_values_map():
+    env, _, _ = _env()
+    result = run_source(
+        'Pair = format_compose(["{x}", " / ", Format("{x}")])\n'
+        'format(Pair, {x: "A"})',
+        env,
+    )
+    assert result == "A / A"
+
+
+def test_format_compose_returns_format_value_for_display():
+    env, _, _ = _env()
+    result = run_source('display(format_compose(["{x}"]))', env)
+    assert result == "<format>"
+
+
+def test_format_compose_does_not_render_during_composition():
+    env, _, _ = _env()
+    result = run_source('Later = format_compose([Format("{missing}")])\ndisplay(Later)', env)
+    assert result == "<format>"
+
+
+def test_format_compose_non_list_rejected():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format_compose expected list of format pieces, received int"):
+        run_source("format_compose(42)", env)
+
+
+def test_format_compose_string_argument_rejected_as_non_list():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format_compose expected list of format pieces, received string"):
+        run_source('format_compose("{x}")', env)
+
+
+def test_format_compose_invalid_piece_reports_index_and_type():
+    env, _, _ = _env()
+    with pytest.raises(TypeError, match="format_compose expected string or Format at index 1, received int"):
+        run_source('format_compose([Format("{x}"), 42])', env)
+
+
+def test_format_compose_missing_placeholder_uses_existing_format_error():
+    env, _, _ = _env()
+    with pytest.raises(ValueError, match="format missing field: missing"):
+        run_source('F = format_compose([Format("{missing}")])\nformat(F, {})', env)


### PR DESCRIPTION
````md
## Summary

Adds explicit `Format` composition for the Representation System.

This introduces `format_compose(parts)`, which creates a reusable `Format` from an ordered list of raw string templates and existing `Format` values.

## What changed

- Added `format_compose(parts)`
- Extended `GeniaFormat` so it can represent composed format pieces
- Updated `format(...)` to render composed `Format` values recursively
- Added public prelude wrapper in `string.genia`
- Added shared eval/error specs for format composition
- Added unit coverage for issue #293
- Updated docs:
  - `GENIA_STATE.md`
  - `GENIA_REPL_README.md`
  - `README.md`

## Behavior

`format_compose(parts)`:

- accepts a list of raw string templates and `Format` values
- returns a new `Format`
- renders each piece in order with the same values map
- supports empty composition
- supports nested composition
- supports repeated placeholders
- adds no separators implicitly
- performs no rendering at composition time

Example:

```genia
Greeting = format_compose(["Hello, ", Format("{name}"), "!"])
format(Greeting, {name: "Matt"})
# "Hello, Matt!"
````

## Explicit non-goals

This does **not** add:

* parser syntax
* Core IR changes
* control flow inside format strings
* expression evaluation inside format strings
* localization
* field paths
* debug mode
* tagged dispatch
* Value Template behavior

## Tests

Ran:

```bash
PYTHONPATH=src pytest -q tests/unit/test_format_composition_293.py
PYTHONPATH=src pytest -q tests/spec/test_spec_ir_runner_blackbox.py -k format-compose
PYTHONPATH=src pytest -q tests/unit/test_format_first_class_168.py tests/unit/test_format_tagged_values_292.py tests/unit/test_format_field_specs_169.py tests/unit/test_format_debug_mode_170.py
uv run python -m tools.spec_runner
PYTHONPATH=src UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx --with pyyaml pytest -q
```

Results:

* 11 format composition unit tests passed
* 10 format composition shared spec cases passed
* 81 nearby format tests passed
* shared spec runner: 301 passed
* full suite: 2285 passed

```
```
