### PR TITLE
Feature/issue 114 template operators implement at check assert and compose over outcome matcher functions

### DIFF
--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -279,6 +279,7 @@ Implemented operators are limited to:
 - binary: `+ - * / % < <= > >= == != && ||`
 - pipeline: `|>`
 - named accessor form: canonical `lhs.name`; legacy compatibility `lhs/name` (RHS bare identifier only)
+- matcher operators (Experimental): `@?`, `@!`, `&` — see section 9.7
 
 Pipeline invariant:
 
@@ -297,6 +298,42 @@ Pipeline invariant:
   - if a stage input is `some(x)` and the stage is not explicitly Option-aware, the stage receives `x`
 - when that lifted stage returns a non-Option value `y`, the pipeline wraps it back as `some(y)`
 - when that lifted stage returns `some(...)` or `none(...)`, that Option result is used as-is
+
+
+## 9.7) Matcher operator invariants (Experimental)
+
+These operators apply Outcome matcher functions. A matcher function is a callable value that accepts one argument and returns an Outcome (`some(...)`, `none(...)`, or `err(...)`).
+
+### `@?` invariants
+
+- `value @? matcher` calls `matcher(value)` and returns the resulting Outcome unchanged
+- `@?` must not coerce the Outcome to boolean
+- `@?` must not unwrap `some(...)`
+- `@?` must not raise merely because the matcher returned `none(...)` or `err(...)`
+- right operand not callable → runtime error
+- matcher returns non-Outcome → runtime error
+
+### `@!` invariants
+
+- `value @! matcher` calls `matcher(value)`
+- if result is `some(v[, ctx])` → evaluates to `v`; context is not exposed by this operator
+- if result is `none(...)` → runtime error (`@! assertion failed: matcher returned none`)
+- if result is `err(reason[, ctx])` → runtime error preserving reason (`@! assertion failed: matcher returned err: <reason>`)
+- right operand not callable → runtime error
+- matcher returns non-Outcome → runtime error
+
+### `&` matcher composition invariants
+
+- `matcher_a & matcher_b` evaluates to a new callable matcher function
+- the composed matcher applies `matcher_a` first, then (only on `some`) passes the payload to `matcher_b`
+- if `matcher_a(value)` returns `none(...)` → return that `none(...)` without calling `matcher_b`
+- if `matcher_a(value)` returns `err(...)` → return that `err(...)` without calling `matcher_b`
+- if `matcher_a(value)` returns `some(next[, ctx])` → call `matcher_b(next)` and return its Outcome
+- composition is left-to-right and deterministic
+- context merging across composed success is not implemented in this phase
+- either operand not callable → runtime error at composition time
+- either matcher returns non-Outcome at invocation time → runtime error
+- `&` for matcher composition is distinct from `&&` (boolean and); non-matcher operands are a runtime error
 
 
 ## 10) Observable Spec Contract (Current Implemented Scope)

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -495,6 +495,9 @@ This is the current runtime value model in `main`. It is intentionally descripti
 - unary operators: `-`, `!`
 - binary operators: `+ - * / % < <= > >= == != && ||`
 - pipeline operator: `|>`
+- matcher check operator: `value @? matcher` — applies `matcher(value)` and returns the Outcome unchanged (`some`, `none`, or `err`); never returns boolean — Experimental
+- matcher assert operator: `value @! matcher` — applies `matcher(value)`, unwraps `some(v)` to `v`, and raises a runtime error on `none` or `err`, preserving the `err` reason in the diagnostic — Experimental
+- matcher composition operator: `matcher_a & matcher_b` — creates a composed matcher that applies `matcher_a` first; short-circuits on `none` or `err`; passes `some` payload to `matcher_b` — Experimental
 - block expressions: `{ ... }`
 - list literals: `[a, b, c]`
 - map literals: `{ key: value }` with identifier/string keys (`name: 1` sugar for `"name": 1`)

--- a/hosts/python/parse_adapter.py
+++ b/hosts/python/parse_adapter.py
@@ -71,6 +71,9 @@ def normalize_ast(node):
             'AND': '&&',
             'OR': '||',
             'PIPE_FWD': '|>',
+            'AT_CHECK': '@?',
+            'AT_ASSERT': '@!',
+            'AMP': '&',
         }
         op = getattr(node, 'op', None)
         op_str = op_symbol_map.get(op, op)

