### PR TITLE
Feature/issue 113 named patterns lower reusable patterns to outcome matcher functions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,22 @@
       "Bash(sed -n '3385,3410p' src/genia/interpreter.py)",
       "Bash(sed -n '3555,3615p' src/genia/interpreter.py)",
       "Bash(sed -n '8073,8085p' src/genia/interpreter.py)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./.git/**)",
+      "Read(./.venv/**)",
+      "Read(./node_modules/**)",
+      "Read(./dist/**)",
+      "Read(./build/**)",
+      "Read(./site/**)",
+      "Read(./htmlcov/**)",
+      "Read(./.pytest_cache/**)",
+      "Read(./.mypy_cache/**)",
+      "Read(./.ruff_cache/**)",
+      "Read(./.coverage)",
+      "Read(./.genia/process/tmp/**)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,7 @@
       "Read(./.mypy_cache/**)",
       "Read(./.ruff_cache/**)",
       "Read(./.coverage)",
-      "Read(./.genia/process/tmp/**)"
+      "Read(./.genia/process/tmp/cache/**)"
     ]
   }
 }

--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -159,6 +159,7 @@ CLI contract summary (actual behavior):
   - rest pattern `..rest` / `.._`
   - duplicate-binding equality semantics (`[x, x]`)
   - guards with `?`
+  - named reusable patterns (`pattern Name(value) = body` / `Name(inner_pattern)`) — Experimental; matcher must return `some(...)`, `none(...)`, or `err(...)`; `err(...)` does not fall through as a miss
 - case expressions in function bodies and as final expression in a block
 - conditionals expressed only through pattern matching in function definitions/case expressions; lambdas can pattern-match a single parameter arm but do not support multi-arm lambda syntax
 - function resolution with fixed arity + varargs precedence

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -50,6 +50,7 @@ Supported patterns:
 - tuple pattern
 - list pattern with optional rest
 - map pattern (string-keyed entries; partial-by-default)
+- named reusable pattern (`Name(inner_pattern)`) — Experimental
 
 Required constraints:
 
@@ -63,6 +64,23 @@ Required constraints:
   - `*`, `?`, `[abc]`, `[a-z]`, `[!abc]`
   - escapes: `\*`, `\?`, `\[`, `\]`, `\\`
 - malformed glob classes must raise deterministic syntax errors
+
+## 6.1) Named reusable pattern invariants (Experimental)
+
+- `pattern Name(value) = body` declares a named pattern at top level with exactly one matcher parameter
+- `pattern Name() = body` and `pattern Name(a, b) = body` must fail at parse time (arity error)
+- `Name(inner_pattern)` in pattern position is the use form; only one nested pattern argument is supported
+- `Name()` and `Name(a, b)` in pattern position must fail at parse time (use arity error)
+- `some`, `none`, and `err` in pattern position remain built-in Outcome constructor patterns; named pattern resolution does not apply to them
+- the matcher body must return one of `some(...)`, `none(...)`, or `err(...)`; any other return value is a runtime error
+- `some(payload, context?)` means match success; the pattern engine continues matching `inner_pattern` against `payload`
+- `none(reason, context?)` means pattern miss; dispatch tries the next arm
+- `err(reason, context?)` must NOT be treated as a miss; it surfaces as the dispatch result without trying later arms
+- a name bound to an ordinary function used in named-pattern position must fail with a deterministic runtime error
+- an unknown name used in named-pattern position must fail with a deterministic runtime error
+- named pattern declarations bind `Name` in the normal lexical environment; no separate pattern namespace is introduced
+- named patterns are valid in the same pattern positions as other implemented pattern forms
+- recursive named pattern definitions are not supported in this phase
 
 ## 7) Spread semantics
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -144,7 +144,7 @@ PYTHON REFERENCE HOST:
   - stdin-fed eval cases whose compared surface remains `stdout`, `stderr`, and `exit_code`
   - direct Option rendering for deterministic final-result output (`some(...)`, `none(...)`)
   - pipeline Option propagation for deterministic final-result output (`some(...)` lift and `none(...)` short-circuit)
-  - deterministic pattern matching output for currently implemented pattern families (first-match behavior, literals, wildcard/variable binding, list/tuple/map, option, guard, and glob forms)
+  - deterministic pattern matching output for currently implemented pattern families (first-match behavior, literals, wildcard/variable binding, list/tuple/map, option, guard, glob, and named reusable pattern forms)
   - deterministic eval failures with exact `stderr` and `exit_code`, including Flow/value boundary errors: `each` given a list, `first` given a Flow, `reduce` given a non-Seq-compatible value (int, string)
   - focused core stdlib list/absence helper behavior: `map` over lists (basic and empty), `filter` over lists (basic, no-match, and Option-element callbacks), `first` (some and empty-list), `last` (some and empty-list), `nth` (in-range and out-of-bounds)
 - Eval normalization is limited to line-ending normalization for `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
@@ -152,10 +152,10 @@ PYTHON REFERENCE HOST:
 - Error normalization is limited to the same line-ending normalization used for eval `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Error comparison is otherwise exact in this phase: `stdout` must be `""`, `stderr` must match exactly after that line-ending normalization, and `exit_code` must be `1`.
 - The current shared spec runner also executes IR cases (`spec/ir/`), comparing normalized portable Core IR output before host-local optimization.
-- Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface (including deterministic pattern miss, guard-all-fail, and malformed-glob cases) and does not machine-assert structured phase/category/message fields.
+- Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface (including deterministic pattern miss, guard-all-fail, malformed-glob, and named-pattern error cases) and does not machine-assert structured phase/category/message fields.
 - The current shared spec runner executes Parse cases (`spec/parse/`) by calling the Python host parse adapter directly; for `kind: ok` cases the normalized AST is compared exactly; for `kind: error` cases the error type is compared exactly and the message is matched as a substring.
 - The current shared spec runner accepts `-v` / `--verbose`, printing each spec name before execution starts and then a single timing line (`<name>\t<elapsed>s`) after each spec completes.
