### PR TITLE
Feature/issue 341 predicate style matcher operators preserve original subject

### DIFF
--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -306,9 +306,9 @@ These operators apply Outcome matcher functions. A matcher function is a callabl
 
 ### `@?` invariants
 
-- `value @? matcher` calls `matcher(value)` and returns the resulting Outcome unchanged
+- `value @? matcher` calls `matcher(value)`; if result is `some(...)` → returns `some(value)` (original subject); if result is `none(...)` or `err(...)` → returns it unchanged
 - `@?` must not coerce the Outcome to boolean
-- `@?` must not unwrap `some(...)`
+- `@?` must not expose the matcher's success payload; the original subject is the success value
 - `@?` must not raise merely because the matcher returned `none(...)` or `err(...)`
 - right operand not callable → runtime error
 - matcher returns non-Outcome → runtime error
@@ -316,7 +316,7 @@ These operators apply Outcome matcher functions. A matcher function is a callabl
 ### `@!` invariants
 
 - `value @! matcher` calls `matcher(value)`
-- if result is `some(v[, ctx])` → evaluates to `v`; context is not exposed by this operator
+- if result is `some(...)` → evaluates to `value` (original subject); matcher success payload is not exposed
 - if result is `none(...)` → runtime error (`@! assertion failed: matcher returned none`)
 - if result is `err(reason[, ctx])` → runtime error preserving reason (`@! assertion failed: matcher returned err: <reason>`)
 - right operand not callable → runtime error
@@ -325,10 +325,10 @@ These operators apply Outcome matcher functions. A matcher function is a callabl
 ### `&` matcher composition invariants
 
 - `matcher_a & matcher_b` evaluates to a new callable matcher function
-- the composed matcher applies `matcher_a` first, then (only on `some`) passes the payload to `matcher_b`
+- the composed matcher applies `matcher_a` first; if that succeeds, applies `matcher_b` to the original subject (not the matcher payload)
 - if `matcher_a(value)` returns `none(...)` → return that `none(...)` without calling `matcher_b`
 - if `matcher_a(value)` returns `err(...)` → return that `err(...)` without calling `matcher_b`
-- if `matcher_a(value)` returns `some(next[, ctx])` → call `matcher_b(next)` and return its Outcome
+- if `matcher_a(value)` returns `some(...)` → call `matcher_b(value)` (original subject); if result is `some(...)` → return `some(value)`; propagate `none(...)` or `err(...)` unchanged
 - composition is left-to-right and deterministic
 - context merging across composed success is not implemented in this phase
 - either operand not callable → runtime error at composition time

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -495,9 +495,9 @@ This is the current runtime value model in `main`. It is intentionally descripti
 - unary operators: `-`, `!`
 - binary operators: `+ - * / % < <= > >= == != && ||`
 - pipeline operator: `|>`
-- matcher check operator: `value @? matcher` — applies `matcher(value)` and returns the Outcome unchanged (`some`, `none`, or `err`); never returns boolean — Experimental
-- matcher assert operator: `value @! matcher` — applies `matcher(value)`, unwraps `some(v)` to `v`, and raises a runtime error on `none` or `err`, preserving the `err` reason in the diagnostic — Experimental
-- matcher composition operator: `matcher_a & matcher_b` — creates a composed matcher that applies `matcher_a` first; short-circuits on `none` or `err`; passes `some` payload to `matcher_b` — Experimental
+- matcher check operator: `value @? matcher` — applies `matcher(value)`; returns `some(value)` when matcher succeeds, preserves `none(...)` and `err(...)` unchanged; never returns boolean — Experimental
+- matcher assert operator: `value @! matcher` — applies `matcher(value)`; returns the original `value` when matcher succeeds; raises a runtime error on `none` or `err`, preserving the `err` reason in the diagnostic — Experimental
+- matcher composition operator: `matcher_a & matcher_b` — creates a composed matcher that applies `matcher_a` first; short-circuits on `none` or `err`; if `matcher_a` succeeds, applies `matcher_b` to the original subject; returns `some(subject)` when both matchers succeed — Experimental
 - block expressions: `{ ... }`
 - list literals: `[a, b, c]`
 - map literals: `{ key: value }` with identifier/string keys (`name: 1` sugar for `"name": 1`)

--- a/spec/eval/template-at-assert-some.yaml
+++ b/spec/eval/template-at-assert-some.yaml
@@ -1,11 +1,11 @@
 name: template-at-assert-some
 category: eval