--- a/spec/error/error-template-at-assert-err.yaml
+++ b/spec/error/error-template-at-assert-err.yaml
@@ -1,0 +1,14 @@
+name: error-template-at-assert-err
+category: error
+description: "@! fails loudly and preserves the reason when the matcher returns err(...)"
+input:
+  source: |
+    fail(n) = err("not-a-number")
+    "x" @! fail
+expected:
+  stdout: ""
+  stderr: "Error: @! assertion failed: matcher returned err: not-a-number\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: RuntimeError

--- a/spec/error/error-template-at-assert-non-callable.yaml
+++ b/spec/error/error-template-at-assert-non-callable.yaml
@@ -1,0 +1,13 @@
+name: error-template-at-assert-non-callable
+category: error
+description: "@! rejects a non-callable matcher operand"
+input:
+  source: |
+    1 @! 2
+expected:
+  stdout: ""
+  stderr: "Error: @! expected matcher function, received int\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError

--- a/spec/error/error-template-at-assert-non-outcome-return.yaml
+++ b/spec/error/error-template-at-assert-non-outcome-return.yaml
@@ -1,0 +1,14 @@
+name: error-template-at-assert-non-outcome-return
+category: error
+description: "@! rejects matcher functions that return non-Outcome values"
+input:
+  source: |
+    bad(n) = n > 0
+    1 @! bad
+expected:
+  stdout: ""
+  stderr: "Error: matcher used with @! must return Outcome, received bool\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError

--- a/spec/error/error-template-at-assert-none.yaml
+++ b/spec/error/error-template-at-assert-none.yaml
@@ -1,0 +1,14 @@
+name: error-template-at-assert-none
+category: error
+description: "@! fails loudly when the matcher returns none(...)"
+input:
+  source: |
+    miss(n) = none("not-positive")
+    -1 @! miss
+expected:
+  stdout: ""
+  stderr: "Error: @! assertion failed: matcher returned none: not-positive\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: RuntimeError

--- a/spec/error/error-template-at-check-non-callable.yaml
+++ b/spec/error/error-template-at-check-non-callable.yaml
@@ -1,0 +1,13 @@
+name: error-template-at-check-non-callable
+category: error
+description: "@? rejects a non-callable matcher operand"
+input:
+  source: |
+    1 @? 2
+expected:
+  stdout: ""
+  stderr: "Error: @? expected matcher function, received int\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError

--- a/spec/error/error-template-at-check-non-outcome-return.yaml
+++ b/spec/error/error-template-at-check-non-outcome-return.yaml
@@ -1,0 +1,14 @@
+name: error-template-at-check-non-outcome-return
+category: error
+description: "@? rejects matcher functions that return non-Outcome values"
+input:
+  source: |
+    bad(n) = n > 0
+    1 @? bad
+expected:
+  stdout: ""
+  stderr: "Error: matcher used with @? must return Outcome, received bool\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError

--- a/spec/error/error-template-compose-left-non-callable.yaml
+++ b/spec/error/error-template-compose-left-non-callable.yaml
@@ -1,0 +1,15 @@
+name: error-template-compose-left-non-callable
+category: error
+description: Matcher composition rejects a non-callable left operand
+input:
+  source: |
+    ok(n) = some(n)
+    1 & ok
+expected:
+  stdout: ""
+  stderr: "Error: & expected matcher function on left, received int\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError
+

--- a/spec/error/error-template-compose-left-non-outcome-return.yaml
+++ b/spec/error/error-template-compose-left-non-outcome-return.yaml
@@ -1,0 +1,15 @@
+name: error-template-compose-left-non-outcome-return
+category: error
+description: "Matcher composition rejects non-Outcome values returned by the left matcher"
+input:
+  source: |
+    bad(n) = n > 0
+    ok(n) = some(n)
+    1 @? (bad & ok)
+expected:
+  stdout: ""
+  stderr: "Error: matcher composed with & must return Outcome, received bool\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError

--- a/spec/error/error-template-compose-right-non-callable.yaml
+++ b/spec/error/error-template-compose-right-non-callable.yaml
@@ -1,0 +1,15 @@
+name: error-template-compose-right-non-callable
+category: error
+description: Matcher composition rejects a non-callable right operand
+input:
+  source: |
+    ok(n) = some(n)
+    ok & 1
+expected:
+  stdout: ""
+  stderr: "Error: & expected matcher function on right, received int\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError
+

