### PR TITLE
Feature/issue 329 named access make dot the canonical named access separator

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -144,7 +144,7 @@ CLI contract summary (actual behavior):
 - map literals (`{name: "m"}`, `{"name": "m"}`, `{}`)
 - module import forms: `import mod`, `import mod as alias`
   - imports are cached by module name; repeated imports/aliases reuse the same module value
-- phase-1 slash named accessor: `mod/name`, `map/name` (bare identifier RHS only; not general field-path lookup)
+- named accessor (phase 1): `lhs.name` is the canonical form; legacy `lhs/name` is compatibility only (bare identifier RHS only; not general field-path lookup)
 - callable data (phase 1 subset):
   - map lookup calls: `m(key)`, `m(key, default)`
   - string projector calls over maps: `"key"(m)`, `"key"(m, default)`

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -249,7 +249,7 @@ Required constraints:
 - The frozen minimal portable Core IR contract is documented in `docs/architecture/core-ir-portability.md`.
 - AST->IR lowering output must stay inside the frozen portable `Ir*` node families.
 - Host-local post-lowering optimized nodes (for example `IrListTraversalLoop`) are allowed only after host-local optimization passes and are not part of the minimal shared Core IR contract.
-- Named slash access `lhs/name` lowers as `IrBinary(op=SLASH)`; this is narrow named access, not general field-path lookup, and hosts must not introduce a separate `IrSlashAccess` node.
+- Dot is the canonical named-access separator: `lhs.name` lowers as `IrBinary(op=SLASH)`. This is narrow named access, not general field-path lookup, and hosts must not introduce a separate access node. Legacy `lhs/name` remains compatibility syntax only.
 - `none(reason, ctx)` lowers as `IrOptionNone`; the reason argument is wrapped in `IrQuote` (not evaluated) — bare `none` produces `reason=null`.
 - `IrAssign` appears directly in `IrBlock.exprs`; it is not wrapped in `IrExprStmt`.
 
@@ -260,7 +260,7 @@ Implemented operators are limited to:
 - unary: `-`, `!`
 - binary: `+ - * / % < <= > >= == != && ||`
 - pipeline: `|>`
-- slash named accessor form: `lhs/name` (RHS bare identifier only)
+- named accessor form: canonical `lhs.name`; legacy compatibility `lhs/name` (RHS bare identifier only)
 
 Pipeline invariant:
 
@@ -302,7 +302,8 @@ Pipeline invariant:
 
 Slash accessor invariants (phase 1):
 
