### PR TITLE
Feature/issue 171 docs document representation system and format

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -185,17 +185,24 @@ CLI contract summary (actual behavior):
 - builtins:
   - direct I/O/runtime names: `log`, `print`, `display`, `debug_repr`, `input`, `stdin`, `stdout`, `stderr`, `help`
   - first Representation System entry points:
+    - representation renders values as strings for output and debugging
+    - representation does not change value identity
+    - representation is separate from value templates; value templates describe or constrain values, while representation formats describe output strings
     - `display(value)` returns the user-facing display representation string without writing output
     - `debug_repr(value)` returns the debug representation string without writing output
     - these entry points are minimal #185 surface area; #166 owns the broader Representation System model
   - public prelude-backed string formatting helper:
     - `format(template_or_format, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; `{name:?}` and `{0:?}` use debug rendering; it supports escaped braces with `{{` and `}}`
+    - `format(template_or_format, values)` does not write output and does not mutate the input template, `Format` value, or values map/list
     - `format` accepts either a raw string template or a `Format` value as its first argument
+    - `Format` is for output representation and does not affect value identity
+    - `Format` is separate from value templates
     - `Format(template)` constructs an untagged first-class representation value from a string template (**Experimental**, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
     - `Format(template, tag)` constructs a tagged first-class representation value; `tag` must be a non-empty string; the tag is metadata only and does not affect rendering or display/debug output (**Experimental**, #292)
     - `format_template(fmt)` returns the original source template string from a `Format` value (**Experimental**, #294); `display(Format(...))` and `debug_repr(Format(...))` remain opaque as `<format>`
     - `format_tag(fmt)` returns `some(tag)` for a tagged `Format` value or `none("missing-format-tag")` for an untagged `Format` value (**Experimental**, #292)
     - `format_compose(parts)` creates a composed `Format` from an ordered list of raw string templates and `Format` values; rendering concatenates each piece rendered with the same values map; empty composition is valid; pieces share one input namespace (**Experimental**, #293)
+    - see `docs/design/representation-system-and-format.md` for the focused representation and `Format` documentation
   - public flow helpers are prelude-backed wrappers: `lines`, `keep_some_else`, `rules`, `refine`, `each`, `collect`, `run`, plus `rule_*` compatibility constructors and preferred `step_*` constructors
   - public sink helpers are prelude-backed wrappers: `write`, `writeln`, `flush`
   - raw CLI primitive: `argv`

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -979,10 +979,14 @@ Representation System entry points (#185, implemented):
 
 - `display(value)` and `debug_repr(value)` are the first concrete public surface of the planned Representation System.
 - They are entry points into that system, not independent formatting utilities.
+- Representation renders values as strings for output and debugging.
+- Representation does not change value identity.
+- Representation is separate from value templates; value templates describe or constrain values, while representation formats describe output strings.
 - `display(value)` returns a string containing the user-facing display representation of `value`.
 - `debug_repr(value)` returns a string containing the debug representation of `value`.
 - `format(template_or_format, values)` is a public prelude-backed helper for building strings from a small placeholder template.
 - `format(template_or_format, values)` returns a string and does not write output.
+- `format(template_or_format, values)` does not mutate the input template, `Format` value, or values map/list.
 - The first argument to `format` is either a raw string template or a `Format` value (see below).
 - `format` supports:
   - named placeholders such as `{name}`, looked up in a map by string key
@@ -1004,6 +1008,8 @@ Representation System entry points (#185, implemented):
 - `Format(template)` and `Format(template, tag)` are first-class Representation System constructors (**Experimental**, #168, #292):
   - `Format(template)` accepts a string template and returns an untagged first-class `Format` value.
   - `Format(template, tag)` accepts a string template and a non-empty string tag and returns a tagged first-class `Format` value.
+  - `Format` is for output representation and does not affect value identity.
+  - `Format` is separate from value templates.
   - A `Format` value is representation-only: it is not a Value Template and does not participate in shape/refinement/contract/variant semantics.
   - The tag is representation metadata attached to the `Format` value only. It does not affect placeholder parsing, placeholder resolution, field-spec rendering, debug field specs, or the identity of values being formatted.
   - `format(Format(template), values)` and `format(Format(template, tag), values)` produce the same result as `format(template, values)` for the same template and values.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository currently provides:
 - terminal helpers and input sources (`clear_screen`, `move_cursor`, `render_grid`, `stdin_keys`) (**Python-host-only**)
 - a minimal host-backed HTTP serving foundation with prelude helpers (`serve_http`, `get`, `post`, `route_request`, `ok_text`, `json`) (**Python-host-only**)
 - shell pipeline stage `$(command)` for invoking host shell commands inside pipelines (**Python-host-only**, not portable; see below)
+- representation helpers (`display`, `debug_repr`, `format`) and experimental `Format` values for output representation
 - autoloaded prelude libraries (flow helpers, lists, map/ref/process/io helpers, option/string helpers, math helpers, awk helpers, fn helpers, evaluator helpers, cells, actors)
   - `cells` and `actors` are public prelude surfaces in the current Python reference host (**Python-host-only**)
   - flow helpers now include stateful `scan(step, initial_state)` for running totals, buffering, and windowing
@@ -577,7 +578,8 @@ Current consistency note:
 - `help()` now points users toward the public prelude-backed stdlib surface, while raw host-backed runtime names remain intentionally generic
 - REPL/debug output now renders structured absence with visible context metadata, for example `none("missing-key", {key: "name"})`
 - `display(value)` and `debug_repr(value)` are the first public Representation System entry points: they return display/debug representation strings without writing output
-- `format(template_or_format, values)` is a public prelude-backed string helper: it returns a string, uses `display(value)` for ordinary replacements, supports debug placeholders `{name:?}` / `{0:?}` using `debug_repr(value)`, supports `{name}`, `{0}`, `{{`, `}}`, and a limited set of field format specs (Experimental, #169: alignment `<N`/`>N`/`^N`, precision `.N`, zero-pad `0N`, comma-group `,`); its first argument is a raw string template or a `Format` value
+- representation does not change value identity; value templates describe or constrain values, while representation formats describe output strings
+- `format(template_or_format, values)` is a public prelude-backed string helper: it returns a string, writes nothing, does not mutate inputs, uses `display(value)` for ordinary replacements, supports debug placeholders `{name:?}` / `{0:?}` using `debug_repr(value)`, supports `{name}`, `{0}`, `{{`, `}}`, and a limited set of field format specs (Experimental, #169: alignment `<N`/`>N`/`^N`, precision `.N`, zero-pad `0N`, comma-group `,`); its first argument is a raw string template or a `Format` value
 - `Format(template)` constructs an untagged first-class representation value from a string template (Experimental, #168); `format(Format("{a}"), values)` is equivalent to `format("{a}", values)`
 - `Format(template, tag)` constructs a tagged first-class representation value; `tag` must be a non-empty string; the tag is metadata only and does not affect rendering or display/debug output (Experimental, #292)
 - `format_template(fmt)` returns the source template string from a first-class `Format` value (Experimental, #294); `display(Format(...))` and `debug_repr(Format(...))` remain opaque as `<format>`; non-Format input fails with a deterministic `TypeError`

--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -67,15 +67,46 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 | --- | --- |
 | display string | `display(value)` |
 | debug string | `debug_repr(value)` |
-| template string | `format(template, values)` |
+| template string | `format(template_or_format, values)` |
+| experimental format value | `Format(template)` |
 
-`display`, `debug_repr`, and `format` return strings. They do not write output. `format` supports named placeholders (`{name}`), positional placeholders (`{0}`), debug placeholders (`{name:?}`, `{0:?}`), escaped braces (`{{`, `}}`), and an experimental limited set of field specs (#169): `{field:<N}` left-align, `{field:>N}` right-align, `{field:^N}` center, `{n:.N}` precision, `{n:0N}` zero-pad, `{n:,}` comma-group. Ordinary replacements use display rendering; exact `:?` replacements use debug rendering.
+`display`, `debug_repr`, and `format` return strings. They do not write output. Representation does not affect value identity. `Format(template)` is Experimental and is for output representation, not value templates. `format` supports named placeholders (`{name}`), positional placeholders (`{0}`), debug placeholders (`{name:?}`, `{0:?}`), escaped braces (`{{`, `}}`), and an experimental limited set of field specs (#169): `{field:<N}` left-align, `{field:>N}` right-align, `{field:^N}` center, `{n:.N}` precision, `{n:0N}` zero-pad, `{n:,}` comma-group. Ordinary replacements use display rendering; exact `:?` replacements use debug rendering.
 
 <!-- [case: core-format-named] -->
 ```genia