--- a/spec/error/error-template-compose-right-non-outcome-return.yaml
+++ b/spec/error/error-template-compose-right-non-outcome-return.yaml
@@ -1,0 +1,15 @@
+name: error-template-compose-right-non-outcome-return
+category: error
+description: "Matcher composition rejects non-Outcome values returned by the right matcher"
+input:
+  source: |
+    bad(n) = n > 0
+    ok(n) = some(n)
+    1 @? (ok & bad)
+expected:
+  stdout: ""
+  stderr: "Error: matcher composed with & must return Outcome, received bool\n"
+  exit_code: 1
+notes: |
+  error_phase: eval
+  error_category: TypeError

--- a/spec/eval/template-at-assert-some.yaml
+++ b/spec/eval/template-at-assert-some.yaml
@@ -1,0 +1,11 @@
+name: template-at-assert-some
+category: eval
+description: "@! unwraps the value carried by a successful some(...) matcher Outcome"
+input:
+  source: |
+    ok(n) = some(n + 1)
+    5 @! ok
+expected:
+  stdout: "6\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/template-at-check-err.yaml
+++ b/spec/eval/template-at-check-err.yaml
@@ -1,0 +1,11 @@
+name: template-at-check-err
+category: eval
+description: "@? returns a matcher err(...) Outcome unchanged instead of throwing"
+input:
+  source: |
+    bad(n) = err("not-a-number")
+    "x" @? bad
+expected:
+  stdout: "err(\"not-a-number\")\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/template-at-check-none.yaml
+++ b/spec/eval/template-at-check-none.yaml
@@ -1,0 +1,11 @@
+name: template-at-check-none
+category: eval
+description: "@? returns a matcher none(...) Outcome unchanged instead of coercing to false"
+input:
+  source: |
+    miss(n) = none("not-positive")
+    -1 @? miss
+expected:
+  stdout: "none(\"not-positive\")\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/template-at-check-some.yaml
+++ b/spec/eval/template-at-check-some.yaml
@@ -1,0 +1,11 @@
+name: template-at-check-some
+category: eval
+description: "@? returns a matcher some(...) Outcome unchanged"
+input:
+  source: |
+    ok(n) = some(n)
+    5 @? ok
+expected:
+  stdout: "some(5)\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/template-compose-first-err-short-circuit.yaml
+++ b/spec/eval/template-compose-first-err-short-circuit.yaml
@@ -1,0 +1,13 @@
+name: template-compose-first-err-short-circuit
+category: eval
+description: Matcher composition short-circuits on a left-side err(...) Outcome
+input:
+  source: |
+    fail(n) = err("left-fail")
+    would_change(n) = some(n + 100)
+    3 @? (fail & would_change)
+expected:
+  stdout: "err(\"left-fail\")\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/template-compose-first-none-short-circuit.yaml
+++ b/spec/eval/template-compose-first-none-short-circuit.yaml
@@ -1,0 +1,13 @@
+name: template-compose-first-none-short-circuit
+category: eval
+description: Matcher composition short-circuits on a left-side none(...) Outcome
+input:
+  source: |
+    miss(n) = none("left-miss")
+    would_change(n) = some(n + 100)
+    3 @? (miss & would_change)
+expected:
+  stdout: "none(\"left-miss\")\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/template-compose-second-none.yaml
+++ b/spec/eval/template-compose-second-none.yaml
@@ -1,0 +1,13 @@
+name: template-compose-second-none
+category: eval
+description: Matcher composition returns the right matcher Outcome when the left matcher succeeds
+input:
+  source: |
+    ok(n) = some(n)
+    miss(n) = none("right-miss")
+    3 @? (ok & miss)
+expected:
+  stdout: "none(\"right-miss\")\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/eval/template-compose-success-passes-value.yaml
+++ b/spec/eval/template-compose-success-passes-value.yaml
@@ -1,0 +1,13 @@
+name: template-compose-success-passes-value
+category: eval
+description: Matcher composition passes the some(...) payload from the left matcher to the right matcher
+input:
+  source: |
+    inc_match(n) = some(n + 1)
+    double_match(n) = some(n * 2)
+    3 @? (inc_match & double_match)
+expected:
+  stdout: "some(8)\n"
+  stderr: ""
+  exit_code: 0
+