-- Parse shared coverage is active but initial only: the current inventory covers stable, already-implemented syntax forms. Parse spec coverage expands only when new forms are explicitly added and tested.
+- Parse shared coverage is active but initial only: the current inventory covers stable, already-implemented syntax forms, and now includes named pattern declaration (`pattern Name(value) = body`) and named pattern use in case arms (`Name(inner_pattern)`), including error cases for invalid declaration and use arity. Parse spec coverage expands only when new forms are explicitly added and tested.
 - Uncovered or partial categories are not guaranteed and may differ in future implementations.
 
 **Summary:**
@@ -873,6 +873,7 @@ Implemented pattern types:
 - rest pattern `..name` / `.._` (list patterns only; final position only)
 - duplicate binding semantics (same name must match equal value)
 - multiline list pattern formatting is accepted (newlines inside `[...]` pattern shapes)
+- named reusable patterns (`Name(inner_pattern)`) — **Experimental**
 
 Map pattern semantics:
 
@@ -905,6 +906,23 @@ Glob pattern semantics (Phase 1):
 - supported escaping inside glob text:
   - `\*`, `\?`, `\[`, `\]`, `\\`
 - malformed character classes raise deterministic syntax errors
+
+Named reusable pattern semantics (Experimental):
+
+- a named pattern is declared at top level with `pattern Name(value) = body`; exactly one matcher parameter is required
+- the body evaluates to an Outcome value; non-Outcome bodies are a runtime error
+- `Name(inner_pattern)` in pattern position invokes the named matcher with the candidate value and then matches `inner_pattern` against the matcher's returned payload
+- `some(payload, context?)` — match succeeds; `inner_pattern` is matched against `payload`
+- `none(reason, context?)` — pattern misses; later case arms are tried normally
+- `err(reason, context?)` — recoverable matcher failure; does NOT fall through as a miss; surfaces as the dispatch result
+- non-Outcome return from the matcher is a runtime error
+- `some`, `none`, and `err` in pattern position remain built-in Outcome constructor patterns unaffected by named pattern resolution
+- using a name that is bound to an ordinary function (not a named pattern) in pattern position is a runtime error
+- using an unknown name in named-pattern position is a runtime error
+- only one nested pattern argument is supported; `Name()` and `Name(a, b)` are parse errors
+- named patterns are valid wherever ordinary patterns are valid (function case arms, list patterns, map patterns, tuple patterns)
+- named pattern declarations do not introduce a separate namespace; `Name` is bound in the normal lexical environment
+- recursive named patterns are not supported in this phase
 
 Case placement rules (enforced):
 

--- a/docs/architecture/core-ir-portability.md
+++ b/docs/architecture/core-ir-portability.md
@@ -44,6 +44,7 @@ The minimal portable Core IR node families are:
 - `IrLambda`
 - `IrAssign`
 - `IrFuncDef`
+- `IrNamedPatternDef`
 - `IrImport`
 
 Pattern families in the portable contract are:

--- a/hosts/python/ir_normalize.py
+++ b/hosts/python/ir_normalize.py
@@ -231,6 +231,17 @@ def _normalize_ir_node(node: IrNode) -> dict[str, Any]:
         if node.alias is not None:
             normalized["alias"] = node.alias
         return normalized
+    from genia.ir import IrNamedPatternDef
+    if isinstance(node, IrNamedPatternDef):
+        normalized = {
+            "node": "IrNamedPatternDef",
+            "name": node.name,
+            "param": node.param,
+            "body": _normalize_ir_node(node.body),
+        }
+        if node.annotations:
+            normalized["annotations"] = [_normalize_ir_node(a) for a in node.annotations]
+        return normalized
 
     raise TypeError(
         "Portable Core IR normalization failed: unsupported node "

--- a/hosts/python/parse_adapter.py
+++ b/hosts/python/parse_adapter.py
@@ -43,6 +43,18 @@ def normalize_ast(node):
             'params': params,
             'body': body
         }
