### PR TITLE
Feature/issue 327 clarify slash operator core ir wording is not field path lookup

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -144,7 +144,7 @@ CLI contract summary (actual behavior):
 - map literals (`{name: "m"}`, `{"name": "m"}`, `{}`)
 - module import forms: `import mod`, `import mod as alias`
   - imports are cached by module name; repeated imports/aliases reuse the same module value
-- phase-1 slash named accessor: `mod/name`, `map/name` (bare identifier RHS only)
+- phase-1 slash named accessor: `mod/name`, `map/name` (bare identifier RHS only; not general field-path lookup)
 - callable data (phase 1 subset):
   - map lookup calls: `m(key)`, `m(key, default)`
   - string projector calls over maps: `"key"(m)`, `"key"(m, default)`

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -249,7 +249,7 @@ Required constraints:
 - The frozen minimal portable Core IR contract is documented in `docs/architecture/core-ir-portability.md`.
 - AST->IR lowering output must stay inside the frozen portable `Ir*` node families.
 - Host-local post-lowering optimized nodes (for example `IrListTraversalLoop`) are allowed only after host-local optimization passes and are not part of the minimal shared Core IR contract.
-- Named slash access `lhs/name` lowers as `IrBinary(op=SLASH)`; hosts must not introduce a separate `IrSlashAccess` node.
+- Named slash access `lhs/name` lowers as `IrBinary(op=SLASH)`; this is narrow named access, not general field-path lookup, and hosts must not introduce a separate `IrSlashAccess` node.
 - `none(reason, ctx)` lowers as `IrOptionNone`; the reason argument is wrapped in `IrQuote` (not evaluated) — bare `none` produces `reason=null`.
 - `IrAssign` appears directly in `IrBlock.exprs`; it is not wrapped in `IrExprStmt`.
 
@@ -302,7 +302,7 @@ Pipeline invariant:
 
 Slash accessor invariants (phase 1):
 
-- `lhs/name` is narrow named access, not general member access
+- `lhs/name` is narrow named access, not general member access or field-path lookup
 - only module values and map values are valid LHS kinds
 - for maps: missing key returns `none("missing-key", {key: <name>})`
 - for modules: missing export raises a clear error

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -55,7 +55,7 @@ Scaffolded or planned, not implemented as hosts:
 - Shared host contract is **Partial**: the contract categories above are documented, and executable shared spec coverage is implemented for `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior in the Python reference host. Other hosts are not implemented.
 - Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist for `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior in this phase.
 - Flow behavior is implemented in Python, and shared semantic-spec coverage for flow is now **active but partial**. Current flow shared coverage is limited to first-wave cases proving lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `evolve(init, f)` progression, `refine(..steps)` behavior, `rules(..fns)` compatibility behavior, `step_*` / `rule_*` equivalence, the `rules()` identity stage, selected rule result defaulting/no-effect behavior, focused Flow `map` / `filter` / `scan` coverage, selected Seq-compatible `each` / `collect` / `run` / `reduce` terminal behavior, and a resource lifecycle case (`seq-finalization-drop-take`) proving Flow-aware `drop |> take |> collect` composition with bounded pulling and correct output. Advanced Flow behavior is not covered by shared semantic specs in this phase.
-- IR stability remains **Partial**: the minimal portable Core IR contract is documented with field-level lowering invariants (bare `none` reason=null, `none()` reason wrapped as `IrQuote`, `lhs/name` → `IrBinary(op=SLASH)`, `IrAssign` placement in `IrBlock.exprs`, optional fields), the Python runtime guards that boundary, and shared semantic-spec case coverage now validates the full portable node family in the Python reference host, including `quasiquote` bodies with `unquote` and `unquote_splicing` in list context.
+- IR stability remains **Partial**: the minimal portable Core IR contract is documented with field-level lowering invariants (bare `none` reason=null, `none()` reason wrapped as `IrQuote`, `lhs/name` -> `IrBinary(op=SLASH)` for narrow named slash access, not general field-path lookup, `IrAssign` placement in `IrBlock.exprs`, optional fields), the Python runtime guards that boundary, and shared semantic-spec case coverage now validates the full portable node family in the Python reference host, including `quasiquote` bodies with `unquote` and `unquote_splicing` in list context.
 
 **Explicit limitations:**
 
@@ -616,7 +616,7 @@ Pipeline (Phase 2) evaluation model:
   - exact fixed arity beats varargs
   - if multiple varargs candidates match and neither is more specific, runtime raises `TypeError("Ambiguous function resolution")`
 - slash named accessor (phase 1):
-  - `lhs/name` uses narrow named access when RHS is a bare identifier
+  - `lhs/name` uses narrow named access when RHS is a bare identifier; it is not general field-path lookup
   - supported LHS runtime kinds: module values, map values
   - map missing key => `none("missing-key", {key: "name"})`
   - module missing export => clear error

--- a/README.md
+++ b/README.md
@@ -803,7 +803,7 @@ person = { name: "Matthew", age: 42 }
 - missing map keys return `none("missing-key", {key: "middle"})`
 - module named access returns exported bindings
 - missing module exports raise a clear error