--- a/spec/ir/template-at-assert.yaml
+++ b/spec/ir/template-at-assert.yaml
@@ -1,0 +1,19 @@
+name: template-at-assert
+category: ir
+description: The @! matcher assertion operator lowers through portable binary IR
+input:
+  source: |
+    value @! matcher
+expected:
+  ir:
+    - node: IrExprStmt
+      expr:
+        node: IrBinary
+        left:
+          node: IrVar
+          name: value
+        op: AT_ASSERT
+        right:
+          node: IrVar
+          name: matcher
+

--- a/spec/ir/template-at-check-composed-matcher.yaml
+++ b/spec/ir/template-at-check-composed-matcher.yaml
@@ -1,0 +1,25 @@
+name: template-at-check-composed-matcher
+category: ir
+description: A composed matcher can be the right operand of @? in portable binary IR
+input:
+  source: |
+    value @? (left & right)
+expected:
+  ir:
+    - node: IrExprStmt
+      expr:
+        node: IrBinary
+        left:
+          node: IrVar
+          name: value
+        op: AT_CHECK
+        right:
+          node: IrBinary
+          left:
+            node: IrVar
+            name: left
+          op: AMP
+          right:
+            node: IrVar
+            name: right
+

--- a/spec/ir/template-compose.yaml
+++ b/spec/ir/template-compose.yaml
@@ -1,0 +1,18 @@
+name: template-compose
+category: ir
+description: The matcher composition operator lowers as standalone portable binary IR
+input:
+  source: |
+    left & right
+expected:
+  ir:
+    - node: IrExprStmt
+      expr:
+        node: IrBinary
+        left:
+          node: IrVar
+          name: left
+        op: AMP
+        right:
+          node: IrVar
+          name: right

--- a/spec/parse/parse-template-at-assert.yaml
+++ b/spec/parse/parse-template-at-assert.yaml
@@ -1,0 +1,18 @@
+name: parse-template-at-assert
+category: parse
+description: The @! matcher-assert operator parses as an infix binary expression
+input:
+  source: "value @! matcher"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Binary
+      op: "@!"
+      left:
+        kind: Var
+        name: value
+      right:
+        kind: Var
+        name: matcher
+

--- a/spec/parse/parse-template-at-check-compose-precedence.yaml
+++ b/spec/parse/parse-template-at-check-compose-precedence.yaml
@@ -1,0 +1,23 @@
+name: parse-template-at-check-compose-precedence
+category: parse
+description: Unparenthesized matcher composition binds tighter than @?
+input:
+  source: "value @? left & right"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Binary
+      op: "@?"
+      left:
+        kind: Var
+        name: value
+      right:
+        kind: Binary
+        op: "&"
+        left:
+          kind: Var
+          name: left
+        right:
+          kind: Var
+          name: right

--- a/spec/parse/parse-template-at-check-composed-matcher.yaml
+++ b/spec/parse/parse-template-at-check-composed-matcher.yaml
@@ -1,0 +1,24 @@
+name: parse-template-at-check-composed-matcher
+category: parse
+description: Parenthesized matcher composition parses as the right operand to @?
+input:
+  source: "value @? (left & right)"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Binary
+      op: "@?"
+      left:
+        kind: Var
+        name: value
+      right:
+        kind: Binary
+        op: "&"
+        left:
+          kind: Var
+          name: left
+        right:
+          kind: Var
+          name: right
+

--- a/spec/parse/parse-template-at-check.yaml
+++ b/spec/parse/parse-template-at-check.yaml
@@ -1,0 +1,18 @@
+name: parse-template-at-check
+category: parse
+description: The @? matcher-check operator parses as an infix binary expression
+input:
+  source: "value @? matcher"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Binary
+      op: "@?"
+      left:
+        kind: Var
+        name: value
+      right:
+        kind: Var
+        name: matcher
+

--- a/spec/parse/parse-template-compose.yaml
+++ b/spec/parse/parse-template-compose.yaml
@@ -1,0 +1,17 @@
+name: parse-template-compose
+category: parse
+description: The matcher composition operator parses as a standalone infix binary expression
+input:
+  source: "left & right"
+expected:
+  parse:
+    kind: ok
+    ast:
+      kind: Binary
+      op: "&"
+      left:
+        kind: Var
+        name: left
+      right:
+        kind: Var
+        name: right