-description: "@! unwraps the value carried by a successful some(...) matcher Outcome"
+description: "@! returns the original subject when the matcher succeeds"
 input:
   source: |
-    ok(n) = some(n + 1)
-    5 @! ok
+    replace(n) = some(n + 100)
+    5 @! replace
 expected:
-  stdout: "6\n"
+  stdout: "5\n"
   stderr: ""
   exit_code: 0

--- a/spec/eval/template-at-check-some.yaml
+++ b/spec/eval/template-at-check-some.yaml
@@ -1,10 +1,10 @@
 name: template-at-check-some
 category: eval
-description: "@? returns a matcher some(...) Outcome unchanged"
+description: "@? returns some(original subject) when the matcher succeeds"
 input:
   source: |
-    ok(n) = some(n)
-    5 @? ok
+    replace(n) = some(n + 100)
+    5 @? replace
 expected:
   stdout: "some(5)\n"
   stderr: ""

--- a/spec/eval/template-compose-right-sees-original-subject.yaml
+++ b/spec/eval/template-compose-right-sees-original-subject.yaml
@@ -1,0 +1,15 @@
+name: template-compose-right-sees-original-subject
+category: eval
+description: Matcher composition passes the original subject to the right matcher after left success
+input:
+  source: |
+    left(n) = some(n + 100)
+    right(n) = (
+      x ? x < 10 -> none("right-saw-original") |
+      _ -> some(n)
+    )
+    3 @? (left & right)
+expected:
+  stdout: "none(\"right-saw-original\")\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/template-compose-success-passes-value.yaml
+++ b/spec/eval/template-compose-success-passes-value.yaml
@@ -1,13 +1,12 @@
 name: template-compose-success-passes-value
 category: eval
-description: Matcher composition passes the some(...) payload from the left matcher to the right matcher
+description: Matcher composition preserves the original subject when both matchers succeed
 input:
   source: |
-    inc_match(n) = some(n + 1)
-    double_match(n) = some(n * 2)
-    3 @? (inc_match & double_match)
+    left(n) = some(n + 100)
+    right(n) = some(n * 2)
+    3 @? (left & right)
 expected:
-  stdout: "some(8)\n"
+  stdout: "some(3)\n"
   stderr: ""
   exit_code: 0
-

--- a/src/genia/evaluator.py
+++ b/src/genia/evaluator.py
@@ -605,7 +605,10 @@ class _ComposedMatcher:
         first = self.evaluator.call_matcher(self.left, value, "&")
         if isinstance(first, (GeniaOptionNone, GeniaOptionErr)):
             return first
-        return self.evaluator.call_matcher(self.right, first.value, "&")
+        second = self.evaluator.call_matcher(self.right, value, "&")
+        if isinstance(second, GeniaOptionSome):
+            return GeniaOptionSome(value)
+        return second
 
     def __repr__(self) -> str:
         return "<matcher-composition>"
@@ -1082,7 +1085,10 @@ class Evaluator:
 
     def apply_matcher_check(self, value: Any, matcher_candidate: Any) -> Any:
         matcher = self.ensure_matcher(matcher_candidate, "@? expected matcher function")
-        return self.call_matcher(matcher, value, "@?")
+        outcome = self.call_matcher(matcher, value, "@?")
+        if isinstance(outcome, GeniaOptionSome):
+            return GeniaOptionSome(value)
+        return outcome
 
     def apply_matcher_assert(self, value: Any, matcher_candidate: Any) -> Any:
         outcome = self.call_matcher(
@@ -1091,7 +1097,7 @@ class Evaluator:
             "@!",
         )
         if isinstance(outcome, GeniaOptionSome):
-            return outcome.value
+            return value
         if isinstance(outcome, GeniaOptionErr):
             raise RuntimeError(f"@! assertion failed: matcher returned err: {format_display(outcome.reason)}")
         raise RuntimeError(f"@! assertion failed: matcher returned none: {format_display(outcome.reason)}")

--- a/tests/spec/test_template_matcher_shared_specs.py
+++ b/tests/spec/test_template_matcher_shared_specs.py
@@ -23,6 +23,18 @@ REQUIRED_TEMPLATE_MATCHER_IR_SPECS = {
     "template-compose",
 }
 