-- `lhs/name` is narrow named access, not general member access or field-path lookup
+- `lhs.name` is canonical narrow named access, not general member access or field-path lookup
+- legacy `lhs/name` compatibility remains accepted for the same narrow access shape
 - only module values and map values are valid LHS kinds
 - for maps: missing key returns `none("missing-key", {key: <name>})`
 - for modules: missing export raises a clear error

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -55,7 +55,7 @@ Scaffolded or planned, not implemented as hosts:
 - Shared host contract is **Partial**: the contract categories above are documented, and executable shared spec coverage is implemented for `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior in the Python reference host. Other hosts are not implemented.
 - Semantic Spec System is **Experimental**: the file format, runner, and initial case inventory exist for `eval`, `ir`, `cli`, first-wave `flow`, initial `error`, and initial `parse` behavior in this phase.
 - Flow behavior is implemented in Python, and shared semantic-spec coverage for flow is now **active but partial**. Current flow shared coverage is limited to first-wave cases proving lazy pull-based observable behavior through early termination, single-use enforcement, deterministic outputs, `evolve(init, f)` progression, `refine(..steps)` behavior, `rules(..fns)` compatibility behavior, `step_*` / `rule_*` equivalence, the `rules()` identity stage, selected rule result defaulting/no-effect behavior, focused Flow `map` / `filter` / `scan` coverage, selected Seq-compatible `each` / `collect` / `run` / `reduce` terminal behavior, and a resource lifecycle case (`seq-finalization-drop-take`) proving Flow-aware `drop |> take |> collect` composition with bounded pulling and correct output. Advanced Flow behavior is not covered by shared semantic specs in this phase.
-- IR stability remains **Partial**: the minimal portable Core IR contract is documented with field-level lowering invariants (bare `none` reason=null, `none()` reason wrapped as `IrQuote`, `lhs/name` -> `IrBinary(op=SLASH)` for narrow named slash access, not general field-path lookup, `IrAssign` placement in `IrBlock.exprs`, optional fields), the Python runtime guards that boundary, and shared semantic-spec case coverage now validates the full portable node family in the Python reference host, including `quasiquote` bodies with `unquote` and `unquote_splicing` in list context.
+- IR stability remains **Partial**: the minimal portable Core IR contract is documented with field-level lowering invariants (bare `none` reason=null, `none()` reason wrapped as `IrQuote`, canonical `lhs.name` -> `IrBinary(op=SLASH)` for narrow named access, with legacy `lhs/name` retained as compatibility; neither form is general field-path lookup, `IrAssign` placement in `IrBlock.exprs`, optional fields), the Python runtime guards that boundary, and shared semantic-spec case coverage now validates the full portable node family in the Python reference host, including `quasiquote` bodies with `unquote` and `unquote_splicing` in list context.
 
 **Explicit limitations:**
 
@@ -615,8 +615,9 @@ Pipeline (Phase 2) evaluation model:
 - resolution behavior:
   - exact fixed arity beats varargs
   - if multiple varargs candidates match and neither is more specific, runtime raises `TypeError("Ambiguous function resolution")`
-- slash named accessor (phase 1):
-  - `lhs/name` uses narrow named access when RHS is a bare identifier; it is not general field-path lookup
+- named accessor (phase 1):
+  - `lhs.name` is the canonical narrow named-access form; it is not general field-path lookup
+  - legacy `lhs/name` compatibility is still accepted when RHS is a bare identifier
   - supported LHS runtime kinds: module values, map values
   - map missing key => `none("missing-key", {key: "name"})`
   - module missing export => clear error

--- a/README.md
+++ b/README.md
@@ -792,19 +792,21 @@ import python.json as pyjson
 
 - raises `ValueError("python.json/loads invalid JSON: ...")`
 
-### Named slash access (`/`)
+### Named access
+
+Dot is the canonical named-access separator:
 
 ```genia
 person = { name: "Matthew", age: 42 }
-[person/name, person/age, person/middle]
+[person.name, person.age, person.middle]
 ```
 
+- `lhs.name` is the canonical narrow named-access form (bare identifier RHS only; not general field-path lookup)
 - map named access returns the value when present
 - missing map keys return `none("missing-key", {key: "middle"})`
 - module named access returns exported bindings
 - missing module exports raise a clear error
-- `/` access is narrow: only `lhs/name` (bare identifier RHS), not general member/index access or field-path lookup
-- map slash access is still supported for compatibility, but new code should prefer canonical maybe-aware lookup:
+- legacy `lhs/name` slash access is retained as compatibility only; new code should prefer canonical dot access or maybe-aware lookup:
 
 ```genia
 get("name", person)

--- a/docs/architecture/core-ir-portability.md
+++ b/docs/architecture/core-ir-portability.md
@@ -69,7 +69,7 @@ Hosts must preserve these lowering invariants:
 - `nil` lowers to `IrOptionNone(IrLiteral("nil"), None, ...)`
 - bare `none` lowers to `IrOptionNone` with `reason=null` and `context=null`
 - `none(reason, ctx)` — the reason argument is wrapped in `IrQuote` (not lowered); it is a quoted label, not an evaluated expression
-- named slash access `lhs/name` lowers as `IrBinary(op=SLASH, left=IrVar(lhs), right=IrVar(name))` — this is narrow named access, not general field-path lookup, and hosts must not introduce a separate `IrSlashAccess` node
+- dot is the canonical named-access separator: `lhs.name` lowers as `IrBinary(op=SLASH, left=IrVar(lhs), right=IrVar(name))`; legacy `lhs/name` compatibility lowers to the same shape — this is narrow named access, not general field-path lookup, and hosts must not introduce a separate access node
 - case/function patterns lower into explicit `IrPat*` pattern families
 - `none` in pattern position lowers as `IrPatNone(reason=null, context=null)`, distinct from expression-position `IrOptionNone`
 - `IrAssign` is a statement-level node; it appears directly in `IrBlock.exprs` and at the top level of a program — it is not wrapped in `IrExprStmt`