--- a/src/genia/evaluator.py
+++ b/src/genia/evaluator.py
@@ -43,7 +43,7 @@ if __package__ in (None, ""):
         make_none, symbol, truthy,
     )
     from genia.callable import (
-        DebugHooks, NOOP_DEBUG_HOOKS, GeniaFunction, invoke_callable as _invoke_callable,
+        DebugHooks, NOOP_DEBUG_HOOKS, GeniaFunction, GeniaFunctionGroup, invoke_callable as _invoke_callable,
         _callable_explicitly_handles_some,
     )
     from genia.lowering import lower_node, _lambda_pattern_is_simple_parameter_shape
@@ -77,7 +77,7 @@ else:
         make_none, symbol, truthy,
     )
     from .callable import (
-        DebugHooks, NOOP_DEBUG_HOOKS, GeniaFunction, invoke_callable as _invoke_callable,
+        DebugHooks, NOOP_DEBUG_HOOKS, GeniaFunction, GeniaFunctionGroup, invoke_callable as _invoke_callable,
         _callable_explicitly_handles_some,
     )
     from .lowering import lower_node, _lambda_pattern_is_simple_parameter_shape
@@ -97,6 +97,9 @@ QUOTE_OPERATOR_SYMBOLS = {
     "AND": "&&",
     "OR": "||",
     "PIPE_FWD": "|>",
+    "AT_CHECK": "@?",
+    "AT_ASSERT": "@!",
+    "AMP": "&",
     "BANG": "!",
 }
 
@@ -592,6 +595,22 @@ class GeniaMetaEnv:
         return "<meta-env>"
 
 
+class _ComposedMatcher:
+    def __init__(self, evaluator: "Evaluator", left: Any, right: Any):
+        self.evaluator = evaluator
+        self.left = left
+        self.right = right
+
+    def __call__(self, value: Any) -> Any:
+        first = self.evaluator.call_matcher(self.left, value, "&")
+        if isinstance(first, (GeniaOptionNone, GeniaOptionErr)):
+            return first
+        return self.evaluator.call_matcher(self.right, first.value, "&")
+
+    def __repr__(self) -> str:
+        return "<matcher-composition>"
+
+
 class Evaluator:
     def __init__(self, env: Env, debug_hooks: DebugHooks = NOOP_DEBUG_HOOKS, debug_mode: bool = False):
         self.env = env
@@ -1033,6 +1052,55 @@ class Evaluator:
             autoload_resolver=_autoload,
         )
 
+    def is_matcher_callable(self, value: Any) -> bool:
+        return isinstance(value, (GeniaNamedPattern, GeniaFunctionGroup, GeniaMap, str)) or callable(value)
+
+    def ensure_matcher(self, value: Any, diagnostic: str) -> Any:
+        if self.is_matcher_callable(value):
+            if isinstance(value, GeniaNamedPattern):
+                return value.matcher
+            return value
+        raise TypeError(f"{diagnostic}, received {_runtime_type_name(value)}")
+
+    def ensure_outcome(self, value: Any, diagnostic: str) -> Any:
+        if isinstance(value, (GeniaOptionSome, GeniaOptionNone, GeniaOptionErr)):
+            return value
+        raise TypeError(f"{diagnostic}, received {_runtime_type_name(value)}")
+
+    def call_matcher(self, matcher: Any, value: Any, operator_name: str) -> Any:
+        result = self.invoke_callable(
+            matcher,
+            [value],
+            tail_position=False,
+            skip_none_propagation=True,
+        )
+        if operator_name in {"@?", "@!"}:
+            diagnostic = f"matcher used with {operator_name} must return Outcome"
+        else:
+            diagnostic = "matcher composed with & must return Outcome"
+        return self.ensure_outcome(result, diagnostic)
+
+    def apply_matcher_check(self, value: Any, matcher_candidate: Any) -> Any:
+        matcher = self.ensure_matcher(matcher_candidate, "@? expected matcher function")
+        return self.call_matcher(matcher, value, "@?")
+
+    def apply_matcher_assert(self, value: Any, matcher_candidate: Any) -> Any:
+        outcome = self.call_matcher(
+            self.ensure_matcher(matcher_candidate, "@! expected matcher function"),
+            value,
+            "@!",
+        )
+        if isinstance(outcome, GeniaOptionSome):
+            return outcome.value
+        if isinstance(outcome, GeniaOptionErr):
+            raise RuntimeError(f"@! assertion failed: matcher returned err: {format_display(outcome.reason)}")
+        raise RuntimeError(f"@! assertion failed: matcher returned none: {format_display(outcome.reason)}")
+
+    def compose_matchers(self, left_candidate: Any, right_candidate: Any) -> Any:
+        left = self.ensure_matcher(left_candidate, "& expected matcher function on left")
+        right = self.ensure_matcher(right_candidate, "& expected matcher function on right")
+        return _ComposedMatcher(self, left, right)
+
     def match_pattern(self, pattern: IrPattern, args: tuple[Any, ...]) -> Optional[dict[str, Any]]:
         return match_pattern(pattern, args, named_pattern_resolver=self.resolve_named_pattern)
 