-- `/` access is narrow: only `lhs/name` (bare identifier RHS), not general member/index access
+- `/` access is narrow: only `lhs/name` (bare identifier RHS), not general member/index access or field-path lookup
 - map slash access is still supported for compatibility, but new code should prefer canonical maybe-aware lookup:
 
 ```genia

--- a/docs/architecture/core-ir-portability.md
+++ b/docs/architecture/core-ir-portability.md
@@ -69,7 +69,7 @@ Hosts must preserve these lowering invariants:
 - `nil` lowers to `IrOptionNone(IrLiteral("nil"), None, ...)`
 - bare `none` lowers to `IrOptionNone` with `reason=null` and `context=null`
 - `none(reason, ctx)` — the reason argument is wrapped in `IrQuote` (not lowered); it is a quoted label, not an evaluated expression
-- named slash access `lhs/name` lowers as `IrBinary(op=SLASH, left=IrVar(lhs), right=IrVar(name))` — hosts must not introduce a separate `IrSlashAccess` node
+- named slash access `lhs/name` lowers as `IrBinary(op=SLASH, left=IrVar(lhs), right=IrVar(name))` — this is narrow named access, not general field-path lookup, and hosts must not introduce a separate `IrSlashAccess` node
 - case/function patterns lower into explicit `IrPat*` pattern families
 - `none` in pattern position lowers as `IrPatNone(reason=null, context=null)`, distinct from expression-position `IrOptionNone`
 - `IrAssign` is a statement-level node; it appears directly in `IrBlock.exprs` and at the top level of a program — it is not wrapped in `IrExprStmt`

--- a/docs/design/ir.md
+++ b/docs/design/ir.md
@@ -139,7 +139,8 @@ Spec coverage: `spec/ir/option-constructors.yaml`, `spec/ir/none-bare.yaml`
 ### IrBinary — SLASH operator
 
 Named slash access `lhs/name` lowers as `IrBinary(op=SLASH, left=IrVar(lhs), right=IrVar(name))`.
-This is the portable Core IR form. Hosts must not introduce a separate `IrSlashAccess` node.
+This is the portable Core IR form for narrow named access, not general field-path lookup.
+Hosts must not introduce a separate `IrSlashAccess` node.
 
 Spec coverage: `spec/ir/slash-accessor.yaml`, `spec/ir/import-pipeline-stage.yaml`
 

--- a/spec/ir/slash-accessor.yaml
+++ b/spec/ir/slash-accessor.yaml
@@ -1,6 +1,6 @@
 name: slash-accessor
 category: ir
-description: Named slash access lowers as IrBinary with op SLASH; this is the portable Core IR form
+description: Named slash access lowers as IrBinary with op SLASH; this is narrow named access, not general field-path lookup
 input:
   source: |
     person/name

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -516,6 +516,10 @@ def test_arch_doc_lowering_invariants_cover_slash_as_ir_binary() -> None:
         "docs/architecture/core-ir-portability.md must document that "
         "named slash access (lhs/name) lowers as IrBinary(op=SLASH)"
     )
+    assert "not general field-path lookup" in arch, (
+        "docs/architecture/core-ir-portability.md must clarify that "
+        "IrBinary(op=SLASH) is named slash access, not field-path lookup"
+    )
 
 
 def test_arch_doc_lowering_invariants_cover_bare_none_null_reason() -> None:
@@ -769,4 +773,8 @@ def test_rules_doc_8_4_mentions_slash_lowering_form() -> None:
     section = section_after[:next_section] if next_section > 0 else section_after
     assert "SLASH" in section or "IrBinary" in section, (
         "GENIA_RULES.md §8.4 must document the SLASH accessor lowering form (IrBinary(op=SLASH))"
+    )
+    assert "not general field-path lookup" in section, (
+        "GENIA_RULES.md §8.4 must clarify that SLASH lowering is named slash access, "
+        "not field-path lookup"
     )


### PR DESCRIPTION
````md
## Summary

Clarifies Core IR wording for named slash access so it cannot be confused with general field-path lookup.

This PR documents that:

- `lhs/name` is **narrow named slash access**
- `lhs/name` lowers to portable Core IR as `IrBinary(op=SLASH)`
- this is **not** general field-path lookup
- hosts must not introduce a portable `IrSlashAccess` node
- slash remains invalid as a format placeholder field-path separator

No parser, runtime, evaluator, host adapter, or Core IR behavior changed.

## Files Updated

- `GENIA_STATE.md`
- `GENIA_RULES.md`
- `GENIA_REPL_README.md`
- `README.md`
- `docs/architecture/core-ir-portability.md`
- `docs/design/ir.md`
- `spec/ir/slash-accessor.yaml`
- `tests/doc/test_semantic_doc_sync.py`

## Validation

```bash
uv run pytest -q tests/doc/test_semantic_doc_sync.py
````

Result:

```text
66 passed
```

```bash
uv run pytest -q tests/unit/test_ir.py::test_slash_standalone_lowers_as_ir_binary_slash tests/spec/test_format_field_paths_290.py
```

Result:

```text
3 passed
```

## Notes

This is a documentation/protected-regression clarification only. It preserves the existing slash accessor behavior and keeps format field paths dot-based.

```
::contentReference[oaicite:0]{index=0}
```