--- a/docs/contract/semantic_facts.json
+++ b/docs/contract/semantic_facts.json
@@ -13,5 +13,6 @@
   "host_status": "Python is the only implemented host today.",
   "naming_rule": "new `?`-suffixed APIs are boolean-returning; `get?` remains the current compatibility exception.",
   "annotation_builtins": "`@doc`, `@meta`, `@since`, `@deprecated`, and `@category`",
-  "canonical_format_field_path_separator": "Dot (`.`) is the canonical field-path separator for representation/format placeholders; slash (`/`) is not the format field-path separator and remains limited to existing slash operator/Core IR wording."
+  "canonical_format_field_path_separator": "Dot (`.`) is the canonical field-path separator for representation/format placeholders; slash (`/`) is not the format field-path separator and remains limited to existing slash operator/Core IR wording.",
+  "canonical_named_access_separator": "Dot (`.`) is the canonical named-access separator; legacy slash named access is retained only as compatibility and is not general field-path lookup."
 }

--- a/docs/design/ir.md
+++ b/docs/design/ir.md
@@ -138,11 +138,12 @@ Spec coverage: `spec/ir/option-constructors.yaml`, `spec/ir/none-bare.yaml`
 
 ### IrBinary — SLASH operator
 
-Named slash access `lhs/name` lowers as `IrBinary(op=SLASH, left=IrVar(lhs), right=IrVar(name))`.
+Canonical named access `lhs.name` lowers as `IrBinary(op=SLASH, left=IrVar(lhs), right=IrVar(name))`.
+Legacy `lhs/name` compatibility lowers to the same portable Core IR shape.
 This is the portable Core IR form for narrow named access, not general field-path lookup.
-Hosts must not introduce a separate `IrSlashAccess` node.
+Hosts must not introduce a separate access node.
 
-Spec coverage: `spec/ir/slash-accessor.yaml`, `spec/ir/import-pipeline-stage.yaml`
+Spec coverage: `spec/ir/dot-named-access.yaml`, `spec/ir/slash-accessor.yaml`, `spec/ir/import-pipeline-stage.yaml`
 
 ### IrAssign placement
 

--- a/spec/ir/dot-named-access.yaml
+++ b/spec/ir/dot-named-access.yaml
@@ -1,0 +1,18 @@
+name: dot-named-access
+category: ir
+description: Canonical dot named access lowers through the existing narrow named-access IR shape
+input:
+  source: |
+    person.name
+expected:
+  ir:
+    - node: IrExprStmt
+      expr:
+        node: IrBinary
+        left:
+          node: IrVar
+          name: person
+        op: SLASH
+        right:
+          node: IrVar
+          name: name

--- a/spec/ir/slash-accessor.yaml
+++ b/spec/ir/slash-accessor.yaml
@@ -1,6 +1,6 @@
 name: slash-accessor
 category: ir
-description: Named slash access lowers as IrBinary with op SLASH; this is narrow named access, not general field-path lookup
+description: "Legacy compatibility: slash named access lowers as IrBinary with op SLASH (dot is the canonical source form); this is narrow named access, not general field-path lookup"
 input:
   source: |
     person/name

--- a/spec/parse/parse-decimal-literal-regression.yaml
+++ b/spec/parse/parse-decimal-literal-regression.yaml
@@ -1,0 +1,11 @@
+name: parse-decimal-literal-regression
+category: parse
+description: Decimal numbers remain numeric literals, not dot named access
+input:
+  source: "1.2"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Literal
+      value: 1.2

--- a/spec/parse/parse-dot-named-access-trailing-dot-error.yaml
+++ b/spec/parse/parse-dot-named-access-trailing-dot-error.yaml
@@ -1,0 +1,10 @@
+name: parse-dot-named-access-trailing-dot-error
+category: parse
+description: Dot named access requires a name segment after the dot
+input:
+  source: "person."
+expected:
+  parse:
+    kind: error
+    type: SyntaxError
+    message: "named access"