@@ -1227,6 +1295,12 @@ class Evaluator:
 
     def eval_binary(self, node: IrBinary) -> Any:
         left = self.eval(node.left)
+        if node.op == "AT_CHECK":
+            return self.apply_matcher_check(left, self.eval(node.right))
+        if node.op == "AT_ASSERT":
+            return self.apply_matcher_assert(left, self.eval(node.right))
+        if node.op == "AMP":
+            return self.compose_matchers(left, self.eval(node.right))
         if node.op in {"EQEQ", "NE"}:
             right = self.eval(node.right)
             match node.op:

--- a/src/genia/lexer.py
+++ b/src/genia/lexer.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 # - Clojure-style symbol punctuation that we allow in names is listed below.
 # - `name?` and `name!` are ordinary identifiers (no special lexer semantics).
 # - `/` is reserved for division and is not allowed inside identifier names.
-ALWAYS_OPERATOR_DELIMITERS = frozenset({"+", "*", "/", "%", "=", "<", ">", "|", ",", ";", ":", "@", "(", ")", "{", "}", "[", "]"})
+ALWAYS_OPERATOR_DELIMITERS = frozenset({"+", "*", "/", "%", "=", "<", ">", "|", "&", ",", ";", ":", "@", "(", ")", "{", "}", "[", "]"})
 ALLOWED_SYMBOL_PUNCTUATION = frozenset({"_", "?", "!", ".", "$", "-"})
 IDENT_START_RE = re.compile(r"[A-Za-z_$]")
 IDENT_BODY_RE = re.compile(r"[A-Za-z0-9]")
