### PR TITLE
fix(format): reject bare Format constructor syntax

### DIFF
--- a/src/genia/parser.py
+++ b/src/genia/parser.py
@@ -294,6 +294,8 @@ class Parser:
             return bindable
 
         expr = self.parse_expr()
+        if isinstance(expr, Var) and expr.name == "Format" and self.at("STRING"):
+            raise SyntaxError('Format constructor requires call syntax: Format("...")')
         if self.at("ASSIGN"):
             raise SyntaxError("Assignment target must be a simple name")
         return ExprStmt(expr, span=expr.span)

--- a/tests/unit/test_format_first_class_168.py
+++ b/tests/unit/test_format_first_class_168.py
@@ -57,6 +57,12 @@ def test_format_value_positional_placeholders():
     assert result == "hello world"
 
 
+def test_format_constructor_requires_call_syntax():
+    env, _, _ = _env()
+    with pytest.raises(Exception, match="Format"):
+        run_source('Format "{name}"', env)
+
+
 # --- Display and debug rendering ---
 
 def test_format_value_display_returns_format_tag():


### PR DESCRIPTION
Adds a narrow parser guard so bare Format string syntax fails with a SyntaxError.

Keeps Format(...) and tagged Format(...) call forms unchanged and adds unit coverage for the rejected bare form.

Use this PR title:

```text
fix(format): reject bare Format constructor syntax
```

PR description:

````md
## Summary

This PR completes issue #172’s Representation System / Format truth-review follow-up by enforcing an already-documented Format syntax boundary.

`GENIA_STATE.md` already states that bare parser syntax such as `Format "..."` is not supported, and that the only accepted constructor forms are:

- `Format("...")`
- `Format("...", "tag")`

Previously, `Format "{name}"` could be parsed as an expression sequence and return the raw string template instead of failing. This PR adds a narrow parser guard so that unsupported bare `Format "..."` syntax now raises a deterministic `SyntaxError`.

## Changes

- Added parser validation for bare `Format "..."` syntax.
- Added unit coverage proving the unsupported form is rejected.
- Preserved existing valid Format call forms:
  - `Format("...")`
  - `Format("...", "tag")`
  - `format(...)`
  - `format_template(...)`
  - `format_tag(...)`
  - `format_compose(...)`

## Scope

This PR does **not** add new Format behavior.

It does not implement:

- field paths
- localization-aware formatting
- representation registries
- interpolation syntax
- Genia expressions inside placeholders
- hidden control flow in format strings
- Value Template behavior

## Docs

No documentation changes were needed.

`GENIA_STATE.md` already documented this constraint, and this PR brings parser behavior into alignment with that existing contract.

## Tests

Run:

```bash
uv run pytest tests/unit/test_format_first_class_168.py::test_format_constructor_requires_call_syntax -q
uv run pytest tests/unit/test_format_first_class_168.py tests/unit/test_format_tagged_values_292.py tests/unit/test_format_composition_293.py tests/unit/test_format_debug_mode_170.py tests/unit/test_format_field_specs_169.py tests/unit/test_representation_entrypoints_185.py -q
uv run pytest tests/spec/test_parse_shared_spec_runner.py tests/spec/test_spec_parse_runner_blackbox.py -q
uv run pytest tests/unit/test_format*.py tests/unit/test_representation_entrypoints_185.py -q
uv run pytest tests/doc/test_semantic_doc_sync.py -q
uv run pytest -q
````

Observed:

* `1 passed`
* `97 passed`
* `20 passed`
* `131 passed`
* `66 passed`
* `2286 passed`

## Final verdict

Ready for review. Minimal parser guard, focused test coverage, no docs drift.

```
```