--- a/spec/parse/parse-dot-named-access.yaml
+++ b/spec/parse/parse-dot-named-access.yaml
@@ -1,0 +1,17 @@
+name: parse-dot-named-access
+category: parse
+description: Canonical dot named access parses as narrow named access
+input:
+  source: "person.name"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Binary
+      op: /
+      left:
+        kind: Var
+        name: person
+      right:
+        kind: Var
+        name: name

--- a/src/genia/parser.py
+++ b/src/genia/parser.py
@@ -778,6 +778,8 @@ class Parser:
                 if self.at("LPAREN"):
                     return self.finish_none_expr(tok)
                 return NoneOption(span=self.span_for_tokens(tok, tok))
+            if "." in tok.text:
+                return self.parse_dotted_identifier_expr(tok)
             return Var(tok.text, span=self.span_for_tokens(tok, tok))
         if tok.kind in ("MINUS", "BANG"):
             self.i += 1
@@ -820,6 +822,20 @@ class Parser:
         if tok.kind == "LBRACE":
             return self.parse_brace_expr()
         raise SyntaxError(f"Unexpected token {tok.text!r} ({tok.kind}) at {tok.pos}")
+
+    def parse_dotted_identifier_expr(self, tok: Token) -> Node:
+        parts = tok.text.split(".")
+        if len(parts) == 2 and all(parts):
+            span = self.span_for_tokens(tok, tok)
+            return Binary(
+                Var(parts[0], span=span),
+                "SLASH",
+                Var(parts[1], span=span),
+                span=span,
+            )
+        if parts and parts[-1] == "":
+            raise SyntaxError(f"named access requires an identifier after '.' at {tok.pos}")
+        return Var(tok.text, span=self.span_for_tokens(tok, tok))
 
     def parse_brace_expr(self) -> Node:
         save = self.i

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -34,6 +34,7 @@ def normalize(text: str) -> str:
 
 FACTS = json.loads(FACTS_PATH.read_text(encoding="utf-8"))
 CANONICAL_FIELD_PATH_SEPARATOR_FACT = "canonical_format_field_path_separator"
+CANONICAL_NAMED_ACCESS_SEPARATOR_FACT = "canonical_named_access_separator"
 
 
 def test_semantic_facts_file_stays_small_and_complete() -> None:
@@ -53,9 +54,10 @@ def test_semantic_facts_file_stays_small_and_complete() -> None:
         "naming_rule",
         "annotation_builtins",
         CANONICAL_FIELD_PATH_SEPARATOR_FACT,
+        CANONICAL_NAMED_ACCESS_SEPARATOR_FACT,
     }
     assert set(FACTS) == expected_keys
-    assert len(FACTS) <= 17, "semantic facts surface should stay intentionally small"
+    assert len(FACTS) <= 18, "semantic facts surface should stay intentionally small"
 
 
 def test_authoritative_docs_capture_pipeline_option_contract() -> None:
@@ -600,6 +602,30 @@ def test_arch_doc_lowering_invariants_cover_slash_as_ir_binary() -> None:
         "docs/architecture/core-ir-portability.md must clarify that "
         "IrBinary(op=SLASH) is named slash access, not field-path lookup"
     )
+
+
+def test_authoritative_docs_record_dot_as_canonical_named_access_separator() -> None:
+    state = read_text("GENIA_STATE.md")
+    rules = read_text("GENIA_RULES.md")
+    arch = read_text("docs/architecture/core-ir-portability.md")
+    design = read_text("docs/design/ir.md")
+
+    for relpath, text in {
+        "GENIA_STATE.md": state,
+        "GENIA_RULES.md": rules,
+        "docs/architecture/core-ir-portability.md": arch,
+        "docs/design/ir.md": design,
+    }.items():
+        normalized = normalize(text)
+        assert "dot" in normalized and "canonical" in normalized and "named access" in normalized, (
+            f"{relpath} must state that dot is the canonical named-access separator"
+        )
+        assert "lhs.name" in text or "person.name" in text, (
+            f"{relpath} must show the canonical dot named-access source form"
+        )
+        assert "legacy" in normalized or "compatibility" in normalized, (
+            f"{relpath} must label slash named access as legacy/compatibility if retained"
+        )
 
 
 def test_arch_doc_lowering_invariants_cover_bare_none_null_reason() -> None:

