### PR TITLE
docs/spec: reject slash field-path separators

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -192,7 +192,7 @@ CLI contract summary (actual behavior):
     - `debug_repr(value)` returns the debug representation string without writing output
     - these entry points are minimal #185 surface area; #166 owns the broader Representation System model
   - public prelude-backed string formatting helper:
-    - `format(template_or_format, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; `{name:?}` and `{0:?}` use debug rendering; it supports escaped braces with `{{` and `}}`
+    - `format(template_or_format, values)` returns a string built from `{name}` or `{0}` placeholders using display rendering; `{name:?}` and `{0:?}` use debug rendering; it supports escaped braces with `{{` and `}}`; field-path placeholders `{user.name}` / `{user.address.city}` use dot (`.`) as the canonical separator for nested map lookup (**Experimental**, #290)
     - `format(template_or_format, values)` does not write output and does not mutate the input template, `Format` value, or values map/list
     - `format` accepts either a raw string template or a `Format` value as its first argument
     - `Format` is for output representation and does not affect value identity

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1003,7 +1003,7 @@ Representation System entry points (#185, implemented):
     - `,` — comma-group numeric output (integer portion only, ASCII commas, no localization)
   - `bool` values are not numeric for spec purposes; numeric specs (`0N`, `,`) applied to bools fail deterministically
   - combined specs, bare width specs (e.g. `{n:10}`), debug spec combinations (e.g. `{x:?>10}`), and any spec not listed above are unsupported and fail with a `format-error:` prefixed error
-- Field-path placeholder resolution (#290): a missing top-level or nested segment fails with `format missing field: <path>`; a non-map intermediate fails with `format expected a map while resolving placeholder path: <path>`; invalid path syntax (empty segment, leading/trailing/double dot, brackets, calls) fails with `format invalid placeholder`.
+- Field-path placeholder resolution (#290): a missing top-level or nested segment fails with `format missing field: <path>`; a non-map intermediate fails with `format expected a map while resolving placeholder path: <path>`; invalid path syntax (empty segment, leading/trailing/double dot, slash-separated paths, brackets, calls) fails with `format invalid placeholder`; slash (`/`) is not a field-path separator and must not be used in field-path placeholders.
 - Placeholder replacements use the same user-facing display representation as `display(value)`, except where the exact debug spec `?` or another listed field spec applies.
 - Missing fields and invalid placeholders raise deterministic errors.
 - `format` does not support interpolation string syntax, localization, tag-based format selection, custom formatter protocols, list indexing in field paths, optional chaining, filters, or spec combinations beyond the listed subset.

--- a/spec/error/error-format-field-path-mixed-slash-dot.yaml
+++ b/spec/error/error-format-field-path-mixed-slash-dot.yaml
@@ -1,0 +1,10 @@
+name: error-format-field-path-mixed-slash-dot
+category: error
+input:
+  source: |
+    format("{user/name.first}", {user: {name: {first: "Ada"}}})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format invalid placeholder
+  exit_code: 1

--- a/spec/error/error-format-field-path-slash-nested.yaml
+++ b/spec/error/error-format-field-path-slash-nested.yaml
@@ -1,0 +1,10 @@
+name: error-format-field-path-slash-nested
+category: error
+input:
+  source: |
+    format("{user/address/city}", {user: {address: {city: "Bountiful"}}})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format invalid placeholder
+  exit_code: 1

--- a/spec/error/error-format-field-path-slash-separator.yaml
+++ b/spec/error/error-format-field-path-slash-separator.yaml
@@ -1,0 +1,10 @@
+name: error-format-field-path-slash-separator
+category: error
+input:
+  source: |
+    format("{user/name}", {user: {name: "Ada"}})
+expected:
+  stdout: ""
+  stderr: |
+    Error: format invalid placeholder
+  exit_code: 1

--- a/tests/spec/test_format_field_paths_290.py
+++ b/tests/spec/test_format_field_paths_290.py
@@ -24,6 +24,9 @@ REQUIRED_FORMAT_FIELD_PATH_SPECS = {
         "error-format-field-path-invalid-trailing-dot",
         "error-format-field-path-invalid-double-dot",
         "error-format-field-path-invalid-index",
+        "error-format-field-path-slash-separator",
+        "error-format-field-path-slash-nested",
+        "error-format-field-path-mixed-slash-dot",
     },
 }
 


### PR DESCRIPTION
````md
## Summary

This PR completes issue #324 by making the field-path separator policy explicit and test-covered:

- Documents that dot (`.`) is the canonical/only field-path separator.
- Explicitly rejects slash (`/`) as a field-path separator.
- Adds shared error specs for slash-separated field paths.
- Updates the field-path spec wrapper to include the new slash-rejection specs.
- Updates REPL documentation to mention dot-based `format` field-path placeholders.

No runtime source changes were needed. The existing `format` implementation already rejects slash-separated field paths.

## Scope

This PR affects `format` field-path placeholders such as:

```genia
format("{user.name}", {user: {name: "Ada"}})
````

Slash-separated field paths are invalid:

```genia
format("{user/name}", {user: {name: "Ada"}})
```

This PR does **not** change slash named access syntax such as `lhs/name`. That migration is tracked separately in issue #329.

## Files Changed

* `GENIA_STATE.md`

  * Adds slash-separated paths to invalid field-path syntax.
  * States that `/` is not a field-path separator.

* `GENIA_REPL_README.md`

  * Adds `format` field-path placeholder documentation using dot syntax.

* `tests/spec/test_format_field_paths_290.py`

  * Includes the new slash-rejection shared specs.

* `spec/error/error-format-field-path-slash-separator.yaml`

* `spec/error/error-format-field-path-slash-nested.yaml`

* `spec/error/error-format-field-path-mixed-slash-dot.yaml`

  * Assert slash-separated and mixed slash/dot field paths fail with `format invalid placeholder`.

## Tests

```bash
uv run pytest -q tests/spec/test_format_field_paths_290.py tests/unit/test_format_field_paths_290.py
```

Result:

```text
20 passed
```

## Notes

The test phase added regression coverage rather than failing-first tests because the runtime behavior was already correct. This PR locks that behavior down in shared specs and aligns the canonical docs with the implemented behavior.

```
```