+REQUIRED_TEMPLATE_MATCHER_EVAL_SPECS = {
+    "template-at-check-some",
+    "template-at-check-none",
+    "template-at-check-err",
+    "template-at-assert-some",
+    "template-compose-success-passes-value",
+    "template-compose-right-sees-original-subject",
+    "template-compose-second-none",
+    "template-compose-first-none-short-circuit",
+    "template-compose-first-err-short-circuit",
+}
+
 
 def test_template_matcher_error_shared_spec_inventory_is_present():
     specs, invalid_specs = discover_specs()
@@ -30,11 +42,12 @@ def test_template_matcher_error_shared_spec_inventory_is_present():
     assert not invalid_specs
     discovered = {
         category: {spec.name for spec in specs if spec.category == category}
-        for category in ("parse", "ir", "error")
+        for category in ("parse", "ir", "eval", "error")
     }
 
     assert REQUIRED_TEMPLATE_MATCHER_PARSE_SPECS.issubset(discovered["parse"])
     assert REQUIRED_TEMPLATE_MATCHER_IR_SPECS.issubset(discovered["ir"])
+    assert REQUIRED_TEMPLATE_MATCHER_EVAL_SPECS.issubset(discovered["eval"])
     assert REQUIRED_TEMPLATE_MATCHER_ERROR_SPECS.issubset(discovered["error"])
 
 
@@ -44,6 +57,7 @@ def test_template_matcher_error_shared_specs_execute_as_contract():
     cases = {
         "parse": REQUIRED_TEMPLATE_MATCHER_PARSE_SPECS,
         "ir": REQUIRED_TEMPLATE_MATCHER_IR_SPECS,
+        "eval": REQUIRED_TEMPLATE_MATCHER_EVAL_SPECS,
         "error": REQUIRED_TEMPLATE_MATCHER_ERROR_SPECS,
     }
 


### PR DESCRIPTION
````md
## Summary

Implements issue #341: matcher operators now use predicate-style semantics that preserve the original subject on successful matches.

This corrects the experimental matcher operator behavior introduced around issue #114:

- `value @? matcher` now returns `some(original_value)` when the matcher succeeds
- `value @! matcher` now returns the original value when the matcher succeeds
- `matcher_a & matcher_b` now applies both matchers to the original subject rather than passing the left matcher’s `some(...)` payload to the right matcher
- `none(...)` and `err(...)` behavior remains preserved for `@?` and composed matchers
- `@!` still raises runtime errors on `none(...)` and `err(...)`

This keeps matcher operators aligned with predicate-pattern semantics instead of transform-matcher semantics.

## Changes

- Updated matcher eval specs to prove subject preservation:
  - `@?` success returns `some(original_subject)`
  - `@!` success returns `original_subject`
  - `&` success returns `some(original_subject)`
  - right-side composed matcher receives the original subject
- Updated focused matcher shared-spec inventory to include eval specs
- Updated evaluator behavior:
  - `apply_matcher_check` wraps success as `GeniaOptionSome(value)`
  - `apply_matcher_assert` returns the original `value`
  - `_ComposedMatcher` passes the original subject to the right matcher and wraps right-side success as `GeniaOptionSome(value)`
- Synced docs:
  - `GENIA_STATE.md`
  - `GENIA_RULES.md`

## Non-goals

This does not add:

- full Value Templates
- template declaration syntax
- static typing
- contracts
- `@` apply/view semantics
- parser, lexer, or IR changes
- Outcome redesign

## Testing

Ran:

```bash
uv run pytest -q tests/spec/test_template_matcher_shared_specs.py
uv run python -m tools.spec_runner
uv run pytest -q tests/unit/test_doc_style_sync.py
uv tool run ruff check src/genia/evaluator.py
uv run pytest -n auto -q
````

Results reported in handoffs:

```text
tests/spec/test_template_matcher_shared_specs.py: 2 passed
tools.spec_runner: 378 passed, 0 failed, 0 invalid
tests/unit/test_doc_style_sync.py: 19 passed
ruff: All checks passed
full suite: 2325 passed
```

## Notes

The key semantic correction is:

```text
matcher success payload = evidence of success
original subject = value preserved by @?, @!, and &
```

So:

```genia
replace(n) = some(n + 100)

5 @? replace
# some(5)

5 @! replace
# 5
```

And composition now checks both matchers against the original subject:

```genia
left(n) = some(n + 100)
right(n) = some(n * 2)

3 @? (left & right)
# some(3)
```

```
```