--- a/tests/unit/test_ir.py
+++ b/tests/unit/test_ir.py
@@ -312,6 +312,19 @@ def test_slash_standalone_lowers_as_ir_binary_slash():
     assert expr_stmt.expr.right.name == "name"
 
 
+def test_dot_named_access_lowers_as_existing_named_access_ir_shape():
+    ast_nodes = Parser(lex("person.name")).parse_program()
+    ir_nodes = lower_program(ast_nodes)
+    expr_stmt = ir_nodes[0]
+    assert isinstance(expr_stmt, IrExprStmt)
+    assert isinstance(expr_stmt.expr, IrBinary)
+    assert expr_stmt.expr.op == "SLASH"
+    assert isinstance(expr_stmt.expr.left, IrVar)
+    assert expr_stmt.expr.left.name == "person"
+    assert isinstance(expr_stmt.expr.right, IrVar)
+    assert expr_stmt.expr.right.name == "name"
+
+
 def test_ir_assign_in_block_not_wrapped_in_ir_expr_stmt():
     ast_nodes = Parser(lex("{ x = 1\n x }")).parse_program()
     ir_nodes = lower_program(ast_nodes)

--- a/tests/unit/test_modules_phase1.py
+++ b/tests/unit/test_modules_phase1.py
@@ -54,6 +54,18 @@ def test_map_named_accessor_and_missing_returns_nil(run):
     assert format_debug(result[2]) == 'none("missing-key", {key: "middle"})'
 
 
+def test_dot_named_accessor_reuses_existing_map_and_module_behavior(run):
+    src = """
+    import math
+    person = { name: "Matthew", age: 42 }
+    [person.name, person.age, person.middle, math.pi, math.inc(2)]
+    """
+    result = run(src)
+    assert result[0:2] == ["Matthew", 42]
+    assert format_debug(result[2]) == 'none("missing-key", {key: "middle"})'
+    assert result[3:] == [pytest.approx(3.141592653589793), 3]
+
+
 def test_named_accessor_invalid_lhs_type_errors(run):
     with pytest.raises(TypeError, match="named accessor '/' is only supported for map and module values"):
         run("42/foo")


### PR DESCRIPTION
## Summary

Implements issue #329 by making dot (`.`) the canonical named-access separator.

This change adds canonical `lhs.name` support while retaining legacy `lhs/name` compatibility. Dot named access lowers through the existing narrow named-access IR shape, `IrBinary(op=SLASH)`, so this is a source-syntax canonicalization rather than a broader Core IR redesign.

## What changed

- Added canonical dot named access:
  - `person.name`
  - `mod.name`
- Retained legacy slash named access as compatibility only:
  - `person/name`
  - `mod/name`
- Added shared specs for dot named access parsing/lowering.
- Added regression coverage for:
  - decimal literals like `1.2`
  - malformed trailing-dot access like `person.`
  - runtime reuse of existing map/module named-access behavior
- Updated authoritative docs to teach dot as canonical.
- Clarified `spec/ir/slash-accessor.yaml` as legacy compatibility.
- Added semantic doc guardrails for the canonical named-access separator.

## Important behavior notes

- `lhs.name` is now the canonical source form.
- `lhs/name` remains supported only as legacy compatibility.
- Both forms are narrow named access with a bare identifier RHS.
- This does **not** add general field-path lookup, nested dot paths, object/member dispatch, template access, or a new IR node.
- Dot named access currently lowers to the existing `IrBinary(op=SLASH)` portability shape.

## Validation

Ran:

```bash
uv run pytest -q tests/doc/test_semantic_doc_sync.py tests/unit/test_ir.py tests/unit/test_modules_phase1.py
uv run python -m tools.spec_runner
uv run pytest -q

Results reported in handoffs:

Focused tests passed
Spec runner: 321 passed
Full suite: 2323 passed