### PR TITLE
Feature/issue 325 audit and replace slash field path examples with dot paths

### DIFF
--- a/docs/design/representation-system-and-format.md
+++ b/docs/design/representation-system-and-format.md
@@ -47,11 +47,13 @@ The first argument may be:
 Supported placeholder forms:
 
 - Named placeholders use map values: `{name}`
+- Field-path placeholders use dot-separated nested map lookup: `{user.name}`, `{user.address.city}`
 - Positional placeholders use list values: `{0}`
 - Debug placeholders use debug representation: `{name:?}`, `{0:?}`
 - Escaped braces use `{{` and `}}`
 
 Plain placeholders use display rendering. Debug placeholders use the same debug rendering as `debug_repr(value)`.
+Slash is not a field-path separator.
 
 `format(...)` is side-effect-free at the language surface: it does not write output and does not mutate the template, `Format` value, or values map/list.
 
@@ -100,6 +102,20 @@ Result:
 ```
 
 Classification: Valid, covered by `spec/eval/format-positional-basic.yaml`.
+
+Field-path placeholder:
+
+```genia
+format("{user.name} lives in {user.address.city}", {user: {name: "Ada", address: {city: "Bountiful"}}})
+```
+
+Result:
+
+```text
+"Ada lives in Bountiful"
+```
+
+Classification: Valid, covered by `spec/eval/format-field-path-multi-nested.yaml`.
 
 Escaped braces:
 

--- a/tests/doc/test_field_path_examples_325.py
+++ b/tests/doc/test_field_path_examples_325.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+DOC_PATHS = [
+    "GENIA_STATE.md",
+    "GENIA_REPL_README.md",
+    "README.md",
+    "docs/cheatsheet/core.md",
+    "docs/design/representation-system-and-format.md",
+]
+
+SLASH_PLACEHOLDER_RE = re.compile(
+    r"\{[A-Za-z_][A-Za-z0-9_]*(?:/[A-Za-z_][A-Za-z0-9_]*)+(?:\.[A-Za-z_][A-Za-z0-9_]*)?\}"
+)
+
+
+def read_text(relpath: str) -> str:
+    return (ROOT / relpath).read_text(encoding="utf-8")
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_issue_325_representation_doc_uses_dot_field_path_examples() -> None:
+    relpath = "docs/design/representation-system-and-format.md"
+    text = normalize(read_text(relpath))
+
+    required_excerpts = [
+        "Field-path placeholders use dot-separated nested map lookup: `{user.name}`, `{user.address.city}`",
+        'format("{user.name} lives in {user.address.city}", {user: {name: "Ada", address: {city: "Bountiful"}}})',
+        '"Ada lives in Bountiful"',
+        "Classification: Valid, covered by `spec/eval/format-field-path-multi-nested.yaml`.",
+    ]
+
+    missing = [excerpt for excerpt in required_excerpts if normalize(excerpt) not in text]
+    assert missing == []
+
+
+def test_issue_325_public_docs_do_not_use_slash_field_path_placeholders() -> None:
+    offenders: dict[str, list[str]] = {}
+
+    for relpath in DOC_PATHS:
+        matches = sorted(set(SLASH_PLACEHOLDER_RE.findall(read_text(relpath))))
+        if matches:
+            offenders[relpath] = matches
+
+    assert offenders == {}


### PR DESCRIPTION
````md
## Summary

This PR completes issue #325 by aligning field-path placeholder documentation with the canonical dot-path form.

It updates `docs/design/representation-system-and-format.md` to document dot-separated field-path placeholders such as `{user.name}` and `{user.address.city}`, explicitly clarifies that slash is not a field-path separator, and adds a concrete example backed by existing shared spec coverage.

## What changed

- Added dot field-path placeholder examples to the representation/format design doc.
- Added explicit wording that slash is not a field-path separator.
- Added a valid nested field-path example:

  ```genia
  format("{user.name} lives in {user.address.city}", {user: {name: "Ada", address: {city: "Bountiful"}}})
````

Expected result:

```text
"Ada lives in Bountiful"
```

* Added regression coverage in `tests/doc/test_field_path_examples_325.py`.
* Preserved slash operator / Core IR slash-lowering behavior and documentation.

## What did not change

* No parser changes.
* No runtime changes.
* No Core IR changes.
* No format implementation changes.
* No broad slash-to-dot replacement.

Slash remains valid where it is intentionally the slash operator or Core IR slash lowering, such as `lhs/name -> IrBinary(op=SLASH)`.

## Tests

```bash
pytest -q tests/doc/test_field_path_examples_325.py
# 2 passed
```

```bash
pytest -q tests/doc/test_representation_docs_171.py tests/doc/test_field_path_examples_325.py
# 7 passed
```

```bash
pytest -q tests/doc/test_field_path_examples_325.py tests/doc/test_semantic_doc_sync.py
# 68 passed
```

## Notes

Remaining slash placeholder examples in `spec/error/error-format-field-path-slash-separator.yaml` and `spec/error/error-format-field-path-slash-nested.yaml` are intentional error-spec cases showing that slash placeholders are invalid.

```
```