-format("Hello {name}", {name: "Genia"})
+format("Hello {name}!", {name: "Alice"})
 ```
 Classification: **Valid** (directly tested)
+
+<!-- [case: core-format-positional] -->
+```genia
+format("Item {0} costs {1}", ["apple", "5"])
+```
+Classification: **Valid** (directly tested)
+
+<!-- [case: core-format-escaped-braces] -->
+```genia
+format("{{key}} = {0}", ["value"])
+```
+Classification: **Valid** (directly tested)
+
+<!-- [case: core-format-tic-tac-toe-row] -->
+```genia
+format("{0} | {1} | {2}", ["X", "O", "X"])
+```
+Classification: **Valid** (directly tested)
+
+Missing field failure:
+
+```text
+format("Hello {name}!", {greeting: "Hi"})
+```
+
+Expected stderr:
+
+```text
+Error: format missing field: name
+```
 
 ## List And Sequence Helpers
 

--- a/docs/design/representation-system-and-format.md
+++ b/docs/design/representation-system-and-format.md
@@ -1,0 +1,165 @@
+# Representation System and Format
+
+Status: Current Python reference host behavior unless marked Experimental.
+
+This page documents the implemented Representation System surface for display/debug strings and format templates. `GENIA_STATE.md` remains the final authority.
+
+## Purpose
+
+Representation renders values as strings for output and debugging.
+
+Representation answers:
+
+> How should this value be shown?
+
+It is not a type system, data model, localization layer, or interpolation syntax.
+
+## Core Rule
+
+Representation does not change value identity.
+
+Calling `display(value)`, `debug_repr(value)`, or `format(template_or_format, values)` does not change the value being represented, its runtime category, structure, or value-template compatibility.
+
+## Representation vs Value Templates
+
+Value templates describe or constrain values.
+
+Formats describe output strings.
+
+`Format` values are not refinements, open shapes, closed shapes, contracts, variants, or template composition for value matching.
+
+## Display and Debug Representation
+
+- `display(value)` returns a user-facing representation string without writing output.
+- `debug_repr(value)` returns a debug representation string without writing output.
+
+Output operations such as `print`, `log`, `write`, and `writeln` remain separate.
+
+## format(...)
+
+`format(template_or_format, values)` returns a string and writes nothing.
+
+The first argument may be:
+
+- a raw string template
+- a `Format` value
+
+Supported placeholder forms:
+
+- Named placeholders use map values: `{name}`
+- Positional placeholders use list values: `{0}`
+- Debug placeholders use debug representation: `{name:?}`, `{0:?}`
+- Escaped braces use `{{` and `}}`
+
+Plain placeholders use display rendering. Debug placeholders use the same debug rendering as `debug_repr(value)`.
+
+`format(...)` is side-effect-free at the language surface: it does not write output and does not mutate the template, `Format` value, or values map/list.
+
+## Format Values
+
+`Format(template)` constructs an untagged first-class representation value from a string template. Experimental.
+
+`Format(template, tag)` constructs a tagged first-class representation value. Experimental.
+
+Related helpers are Experimental:
+
+- `format_template(fmt)` returns the original source template string from an atomic `Format` value.
+- `format_tag(fmt)` returns `some(tag)` for a tagged `Format` and `none("missing-format-tag")` for an untagged `Format`.
+- `format_compose(parts)` creates a composed `Format` from ordered raw string templates and/or `Format` values.
+
+Tags are metadata only. They do not affect rendering, display/debug output, or value identity.
+
+`Format` values display and debug as opaque representation values: `<format>`.
+
+## Examples
+
+Named placeholder:
+
+```genia
+format("Hello {name}!", {name: "Alice"})
+```
+
+Result:
+
+```text
+"Hello Alice!"
+```
+
+Classification: Valid, covered by `spec/eval/format-named-basic.yaml`.
+
+Positional placeholder:
+
+```genia
+format("Item {0} costs {1}", ["apple", "5"])
+```
+
+Result:
+
+```text
+"Item apple costs 5"
+```
+
+Classification: Valid, covered by `spec/eval/format-positional-basic.yaml`.
+
+Escaped braces:
+
+```genia
+format("{{key}} = {0}", ["value"])
+```
+
+Result:
+
+```text
+"{key} = value"
+```
+
+Classification: Valid, covered by `spec/eval/format-escaped-braces-mixed.yaml`.
+
+Tic-tac-toe board row:
+
+```genia
+format("{0} | {1} | {2}", ["X", "O", "X"])
+```
+
+Result:
+
+```text
+"X | O | X"
+```
+
+Classification: Valid, covered by `spec/eval/format-tic-tac-toe-row.yaml`.
+
+Missing named field:
+
+```genia
+format("Hello {name}!", {greeting: "Hi"})
+```
+
+Expected stderr:
+
+```text
+Error: format missing field: name
+```
+
+Expected exit code:
+
+```text
+1
+```
+
+Classification: Valid, covered by `spec/error/error-format-missing-named-field.yaml`.
+
+## Non-goals
+
+Not implemented:
+
+- Localization
+- Locale-aware formatting
+- Interpolation syntax
+- Tagged formats as stable behavior
+- `Format` as a value-template mechanism
+- Static typing or protocol behavior for `Format`
+- Implicit template application
+- Arbitrary formatter functions inside placeholders
+- User-defined placeholder renderers
+- Compile-time format validation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
 
   - Design:
       - Pipeline Semantics: design/pipeline-semantics.md
+      - Representation System and Format: design/representation-system-and-format.md
 
   - Architecture:
       - Core IR Portability: architecture/core-ir-portability.md

--- a/spec/eval/format-tic-tac-toe-row.yaml
+++ b/spec/eval/format-tic-tac-toe-row.yaml
@@ -1,0 +1,10 @@
+name: format-tic-tac-toe-row
+category: eval
+input:
+  source: |
+    format("{0} | {1} | {2}", ["X", "O", "X"])
+expected:
+  stdout: |
+    "X | O | X"
+  stderr: ""
+  exit_code: 0

--- a/tests/data/cheatsheet_core_cases.json
+++ b/tests/data/cheatsheet_core_cases.json
@@ -51,8 +51,23 @@
   },
   {
     "id": "core-format-named",
-    "source": "format(\"Hello {name}\", {name: \"Genia\"})",
-    "expected_result": "\"Hello Genia\""
+    "source": "format(\"Hello {name}!\", {name: \"Alice\"})",
+    "expected_result": "\"Hello Alice!\""
+  },
+  {
+    "id": "core-format-positional",
+    "source": "format(\"Item {0} costs {1}\", [\"apple\", \"5\"])",
+    "expected_result": "\"Item apple costs 5\""
+  },
+  {
+    "id": "core-format-escaped-braces",
+    "source": "format(\"{{key}} = {0}\", [\"value\"])",
+    "expected_result": "\"{key} = value\""
+  },
+  {
+    "id": "core-format-tic-tac-toe-row",
+    "source": "format(\"{0} | {1} | {2}\", [\"X\", \"O\", \"X\"])",
+    "expected_result": "\"X | O | X\""
   },
   {
     "id": "core-actor-call-reply",

--- a/tests/doc/test_representation_docs_171.py
+++ b/tests/doc/test_representation_docs_171.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read_text(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split()).lower()
+
+
+def assert_contains(relpath: str, excerpts: list[str]) -> None:
+    text = normalize(read_text(relpath))
+    for excerpt in excerpts:
+        assert normalize(excerpt) in text, f"{relpath} is missing required excerpt: {excerpt}"
+
+
+def test_representation_system_doc_page_exists_and_covers_contract() -> None:
+    relpath = "docs/design/representation-system-and-format.md"
+    path = ROOT / relpath
+
+    assert path.exists(), f"{relpath} must document issue #171 representation behavior"
+
+    assert_contains(
+        relpath,
+        [
+            "Representation renders values as strings for output and debugging",
+            "Representation does not change value identity",
+            "Value templates describe or constrain values",
+            "Formats describe output strings",
+            "`display(value)` returns a user-facing representation string without writing output",
+            "`debug_repr(value)` returns a debug representation string without writing output",
+            "`format(template_or_format, values)` returns a string",
+            "Named placeholders use map values",
+            "Positional placeholders use list values",
+            "Escaped braces use `{{` and `}}`",
+            "`Format(template)`",
+            "Experimental",
+            "Tags are metadata only",
+            "Localization",
+            "Interpolation syntax",
+        ],
+    )
+
+
+def test_representation_doc_page_includes_required_examples() -> None:
+    relpath = "docs/design/representation-system-and-format.md"
+    path = ROOT / relpath
+
+    assert path.exists(), f"{relpath} must exist before required examples can be verified"
+
+    assert_contains(
+        relpath,
+        [
+            'format("Hello {name}!", {name: "Alice"})',
+            '"Hello Alice!"',
+            'format("Item {0} costs {1}", ["apple", "5"])',
+            '"Item apple costs 5"',
+            'format("{{key}} = {0}", ["value"])',
+            '"{key} = value"',
+            'format("{0} | {1} | {2}", ["X", "O", "X"])',
+            '"X | O | X"',
+            'format("Hello {name}!", {greeting: "Hi"})',
+            "Error: format missing field: name",
+        ],
+    )
+
+
+def test_mkdocs_nav_includes_representation_system_page() -> None:
+    assert_contains(
+        "mkdocs.yml",
+        ["Representation System and Format: design/representation-system-and-format.md"],
+    )
+
+
+def test_authoritative_docs_capture_representation_boundaries() -> None:
+    required = [
+        "representation does not change value identity",
+        "`format(template_or_format, values)` returns a string",
+        "does not write output",
+        "does not mutate",
+        "`Format` is for output representation",
+        "`Format` is separate from value templates",
+    ]
+
+    assert_contains("GENIA_STATE.md", required)
+    assert_contains("GENIA_REPL_README.md", required)
+
+
+def test_core_cheatsheet_covers_required_representation_examples() -> None:
+    assert_contains(
+        "docs/cheatsheet/core.md",
+        [
+            "`display`, `debug_repr`, and `format` return strings",
+            "`Format(template)`",
+            "Experimental",
+            "does not affect value identity",
+            'format("Hello {name}!", {name: "Alice"})',
+            'format("Item {0} costs {1}", ["apple", "5"])',
+            'format("{{key}} = {0}", ["value"])',
+            'format("{0} | {1} | {2}", ["X", "O", "X"])',
+            "Error: format missing field: name",
+        ],
+    )
+


### PR DESCRIPTION
````md
## Summary

Documents the current Genia Representation System and `Format` behavior for issue #171.

This PR adds a focused reference page for representation/format behavior, strengthens concise source-of-truth wording, and updates the core cheatsheet with validated examples.

## Changes

- Added `docs/design/representation-system-and-format.md`
- Added the new page to MkDocs navigation
- Updated `GENIA_STATE.md` with concise authoritative representation/`Format` wording
- Updated `GENIA_REPL_README.md` with practical representation/format boundaries and a link to the focused page
- Updated `README.md` with a high-level representation helpers bullet
- Expanded `docs/cheatsheet/core.md` with required `format(...)` examples
- Updated `tests/data/cheatsheet_core_cases.json` for new runnable cheatsheet examples
- Added `spec/eval/format-tic-tac-toe-row.yaml`
- Added `tests/doc/test_representation_docs_171.py`

## Behavior documented

- Representation renders values as strings for output/debugging
- Representation does not change value identity
- `display(value)` and `debug_repr(value)` return strings and write nothing
- `format(template_or_format, values)` returns a string and does not mutate inputs
- `Format` is for output representation, not value templates
- `Format` and related helpers remain marked Experimental
- Tags are metadata only and do not affect rendering
- Missing named fields preserve the current diagnostic:
  - `Error: format missing field: name`

## Examples covered

- Named placeholder
- Positional placeholder
- Escaped braces
- Tic-tac-toe board row
- Missing-field error

## Non-goals

This PR does not add or document:

- localization
- interpolation syntax
- stable tagged formats
- runtime behavior changes
- parser changes
- new syntax
- value-template behavior changes

## Validation

```bash
uv run pytest -q tests/doc/test_representation_docs_171.py tests/unit/test_cheatsheet_core.py tests/doc/test_semantic_doc_sync.py
# 89 passed
````

```bash
uv run python -m tools.spec_runner
# Summary: total=302 passed=302 failed=0 invalid=0
```

```bash
uv run pytest -q tests/unit/test_format_first_class_168.py tests/unit/test_format_debug_mode_170.py tests/unit/test_format_tagged_values_292.py tests/unit/test_format_composition_293.py
# 58 passed
```

```bash
uv run python tools/stage_docs_for_mkdocs.py
uv run mkdocs build --strict
# Documentation built successfully.
```

## Notes

No runtime, parser, Core IR, or host adapter files were changed.

```
```