+    if node_type == 'NamedPatternDef':
+        return {
+            'kind': 'NamedPatternDef',
+            'name': getattr(node, 'name', None),
+            'params': [getattr(node, 'param', None)],
+        }
+    if node_type == 'NamedPatternUse':
+        return {
+            'kind': 'NamedPatternUse',
+            'name': getattr(node, 'name', None),
+            'inner': normalize_ast(getattr(node, 'inner', None)),
+        }
     if node_type == 'Binary':
         op_symbol_map = {
             'PLUS': '+',

--- a/spec/error/error-named-pattern-non-outcome-return.yaml
+++ b/spec/error/error-named-pattern-non-outcome-return.yaml
@@ -1,0 +1,17 @@
+name: error-named-pattern-non-outcome-return
+category: error
+description: Named pattern matchers must return an Outcome value
+input:
+  source: |
+    pattern Positive(n) = n > 0
+    classify(value) =
+      Positive(x) -> x
+    classify(1)
+expected:
+  stdout: ""
+  stderr: "Error: named pattern Positive returned non-Outcome value\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError
+

--- a/spec/error/error-named-pattern-ordinary-function.yaml
+++ b/spec/error/error-named-pattern-ordinary-function.yaml
@@ -1,0 +1,17 @@
+name: error-named-pattern-ordinary-function
+category: error
+description: Ordinary functions are not accepted as named patterns in pattern position
+input:
+  source: |
+    Positive(n) = some(n)
+    classify(value) =
+      Positive(x) -> x
+    classify(1)
+expected:
+  stdout: ""
+  stderr: "Error: Positive is not a named pattern\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError
+

--- a/spec/error/error-named-pattern-unknown.yaml
+++ b/spec/error/error-named-pattern-unknown.yaml
@@ -1,0 +1,16 @@
+name: error-named-pattern-unknown
+category: error
+description: Unknown named pattern use fails deterministically
+input:
+  source: |
+    classify(value) =
+      Missing(x) -> x
+    classify(1)
+expected:
+  stdout: ""
+  stderr: "Error: unknown named pattern Missing\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: NameError
+

--- a/spec/eval/named-pattern-basic-success.yaml
+++ b/spec/eval/named-pattern-basic-success.yaml
@@ -1,0 +1,14 @@
+name: named-pattern-basic-success
+category: eval
+description: Named pattern success matches the nested pattern against the some(...) payload
+input:
+  source: |
+    pattern Positive(n) = some(n)
+    classify(value) =
+      Positive(x) -> x
+    classify(7)
+expected:
+  stdout: "7\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/named-pattern-does-not-hijack-outcome-constructors.yaml
+++ b/spec/eval/named-pattern-does-not-hijack-outcome-constructors.yaml
@@ -1,0 +1,15 @@
+name: named-pattern-does-not-hijack-outcome-constructors
+category: eval
+description: Built-in Outcome constructor patterns keep their existing behavior beside named patterns
+input:
+  source: |
+    classify(value) =
+      some(x) -> x |
+      none(reason) -> reason |
+      err(reason) -> reason
+    [classify(some(3)), classify(none("missing")), classify(err("bad"))]
+expected:
+  stdout: "[3, \"missing\", \"bad\"]\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/named-pattern-duplicate-binding-still-enforced.yaml
+++ b/spec/eval/named-pattern-duplicate-binding-still-enforced.yaml
@@ -1,0 +1,15 @@
+name: named-pattern-duplicate-binding-still-enforced
+category: eval
+description: Duplicate binding equality remains enforced inside nested named-pattern payload patterns
+input:
+  source: |
+    pattern Identity(value) = some(value)
+    classify(value) =
+      Identity([x, x]) -> "same" |
+      _ -> "different"
+    classify([1, 2])
+expected:
+  stdout: "\"different\"\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/named-pattern-err-does-not-fall-through.yaml
+++ b/spec/eval/named-pattern-err-does-not-fall-through.yaml
@@ -1,0 +1,15 @@
+name: named-pattern-err-does-not-fall-through
+category: eval
+description: err(...) from a named pattern surfaces and does not fall through as a miss
+input:
+  source: |
+    pattern Bad(value) = err("bad-pattern", {value: value})
+    classify(value) =
+      Bad(x) -> "matched" |
+      _ -> "fallback"
+    classify(7)
+expected:
+  stdout: "err(\"bad-pattern\", {value: 7})\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/named-pattern-inner-pattern-miss-falls-through.yaml
+++ b/spec/eval/named-pattern-inner-pattern-miss-falls-through.yaml
@@ -1,0 +1,15 @@
+name: named-pattern-inner-pattern-miss-falls-through
+category: eval
+description: A nested pattern miss after some(payload) behaves as an ordinary pattern miss
+input:
+  source: |
+    pattern Identity(n) = some(n)
+    classify(value) =
+      Identity(0) -> "zero" |
+      _ -> "other"
+    classify(7)
+expected:
+  stdout: "\"other\"\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/named-pattern-miss-falls-through.yaml
+++ b/spec/eval/named-pattern-miss-falls-through.yaml
@@ -1,0 +1,15 @@
+name: named-pattern-miss-falls-through
+category: eval
+description: none(...) from a named pattern is a miss that allows later arms to match
+input:
+  source: |
+    pattern Never(n) = none("no-match", {value: n})
+    classify(value) =
+      Never(x) -> "matched" |
+      _ -> "fallback"
+    classify(7)
+expected:
+  stdout: "\"fallback\"\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/named-pattern-nested-map-binding.yaml
+++ b/spec/eval/named-pattern-nested-map-binding.yaml
@@ -1,0 +1,14 @@
+name: named-pattern-nested-map-binding
+category: eval
+description: Named pattern success composes with nested map-pattern bindings
+input:
+  source: |
+    pattern Identity(value) = some(value)
+    render(value) =
+      Identity({name}) -> name
+    render({name: "Ada", extra: 1})
+expected:
+  stdout: "\"Ada\"\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/ir/ir-named-pattern-declaration.yaml
+++ b/spec/ir/ir-named-pattern-declaration.yaml
@@ -1,0 +1,16 @@
+name: ir-named-pattern-declaration
+category: ir
+description: named pattern declarations lower to IrNamedPatternDef with name, param, and body
+input:
+  source: |
+    pattern Positive(n) = some(n)
+expected:
+  ir:
+    - node: IrNamedPatternDef
+      name: Positive
+      param: n
+      body:
+        node: IrOptionSome
+        value:
+          node: IrVar
+          name: n

--- a/spec/manifest.json
+++ b/spec/manifest.json
@@ -27,6 +27,7 @@
       "IrLambda",
       "IrAssign",
       "IrFuncDef",
+      "IrNamedPatternDef",
       "IrImport"
     ],
     "minimal_portable_pattern_families": [

--- a/spec/parse/parse-error-named-pattern-declaration-arity.yaml
+++ b/spec/parse/parse-error-named-pattern-declaration-arity.yaml
@@ -1,0 +1,11 @@
+name: parse-error-named-pattern-declaration-arity
+category: parse
+description: Named pattern declarations support only one matcher parameter in issue 113
+input:
+  source: "pattern Between(value, low, high) = some(value)"
+expected:
+  parse:
+    kind: error
+    type: SyntaxError
+    message: "named pattern Between expects exactly one parameter"
+

--- a/spec/parse/parse-error-named-pattern-use-arity.yaml
+++ b/spec/parse/parse-error-named-pattern-use-arity.yaml
@@ -1,0 +1,13 @@
+name: parse-error-named-pattern-use-arity
+category: parse
+description: Named pattern use supports only one nested pattern argument in issue 113
+input:
+  source: |
+    f(value) =
+      Positive(x, y) -> x
+expected:
+  parse:
+    kind: error
+    type: SyntaxError
+    message: "named pattern Positive expects exactly one pattern argument"
+

--- a/spec/parse/parse-named-pattern-declaration.yaml
+++ b/spec/parse/parse-named-pattern-declaration.yaml
@@ -1,0 +1,14 @@
+name: parse-named-pattern-declaration
+category: parse
+description: Named pattern declaration parses as a bindable pattern definition
+input:
+  source: "pattern Positive(n) = some(n)"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: NamedPatternDef
+      name: Positive
+      params:
+        - n
+

--- a/spec/parse/parse-named-pattern-use-in-case-arm.yaml
+++ b/spec/parse/parse-named-pattern-use-in-case-arm.yaml
@@ -11,4 +11,7 @@ expected:
     ast:
       kind: FuncDef
       name: f
-
+      params:
+        - value
+      body:
+        kind: CaseExpr

--- a/spec/parse/parse-named-pattern-use-in-case-arm.yaml
+++ b/spec/parse/parse-named-pattern-use-in-case-arm.yaml
@@ -1,0 +1,14 @@
+name: parse-named-pattern-use-in-case-arm
+category: parse
+description: Named pattern use parses in ordinary case-arm pattern position
+input:
+  source: |
+    f(value) =
+      Positive(x) -> x
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: FuncDef
+      name: f
+

--- a/src/genia/ast_nodes.py
+++ b/src/genia/ast_nodes.py
@@ -186,6 +186,13 @@ class ErrPattern(Node):
 
 
 @dataclass
+class NamedPatternUse(Node):
+    name: str
+    inner: Node
+    span: SourceSpan | None = None
+
+
+@dataclass
 class CaseClause(Node):
     pattern: Node
     guard: Optional[Node]
@@ -235,6 +242,14 @@ class FuncDef(Node):
     params: list[str]
     rest_param: str | None
     docstring: str | None
+    body: Node
+    span: SourceSpan | None = None
+
+
+@dataclass
+class NamedPatternDef(Node):
+    name: str
+    param: str
     body: Node
     span: SourceSpan | None = None
 

--- a/src/genia/evaluator.py
+++ b/src/genia/evaluator.py
@@ -27,19 +27,19 @@ if __package__ in (None, ""):
     from genia.ir import (
         IrAnnotation, IrAssign, IrBinary, IrBlock, IrCall, IrCase, IrDelay,
         IrExprStmt, IrFuncDef, IrImport, IrLambda, IrList, IrListTraversalLoop,
-        IrLiteral, IrMap, IrNode, IrOptionNone, IrOptionSome, IrPipeline,
+        IrLiteral, IrMap, IrNamedPatternDef, IrNode, IrOptionNone, IrOptionSome, IrPipeline,
         IrQuote, IrQuasiQuote, IrShellStage, IrSpread, IrUnary, IrUnquote,
         IrUnquoteSplicing, IrVar,
     )
     from genia.pattern_match import (
         IrPatBind, IrPatGlob, IrPatList, IrPatLiteral, IrPatMap, IrPatNone,
         IrPatRest, IrPatSome, IrPatTuple, IrPatWildcard, IrPattern,
-        compile_glob_pattern, match_lambda_pattern, match_pattern,
+        PatternOutcomeError, compile_glob_pattern, match_lambda_pattern, match_pattern,
         match_pattern_atom,
     )
     from genia.values import (
         OPTION_NONE, _is_nil_none, _merge_metadata_maps, _runtime_type_name, GeniaFlow, GeniaMap, GeniaOptionNone,
-        GeniaOptionErr, GeniaOptionSome, GeniaPair, GeniaSymbol, ModuleValue, is_err, is_none,
+        GeniaNamedPattern, GeniaOptionErr, GeniaOptionSome, GeniaPair, GeniaSymbol, ModuleValue, is_err, is_none,
         make_none, symbol, truthy,
     )
     from genia.callable import (
@@ -61,19 +61,19 @@ else:
     from .ir import (
         IrAnnotation, IrAssign, IrBinary, IrBlock, IrCall, IrCase, IrDelay,
         IrExprStmt, IrFuncDef, IrImport, IrLambda, IrList, IrListTraversalLoop,
-        IrLiteral, IrMap, IrNode, IrOptionNone, IrOptionSome, IrPipeline,
+        IrLiteral, IrMap, IrNamedPatternDef, IrNode, IrOptionNone, IrOptionSome, IrPipeline,
         IrQuote, IrQuasiQuote, IrShellStage, IrSpread, IrUnary, IrUnquote,
         IrUnquoteSplicing, IrVar,
     )
     from .pattern_match import (
         IrPatBind, IrPatGlob, IrPatList, IrPatLiteral, IrPatMap, IrPatNone,
         IrPatRest, IrPatSome, IrPatTuple, IrPatWildcard, IrPattern,
-        compile_glob_pattern, match_lambda_pattern, match_pattern,
+        PatternOutcomeError, compile_glob_pattern, match_lambda_pattern, match_pattern,
         match_pattern_atom,
     )
     from .values import (
         OPTION_NONE, _is_nil_none, _merge_metadata_maps, _runtime_type_name, GeniaFlow, GeniaMap, GeniaOptionNone,
-        GeniaOptionErr, GeniaOptionSome, GeniaPair, GeniaSymbol, ModuleValue, is_err, is_none,
+        GeniaNamedPattern, GeniaOptionErr, GeniaOptionSome, GeniaPair, GeniaSymbol, ModuleValue, is_err, is_none,
         make_none, symbol, truthy,
     )
     from .callable import (
@@ -688,7 +688,10 @@ class Evaluator:
 
     def eval_case_expr(self, args: tuple[Any, ...], case_expr: IrCase, fn_name: str | None = None) -> Any:
         for clause in case_expr.clauses:
-            match_env = self.match_pattern(clause.pattern, args)
+            try:
+                match_env = self.match_pattern(clause.pattern, args)
+            except PatternOutcomeError as exc:
+                return exc.outcome
             if match_env is None:
                 continue
             local = Env(self.env)
@@ -1031,13 +1034,27 @@ class Evaluator:
         )
 
     def match_pattern(self, pattern: IrPattern, args: tuple[Any, ...]) -> Optional[dict[str, Any]]:
-        return match_pattern(pattern, args)
+        return match_pattern(pattern, args, named_pattern_resolver=self.resolve_named_pattern)
 
     def match_lambda_pattern(self, pattern: IrPattern, args: tuple[Any, ...]) -> Optional[dict[str, Any]]:
-        return match_lambda_pattern(pattern, args)
+        return match_lambda_pattern(pattern, args, named_pattern_resolver=self.resolve_named_pattern)
 
     def match_pattern_atom(self, pattern: IrPattern, arg: Any) -> Optional[dict[str, Any]]:
-        return match_pattern_atom(pattern, arg)
+        return match_pattern_atom(pattern, arg, named_pattern_resolver=self.resolve_named_pattern)
+
+    def resolve_named_pattern(self, name: str, value: Any) -> Any:
+        try:
+            candidate = self.env.get(name)
+        except NameError as exc:
+            raise RuntimeError(f"unknown named pattern {name}") from exc
+        if not isinstance(candidate, GeniaNamedPattern):
+            raise RuntimeError(f"{name} is not a named pattern")
+        return self.invoke_callable(
+            candidate.matcher,
+            [value],
+            tail_position=False,
+            skip_none_propagation=True,
+        )
 
     def eval(self, node: IrNode) -> Any:
         if self.debug_mode:
@@ -1178,6 +1195,25 @@ class Evaluator:
                 metadata = self.eval_annotations(node.annotations)
                 self.env.merge_binding_metadata(node.name, metadata)
             return fn
+        if isinstance(node, IrNamedPatternDef):
+            matcher = GeniaFunction(
+                node.name,
+                [node.param],
+                None,
+                None,
+                node.body,
+                self.env,
+                span=node.span,
+                debug_hooks=self.debug_hooks,
+                debug_mode=self.debug_mode,
+                internal_access=self.env.internal_access,
+            )
+            value = GeniaNamedPattern(node.name, matcher)
+            self.env.set(node.name, value)
+            if node.annotations:
+                metadata = self.eval_annotations(node.annotations)
+                self.env.merge_binding_metadata(node.name, metadata)
+            return value
         if isinstance(node, IrImport):
             requester = node.span.filename if node.span is not None else None
             module_value = self.env.load_module(node.module_name, requester)

--- a/src/genia/ir.py
+++ b/src/genia/ir.py
@@ -229,6 +229,17 @@ class IrFuncDef(IrNode):
 
 
 @dataclass
+class IrNamedPatternDef(IrNode):
+    """Named pattern matcher definition lowered as a single-argument matcher."""
+
+    name: str
+    param: str
+    body: IrNode
+    annotations: list[IrAnnotation] = field(default_factory=list)
+    span: SourceSpan | None = None
+
+
+@dataclass
 class IrImport(IrNode):
     module_name: str
     alias: str
@@ -281,6 +292,7 @@ PORTABLE_CORE_IR_NODE_TYPES: tuple[type[IrNode], ...] = (
     IrLambda,
     IrAssign,
     IrFuncDef,
+    IrNamedPatternDef,
     IrImport,
 )
 
@@ -347,6 +359,9 @@ def iter_ir_nodes(root: IrNode | Iterable[IrNode]) -> Iterator[IrNode]:
             children.extend(annotation.value for annotation in node.annotations)
             children.append(node.expr)
         elif isinstance(node, IrFuncDef):
+            children.extend(annotation.value for annotation in node.annotations)
+            children.append(node.body)
+        elif isinstance(node, IrNamedPatternDef):
             children.extend(annotation.value for annotation in node.annotations)
             children.append(node.body)
         elif isinstance(node, IrListTraversalLoop):

--- a/src/genia/lowering.py
+++ b/src/genia/lowering.py
@@ -23,6 +23,8 @@ if __package__ in (None, ""):
         ListPattern,
         MapLiteral,
         MapPattern,
+        NamedPatternDef,
+        NamedPatternUse,
         Nil,
         Node,
         NoneOption,
@@ -58,6 +60,7 @@ if __package__ in (None, ""):
         IrList,
         IrLiteral,
         IrMap,
+        IrNamedPatternDef,
         IrNode,
         IrOptionNone,
         IrOptionSome,
@@ -78,6 +81,7 @@ if __package__ in (None, ""):
         IrPatList,
         IrPatLiteral,
         IrPatMap,
+        IrPatNamed,
         IrPatNone,
         IrPatRest,
         IrPatSome,
@@ -108,6 +112,8 @@ else:
         ListPattern,
         MapLiteral,
         MapPattern,
+        NamedPatternDef,
+        NamedPatternUse,
         Nil,
         Node,
         NoneOption,
@@ -143,6 +149,7 @@ else:
         IrList,
         IrLiteral,
         IrMap,
+        IrNamedPatternDef,
         IrNode,
         IrOptionNone,
         IrOptionSome,
@@ -163,6 +170,7 @@ else:
         IrPatList,
         IrPatLiteral,
         IrPatMap,
+        IrPatNamed,
         IrPatNone,
         IrPatRest,
         IrPatSome,
@@ -209,6 +217,14 @@ def lower_node(node: Node) -> IrNode:
                 target.params,
                 target.rest_param,
                 target.docstring,
+                lower_node(target.body),
+                annotations=lowered_annotations,
+                span=node.span,
+            )
+        if isinstance(target, NamedPatternDef):
+            return IrNamedPatternDef(
+                target.name,
+                target.param,
                 lower_node(target.body),
                 annotations=lowered_annotations,
                 span=node.span,
@@ -305,6 +321,8 @@ def lower_node(node: Node) -> IrNode:
             annotations=[],
             span=node.span,
         )
+    if isinstance(node, NamedPatternDef):
+        return IrNamedPatternDef(node.name, node.param, lower_node(node.body), annotations=[], span=node.span)
     if isinstance(node, ImportStmt):
         return IrImport(node.module_name, node.alias, span=node.span)
     if isinstance(node, ShellStage):
@@ -334,6 +352,8 @@ def lower_pattern(pattern: Node) -> IrPattern:
         return IrPatRest(pattern.name)
     if isinstance(pattern, Var):
         return IrPatBind(pattern.name)
+    if isinstance(pattern, NamedPatternUse):
+        return IrPatNamed(pattern.name, lower_pattern(pattern.inner))
     if isinstance(pattern, TuplePattern):
         return IrPatTuple([lower_pattern(item) for item in pattern.items])
     if isinstance(pattern, ListPattern):

--- a/src/genia/parser.py
+++ b/src/genia/parser.py
@@ -21,6 +21,8 @@ from .ast_nodes import (
     ListPattern,
     MapLiteral,
     MapPattern,
+    NamedPatternDef,
+    NamedPatternUse,
     Nil,
     Node,
     NoneOption,
@@ -324,6 +326,10 @@ class Parser:
         return None
 
     def try_parse_bindable_toplevel(self) -> Node | None:
+        named_pattern = self.try_parse_named_pattern_def()
+        if named_pattern is not None:
+            return named_pattern
+
         header = self.try_parse_function_header()
         if header is not None:
             name, params, rest_param, name_tok = header
@@ -379,6 +385,35 @@ class Parser:
         if assign is not None:
             return assign
         return None
+
+    def try_parse_named_pattern_def(self) -> NamedPatternDef | None:
+        if not (self.at("IDENT") and self.peek().text == "pattern"):
+            return None
+
+        pattern_tok = self.eat("IDENT")
+        self.skip_newlines()
+        if not self.at("IDENT"):
+            bad = self.peek()
+            raise SyntaxError(f"pattern expected a name identifier, got {bad.text!r} ({bad.kind}) at {bad.pos}")
+        name_tok = self.eat("IDENT")
+        name = name_tok.text
+        self.skip_newlines()
+        self.eat("LPAREN")
+        self.skip_newlines()
+
+        if not self.at("IDENT"):
+            raise SyntaxError(f"named pattern {name} expects exactly one parameter")
+        param_tok = self.eat("IDENT")
+        param = self.validate_parameter_name(param_tok, context="Named pattern")
+        self.skip_newlines()
+        if self.at("COMMA"):
+            raise SyntaxError(f"named pattern {name} expects exactly one parameter")
+        self.eat("RPAREN")
+        self.skip_newlines()
+        self.eat("ASSIGN")
+        self.skip_separators()
+        body = self.parse_function_body_after_intro(1)
+        return NamedPatternDef(name, param, body, span=self.merge_spans(self.span_for_tokens(pattern_tok, name_tok), body.span))
 
     def parse_prefix_annotations(self) -> list[Annotation]:
         annotations: list[Annotation] = []
@@ -669,6 +704,17 @@ class Parser:
                 return ErrPattern(reason, context, span=self.span_for_tokens(tok, end))
             if tok.text == "_":
                 return WildcardPattern(span=self.span_for_tokens(tok, tok))
+            if self.at("LPAREN"):
+                self.eat("LPAREN")
+                self.skip_newlines()
+                if self.at("RPAREN"):
+                    raise SyntaxError(f"named pattern {tok.text} expects exactly one pattern argument")
+                inner = self.parse_pattern_atom()
+                self.skip_newlines()
+                if self.at("COMMA"):
+                    raise SyntaxError(f"named pattern {tok.text} expects exactly one pattern argument")
+                end = self.eat("RPAREN")
+                return NamedPatternUse(tok.text, inner, span=self.span_for_tokens(tok, end))
             return Var(tok.text, span=self.span_for_tokens(tok, tok))
         if tok.kind == "LBRACK":
             start = self.eat("LBRACK")

--- a/src/genia/pattern_match.py
+++ b/src/genia/pattern_match.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from .values import GeniaMap, GeniaOptionErr, GeniaOptionNone, GeniaOptionSome
 
@@ -228,11 +228,28 @@ class IrPatErr(IrPattern):
 
 
 @dataclass
+class IrPatNamed(IrPattern):
+    """Named pattern invocation with one nested payload pattern."""
+
+    name: str
+    inner: IrPattern
+
+
+@dataclass
 class IrPatNone(IrPattern):
     """Option none-family pattern with optional reason and context matching."""
 
     reason: IrPattern | None = None
     context: IrPattern | None = None
+
+
+NamedPatternResolver = Callable[[str, Any], Any]
+
+
+class PatternOutcomeError(Exception):
+    def __init__(self, outcome: GeniaOptionErr):
+        super().__init__(repr(outcome))
+        self.outcome = outcome
 
 
 def _merge_bindings(target: dict[str, Any], source: dict[str, Any]) -> bool:
@@ -243,25 +260,35 @@ def _merge_bindings(target: dict[str, Any], source: dict[str, Any]) -> bool:
     return True
 
 
-def match_pattern(pattern: IrPattern, args: tuple[Any, ...]) -> Optional[dict[str, Any]]:
+def match_pattern(
+    pattern: IrPattern,
+    args: tuple[Any, ...],
+    *,
+    named_pattern_resolver: NamedPatternResolver | None = None,
+) -> Optional[dict[str, Any]]:
     # Pattern matching targets the full argument tuple.
     if isinstance(pattern, IrPatTuple):
         if len(pattern.items) != len(args):
             return None
         env: dict[str, Any] = {}
         for pat, arg in zip(pattern.items, args):
-            sub = match_pattern_atom(pat, arg)
+            sub = match_pattern_atom(pat, arg, named_pattern_resolver=named_pattern_resolver)
             if sub is None or not _merge_bindings(env, sub):
                 return None
         return env
     if len(args) != 1:
         return None
-    return match_pattern_atom(pattern, args[0])
+    return match_pattern_atom(pattern, args[0], named_pattern_resolver=named_pattern_resolver)
 
 
-def match_lambda_pattern(pattern: IrPattern, args: tuple[Any, ...]) -> Optional[dict[str, Any]]:
+def match_lambda_pattern(
+    pattern: IrPattern,
+    args: tuple[Any, ...],
+    *,
+    named_pattern_resolver: NamedPatternResolver | None = None,
+) -> Optional[dict[str, Any]]:
     if not isinstance(pattern, IrPatTuple):
-        return match_pattern(pattern, args)
+        return match_pattern(pattern, args, named_pattern_resolver=named_pattern_resolver)
 
     rest_index = None
     for index, item in enumerate(pattern.items):
@@ -270,7 +297,7 @@ def match_lambda_pattern(pattern: IrPattern, args: tuple[Any, ...]) -> Optional[
             break
 
     if rest_index is None:
-        return match_pattern(pattern, args)
+        return match_pattern(pattern, args, named_pattern_resolver=named_pattern_resolver)
 
     if rest_index != len(pattern.items) - 1:
         return None
@@ -280,18 +307,23 @@ def match_lambda_pattern(pattern: IrPattern, args: tuple[Any, ...]) -> Optional[
 
     env: dict[str, Any] = {}
     for pat, arg in zip(prefix, args[:len(prefix)]):
-        sub = match_pattern_atom(pat, arg)
+        sub = match_pattern_atom(pat, arg, named_pattern_resolver=named_pattern_resolver)
         if sub is None or not _merge_bindings(env, sub):
             return None
 
     rest_pat = pattern.items[rest_index]
-    sub = match_pattern_atom(rest_pat, list(args[len(prefix):]))
+    sub = match_pattern_atom(rest_pat, list(args[len(prefix):]), named_pattern_resolver=named_pattern_resolver)
     if sub is None or not _merge_bindings(env, sub):
         return None
     return env
 
 
-def match_pattern_atom(pattern: IrPattern, arg: Any) -> Optional[dict[str, Any]]:
+def match_pattern_atom(
+    pattern: IrPattern,
+    arg: Any,
+    *,
+    named_pattern_resolver: NamedPatternResolver | None = None,
+) -> Optional[dict[str, Any]]:
     if isinstance(pattern, IrPatLiteral):
         return {} if pattern.value == arg else None
     if isinstance(pattern, IrPatWildcard):
@@ -309,37 +341,48 @@ def match_pattern_atom(pattern: IrPattern, arg: Any) -> Optional[dict[str, Any]]
             return None
         env: dict[str, Any] = {}
         if pattern.reason is not None:
-            reason_bindings = match_pattern_atom(pattern.reason, arg.reason)
+            reason_bindings = match_pattern_atom(pattern.reason, arg.reason, named_pattern_resolver=named_pattern_resolver)
             if reason_bindings is None:
                 return None
             env.update(reason_bindings)
         if pattern.context is not None:
-            context_bindings = match_pattern_atom(pattern.context, arg.context)
+            context_bindings = match_pattern_atom(pattern.context, arg.context, named_pattern_resolver=named_pattern_resolver)
             if context_bindings is None or not _merge_bindings(env, context_bindings):
                 return None
         return env
     if isinstance(pattern, IrPatSome):
         if not isinstance(arg, GeniaOptionSome):
             return None
-        env = match_pattern_atom(pattern.inner, arg.value)
+        env = match_pattern_atom(pattern.inner, arg.value, named_pattern_resolver=named_pattern_resolver)
         if env is None:
             return None
         if pattern.context is not None:
-            context_bindings = match_pattern_atom(pattern.context, arg.context)
+            context_bindings = match_pattern_atom(pattern.context, arg.context, named_pattern_resolver=named_pattern_resolver)
             if context_bindings is None or not _merge_bindings(env, context_bindings):
                 return None
         return env
     if isinstance(pattern, IrPatErr):
         if not isinstance(arg, GeniaOptionErr):
             return None
-        env = match_pattern_atom(pattern.reason, arg.reason)
+        env = match_pattern_atom(pattern.reason, arg.reason, named_pattern_resolver=named_pattern_resolver)
         if env is None:
             return None
         if pattern.context is not None:
-            context_bindings = match_pattern_atom(pattern.context, arg.context)
+            context_bindings = match_pattern_atom(pattern.context, arg.context, named_pattern_resolver=named_pattern_resolver)
             if context_bindings is None or not _merge_bindings(env, context_bindings):
                 return None
         return env
+    if isinstance(pattern, IrPatNamed):
+        if named_pattern_resolver is None:
+            raise RuntimeError(f"unknown named pattern {pattern.name}")
+        outcome = named_pattern_resolver(pattern.name, arg)
+        if isinstance(outcome, GeniaOptionSome):
+            return match_pattern_atom(pattern.inner, outcome.value, named_pattern_resolver=named_pattern_resolver)
+        if isinstance(outcome, GeniaOptionNone):
+            return None
+        if isinstance(outcome, GeniaOptionErr):
+            raise PatternOutcomeError(outcome)
+        raise RuntimeError(f"named pattern {pattern.name} returned non-Outcome value")
     if isinstance(pattern, IrPatList):
         if not isinstance(arg, list):
             return None
@@ -355,7 +398,7 @@ def match_pattern_atom(pattern: IrPattern, arg: Any) -> Optional[dict[str, Any]]
                 return None
             env: dict[str, Any] = {}
             for pat, item in zip(pattern.items, arg):
-                sub = match_pattern_atom(pat, item)
+                sub = match_pattern_atom(pat, item, named_pattern_resolver=named_pattern_resolver)
                 if sub is None or not _merge_bindings(env, sub):
                     return None
             return env
@@ -368,11 +411,11 @@ def match_pattern_atom(pattern: IrPattern, arg: Any) -> Optional[dict[str, Any]]
 
         env: dict[str, Any] = {}
         for pat, item in zip(prefix, arg[:len(prefix)]):
-            sub = match_pattern_atom(pat, item)
+            sub = match_pattern_atom(pat, item, named_pattern_resolver=named_pattern_resolver)
             if sub is None or not _merge_bindings(env, sub):
                 return None
 
-        sub = match_pattern_atom(rest_pat, arg[len(prefix):])
+        sub = match_pattern_atom(rest_pat, arg[len(prefix):], named_pattern_resolver=named_pattern_resolver)
         if sub is None or not _merge_bindings(env, sub):
             return None
         return env
@@ -384,7 +427,7 @@ def match_pattern_atom(pattern: IrPattern, arg: Any) -> Optional[dict[str, Any]]
             if not arg.has(key):
                 return None
             value = arg.get(key)
-            sub = match_pattern_atom(value_pattern, value)
+            sub = match_pattern_atom(value_pattern, value, named_pattern_resolver=named_pattern_resolver)
             if sub is None or not _merge_bindings(env, sub):
                 return None
         return env
@@ -401,6 +444,8 @@ def pattern_explicitly_handles_none(pattern: IrPattern) -> bool:
     if isinstance(pattern, IrPatMap):
         return any(pattern_explicitly_handles_none(item) for _, item in pattern.items)
     if isinstance(pattern, IrPatSome):
+        return pattern_explicitly_handles_none(pattern.inner)
+    if isinstance(pattern, IrPatNamed):
         return pattern_explicitly_handles_none(pattern.inner)
     return False
 
@@ -419,4 +464,6 @@ def pattern_explicitly_handles_some(pattern: IrPattern) -> bool:
             return True
         if pattern.context is not None and pattern_explicitly_handles_some(pattern.context):
             return True
+    if isinstance(pattern, IrPatNamed):
+        return pattern_explicitly_handles_some(pattern.inner)
     return False

--- a/src/genia/values.py
+++ b/src/genia/values.py
@@ -31,6 +31,8 @@ def _runtime_type_name(value: Any) -> str:
         return "list"
     if isinstance(value, GeniaMap):
         return "map"
+    if isinstance(value, GeniaNamedPattern):
+        return "named-pattern"
     if isinstance(value, GeniaFlow):
         return "flow"
     if isinstance(value, GeniaRng):
@@ -249,6 +251,15 @@ class GeniaOptionErr:
 
 def is_err(value: Any) -> bool:
     return isinstance(value, GeniaOptionErr)
+
+
+@dataclass(frozen=True)
+class GeniaNamedPattern:
+    name: str
+    matcher: Any
+
+    def __repr__(self) -> str:
+        return f"<pattern {self.name}>"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION

## Summary

Adds Experimental named reusable patterns that lower to Outcome-returning matcher functions.

This PR introduces the narrow issue #113 surface:

- `pattern Name(value) = body`
- `Name(inner_pattern)` in pattern position
- matcher body must return an Outcome:
  - `some(payload, context?)` → match succeeds; `inner_pattern` matches against `payload`
  - `none(reason, context?)` → pattern miss; later arms may be tried
  - `err(reason, context?)` → recoverable matcher failure; does **not** fall through as a miss
- non-Outcome matcher results fail deterministically
- unknown named patterns and ordinary functions used as named patterns fail deterministically
- built-in `some(...)`, `none(...)`, and `err(...)` constructor patterns keep priority and are not hijacked

The feature is documented as **Experimental** and limited to one matcher parameter / one nested pattern argument.

## Implementation

- Added AST / IR representation for named pattern definitions and uses
- Added parser support for named pattern declarations and named pattern use in pattern position
- Added lowering support for named pattern forms
- Added `GeniaNamedPattern` runtime wrapper
- Extended pattern matching to invoke Outcome-returning matchers
- Updated Python parse adapter projection
- Added shared parse, eval, error, and IR spec coverage

## Docs

Updated:

- `GENIA_STATE.md`
- `GENIA_RULES.md`
- `GENIA_REPL_README.md`

Docs describe only implemented/tested behavior and keep the feature marked Experimental.

## Validation

```bash
PYTHONPATH=src python3 -m tools.spec_runner
````

```text
Summary: total=350 passed=350 failed=0 invalid=0
```

```bash
PYTHONPATH=src pytest -q tests/spec/test_parse_shared_spec_runner.py tests/spec/test_spec_ir_runner_blackbox.py
```

```text
166 passed
```

```bash
PYTHONPATH=src pytest -q tests/unit/test_option.py tests/unit/test_option_semantics.py
```

```text
53 passed
```

```bash
uv tool run ruff check src/genia/ast_nodes.py src/genia/ir.py src/genia/parser.py src/genia/lowering.py src/genia/pattern_match.py src/genia/values.py src/genia/evaluator.py hosts/python/parse_adapter.py
```

```text
All checks passed!
```

```bash
git diff --check
```

Passed.

## Notes

Out of scope for this PR:

* parameterized/multi-argument named patterns
* recursive named patterns
* matcher-produced binding maps
* value templates, ADTs, or refinement syntax
* Flow/pipeline behavior changes

```