@@ -22,6 +22,8 @@ TOKEN_SPEC = [
     ("AND", r"&&"),
     ("OR", r"\|\|"),
     ("PIPE_FWD", r"\|>"),
+    ("AT_CHECK", r"@\?"),
+    ("AT_ASSERT", r"@!"),
     ("ASSIGN", r"="),
     ("LT", r"<"),
     ("GT", r">"),
@@ -33,6 +35,7 @@ TOKEN_SPEC = [
     ("BANG", r"!"),
     ("QMARK", r"\?"),
     ("PIPE", r"\|"),
+    ("AMP", r"&"),
     ("LPAREN", r"\("),
     ("RPAREN", r"\)"),
     ("LBRACE", r"\{"),
@@ -59,6 +62,8 @@ PUNCTUATION_TOKENS = [
     ("AND", "&&"),
     ("OR", "||"),
     ("PIPE_FWD", "|>"),
+    ("AT_CHECK", "@?"),
+    ("AT_ASSERT", "@!"),
     ("DOTDOT", ".."),
     ("ASSIGN", "="),
     ("LT", "<"),
@@ -71,6 +76,7 @@ PUNCTUATION_TOKENS = [
     ("BANG", "!"),
     ("QMARK", "?"),
     ("PIPE", "|"),
+    ("AMP", "&"),
     ("LPAREN", "("),
     ("RPAREN", ")"),
     ("LBRACE", "{"),

--- a/src/genia/parser.py
+++ b/src/genia/parser.py
@@ -46,7 +46,10 @@ from .lexer import Token, SourceSpan, parse_string_literal, parse_glob_literal
 PRECEDENCE = {
     "PIPE_FWD": 5,
     "OR": 10,
+    "AT_CHECK": 15,
+    "AT_ASSERT": 15,
     "AND": 20,
+    "AMP": 25,
     "EQEQ": 30,
     "NE": 30,
     "LT": 40,

--- a/tests/spec/test_template_matcher_shared_specs.py
+++ b/tests/spec/test_template_matcher_shared_specs.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+from tools.spec_runner.comparator import compare_spec
+from tools.spec_runner.executor import execute_spec
+from tools.spec_runner.loader import discover_specs, load_spec
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+REQUIRED_TEMPLATE_MATCHER_ERROR_SPECS = {
+    "error-template-at-check-non-outcome-return",
+    "error-template-at-assert-non-outcome-return",
+    "error-template-compose-left-non-outcome-return",
+    "error-template-compose-right-non-outcome-return",
+}
+
+REQUIRED_TEMPLATE_MATCHER_PARSE_SPECS = {
+    "parse-template-at-check-compose-precedence",
+    "parse-template-compose",
+}
+
+REQUIRED_TEMPLATE_MATCHER_IR_SPECS = {
+    "template-compose",
+}
+
+
+def test_template_matcher_error_shared_spec_inventory_is_present():
+    specs, invalid_specs = discover_specs()
+
+    assert not invalid_specs
+    discovered = {
+        category: {spec.name for spec in specs if spec.category == category}
+        for category in ("parse", "ir", "error")
+    }
+
+    assert REQUIRED_TEMPLATE_MATCHER_PARSE_SPECS.issubset(discovered["parse"])
+    assert REQUIRED_TEMPLATE_MATCHER_IR_SPECS.issubset(discovered["ir"])
+    assert REQUIRED_TEMPLATE_MATCHER_ERROR_SPECS.issubset(discovered["error"])
+
+
+def test_template_matcher_error_shared_specs_execute_as_contract():
+    failures_by_name = {}
+
+    cases = {
+        "parse": REQUIRED_TEMPLATE_MATCHER_PARSE_SPECS,
+        "ir": REQUIRED_TEMPLATE_MATCHER_IR_SPECS,
+        "error": REQUIRED_TEMPLATE_MATCHER_ERROR_SPECS,
+    }
+
+    for category, names in cases.items():
+        for name in sorted(names):
+            spec = load_spec(REPO / "spec" / category / f"{name}.yaml")
+            actual = execute_spec(spec)
+            failures = compare_spec(spec, actual)
+            if failures:
+                failures_by_name[name] = [
+                    (failure.field, failure.expected, failure.actual)
+                    for failure in failures
+                ]
+
+    assert failures_by_name == {}


### PR DESCRIPTION

## Summary

Implements issue #114: Outcome matcher operators for Genia.

This adds a narrow operator surface over matcher functions:

- `value @? matcher` applies `matcher(value)` and returns the matcher Outcome unchanged (`some`, `none`, or `err`)
- `value @! matcher` applies `matcher(value)`, unwraps `some(v)` to `v`, and raises a runtime error on `none` or `err`
- `matcher_a & matcher_b` creates a composed matcher that runs left-to-right, short-circuits on `none` / `err`, and passes the `some` payload to the next matcher

This intentionally does **not** implement the full Value Templates system, static typing, contracts, or general template algebra.

## Changes

- Added lexer/parser support for:
  - `@?`
  - `@!`
  - `&`
- Lowered matcher operators through existing binary AST / IR shapes
- Added parse adapter normalization for new operators
- Added evaluator support for:
  - matcher validation
  - Outcome return validation
  - `@?` check behavior
  - `@!` assert behavior
  - matcher composition
- Added shared parse, IR, eval, and error specs
- Added focused shared spec pytest coverage
- Updated `GENIA_STATE.md` and `GENIA_RULES.md` with truth-aligned experimental behavior

## Testing

Ran:

```bash
PYTHONPATH=src:. python3 -m tools.spec_runner
uv run pytest -q tests/spec/test_template_matcher_shared_specs.py
uv run pytest -q tests/spec/test_parse_shared_spec_runner.py tests/spec/test_spec_ir_runner_blackbox.py tests/spec/test_spec_parse_runner.py
uv tool run ruff check src/genia/lexer.py src/genia/parser.py src/genia/evaluator.py hosts/python/parse_adapter.py
````

Also confirmed:

```bash
git status --short
git log --oneline main..HEAD
```

## Commit stack

```text
c19c91d docs(template): document matcher operators issue #114
41bd534 test(template): add matcher operator shared specs issue #114
a69d868 feat(template-operators): implement outcome matcher operators issue #114
de1e543 test(template-operators): add failing matcher operator specs issue #114
```

## Notes

`@?` is explicitly Outcome-based and never boolean-based.


