### PR TITLE
Feature/issue 335 sheets define minimal immutable columnar sheet core

### DIFF
--- a/.genia/process/tmp/handoffs/issue-335-sheets-define-minimal-immutable-columnar-sheet-core/03-failing-tests.md
+++ b/.genia/process/tmp/handoffs/issue-335-sheets-define-minimal-immutable-columnar-sheet-core/03-failing-tests.md
@@ -1,0 +1,218 @@
+# === GENIA FAILING TESTS ===
+
+CHANGE NAME:
+issue #335 sheets-define-minimal-immutable-columnar-sheet-core
+
+CHANGE SLUG:
+issue-335-sheets-define-minimal-immutable-columnar-sheet-core
+
+BRANCH:
+feature/issue-335-sheets-define-minimal-immutable-columnar-sheet-core
+
+HANDOFF DIRECTORY:
+.genia/process/tmp/handoffs/issue-335-sheets-define-minimal-immutable-columnar-sheet-core/
+
+OUTPUT FILE:
+.genia/process/tmp/handoffs/issue-335-sheets-define-minimal-immutable-columnar-sheet-core/03-failing-tests.md
+
+---
+
+0. BRANCH CHECK
+
+---
+
+Result: PASS
+
+Current branch:
+
+```text
+feature/issue-335-sheets-define-minimal-immutable-columnar-sheet-core
+```
+
+Preflight branch:
+
+```text
+feature/issue-335-sheets-define-minimal-immutable-columnar-sheet-core
+```
+
+The branch is not `main` and matches the preflight handoff.
+
+---
+
+1. TEST PLAN
+
+---
+
+Files added:
+
+* `spec/eval/sheet-shape-columns-rows.yaml`
+* `spec/eval/sheet-empty-core.yaml`
+* `spec/eval/sheet-select-immutable.yaml`
+* `spec/eval/sheet-where-core.yaml`
+* `spec/eval/sheet-derive-core.yaml`
+* `spec/error/error-sheet-unequal-column-lengths.yaml`
+* `spec/error/error-sheet-select-missing-column.yaml`
+* `spec/error/error-sheet-derive-duplicate-column.yaml`
+* `tests/unit/test_sheet.py`
+* `tests/spec/test_sheet_shared_specs_335.py`
+
+Behavior groups covered:
+
+* Sheet construction from ordered list-of-pairs column input.
+* Shape inspection through `shape(sheet)`.
+* Column inspection through `columns(sheet)`.
+* Row inspection through `rows(sheet)`.
+* Empty Sheet behavior.
+* Column selection and requested-order preservation.
+* `where` true/false filtering with pair-list row values and current legal lambda syntax.
+* `derive` of a constant column with Outcome values stored as ordinary cells.
+* Immutability as observed by the original Sheet shape after `select`, `where`, and `derive`.
+* Clear errors for unequal column lengths, duplicate construction names, missing selected columns, and duplicate derived names.
+* Shared spec discovery for the new Sheet cases.
+
+Contract invariants covered:
+
+* Columns are named and ordered.
+* Column lengths must be aligned.
+* Row count and column count are deterministic.
+* Rows are deterministic pair-list views.
+* Sheet operations return new values and leave the original Sheet unchanged.
+* Outcome cell values are not unwrapped or propagated automatically.
+* Duplicate derived names and duplicate selected/constructed names are rejected in phase one.
+* No new syntax is required; tests use `quote(name)` and `(row) -> ...`.
+
+---
+
+2. FILES CHANGED
+
+---
+
+Added shared eval specs:
+
+* `spec/eval/sheet-shape-columns-rows.yaml`
+* `spec/eval/sheet-empty-core.yaml`
+* `spec/eval/sheet-select-immutable.yaml`
+* `spec/eval/sheet-where-core.yaml`
+* `spec/eval/sheet-derive-core.yaml`
+
+Added shared error specs:
+
+* `spec/error/error-sheet-unequal-column-lengths.yaml`
+* `spec/error/error-sheet-select-missing-column.yaml`
+* `spec/error/error-sheet-derive-duplicate-column.yaml`
+
+Added pytest coverage:
+
+* `tests/unit/test_sheet.py`
+* `tests/spec/test_sheet_shared_specs_335.py`
+
+No implementation files were modified.
+
+No docs were updated in this phase.
+
+---
+
+3. COMMANDS RUN
+
+---
+
+Targeted new tests:
+
+```bash
+uv run pytest -q tests/unit/test_sheet.py tests/spec/test_sheet_shared_specs_335.py
+```
+
+Result:
+
+```text
+17 failed, 1 passed
+```
+
+Nearby shared-spec discovery sanity check:
+
+```bash
+uv run pytest -q tests/spec/test_spec_ir_runner_blackbox.py::test_discover_specs_includes_eval_cases tests/spec/test_spec_ir_runner_blackbox.py::test_discover_specs_includes_error_pattern_cases
+```
+
+Result:
+
+```text
+2 passed
+```
+
+---
+
+4. FAILING EVIDENCE
+
+---
+
+Expected failures:
+
+* `tests/unit/test_sheet.py::test_sheet_shape_columns_and_rows_are_deterministic`
+  * Fails with `NameError: Undefined name: sheet`.
+  * Expected because `sheet` is not implemented or registered yet.
+
+* `tests/unit/test_sheet.py::test_empty_sheet_has_zero_shape_and_empty_rows`
+  * Fails with `NameError: Undefined name: sheet`.
+  * Expected because empty Sheet construction is not implemented yet.
+
+* `tests/unit/test_sheet.py::test_select_reorders_columns_and_preserves_original_sheet`
+  * Fails with `NameError: Undefined name: sheet`.
+  * Expected because Sheet construction and `select` are not implemented yet.
+
+* `tests/unit/test_sheet.py::test_where_filters_rows_and_preserves_original_sheet`
+  * Fails with `NameError: Undefined name: sheet`.
+  * Expected because Sheet construction and `where` are not implemented yet.
+
+* `tests/unit/test_sheet.py::test_derive_appends_column_stores_outcomes_and_preserves_original_sheet`
+  * Fails with `NameError: Undefined name: sheet`.
+  * Expected because Sheet construction and `derive` are not implemented yet.
+
+* `tests/unit/test_sheet.py::test_sheet_errors_are_clear[...]`
+  * Four parameterized cases fail with `NameError: Undefined name: sheet`.
+  * Expected before implementation because the tested validation paths are unreachable until `sheet` exists.
+
+* `tests/spec/test_sheet_shared_specs_335.py::test_sheet_eval_shared_specs[...]`
+  * Five shared eval specs fail with actual stderr `Error: Undefined name: sheet`.
+  * Expected before implementation because the public Sheet API is absent.
+
+* `tests/spec/test_sheet_shared_specs_335.py::test_sheet_error_shared_specs[...]`
+  * Three shared error specs fail because actual stderr is `Error: Undefined name: sheet` instead of the Sheet-specific diagnostics.
+  * Expected before implementation because validation errors are not implemented yet.
+
+Passing evidence:
+
+* `tests/spec/test_sheet_shared_specs_335.py::test_discover_specs_includes_sheet_cases`
+  * Passes, proving the new YAML files load and are discoverable by the existing shared-spec runner.
+
+* Existing eval/error discovery sanity tests pass:
+  * `test_discover_specs_includes_eval_cases`
+  * `test_discover_specs_includes_error_pattern_cases`
+
+Failure count:
+
+* 17 failures in the targeted new tests.
+* This is below the 20-failure stop threshold.
+
+---
+
+5. AMBIGUITIES / BLOCKERS
+
+---
+
+No contract/design blockers found.
+
+One initial test bug was corrected during this phase:
+
+* The first draft used conceptual `row -> ...` lambda syntax from the contract examples.
+* Current Genia syntax requires `(row) -> ...`.
+* Specs and tests were corrected to use `(row) -> ...`, matching the design condition that tests use current legal syntax.
+
+Implementation phase notes:
+
+* Expected observable shape output is the design-selected pair-list representation:
+  * `[[rows, <row_count>], [columns, <column_count>]]`
+* Expected row output is deterministic pair-list rows:
+  * `[[[name, "Ann"], [age, 30]], ...]`
+* Tests avoid direct bare Sheet rendering.
+* Tests do not require row dot-access or new parser syntax.

--- a/.genia/process/tmp/handoffs/issue-335-sheets-define-minimal-immutable-columnar-sheet-core/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-335-sheets-define-minimal-immutable-columnar-sheet-core/04-implementation.md
@@ -1,0 +1,254 @@
+# === GENIA IMPLEMENTATION ===
+
+CHANGE NAME:
+issue #335 sheets-define-minimal-immutable-columnar-sheet-core
+
+CHANGE SLUG:
+issue-335-sheets-define-minimal-immutable-columnar-sheet-core
+
+BRANCH:
+feature/issue-335-sheets-define-minimal-immutable-columnar-sheet-core
+
+HANDOFF DIRECTORY:
+.genia/process/tmp/handoffs/issue-335-sheets-define-minimal-immutable-columnar-sheet-core/
+
+OUTPUT FILE:
+.genia/process/tmp/handoffs/issue-335-sheets-define-minimal-immutable-columnar-sheet-core/04-implementation.md
+
+FAILING TEST COMMIT:
+d86bf6a
+
+---
+
+0. BRANCH CHECK
+
+---
+
+Result: PASS
+
+Current branch:
+
+```text
+feature/issue-335-sheets-define-minimal-immutable-columnar-sheet-core
+```
+
+Preflight branch:
+
+```text
+feature/issue-335-sheets-define-minimal-immutable-columnar-sheet-core
+```
+
+The branch is not `main` and matches the preflight handoff.
+
+---
+
+1. CHANGE PLAN
+
+---
+
+Files to add:
+
+* `src/genia/sheet.py`
+  * Add minimal immutable `GeniaSheet` runtime value.
+  * Add list-of-pairs construction validation.
+  * Add helper operations for `shape`, `columns`, `select`, `where`, `derive`, and `rows`.
+
+Files to modify:
+
+* `src/genia/builtins.py`
+  * Register the public Sheet API in the Python reference host.
+  * Use arity-specific function groups for Sheet helpers so existing user-defined helpers such as `rows()` can coexist with `rows(sheet)`.
+
+* `src/genia/utf8.py`
+  * Add deterministic Sheet formatting to avoid leaking Python dataclass reprs when a Sheet is printed directly.
+
+Files to remove:
+
+* None.
+
+---
+
+2. SUMMARY OF CHANGES
+
+---
+
+Implemented the minimal immutable Sheet core defined by the approved contract/design:
+
+* `sheet(columns)`
+  * Accepts ordered list-of-pairs input: `[[quote(name), values], ...]`.
+  * Requires column values to be lists.
+  * Requires unique column names.
+  * Requires equal column lengths.
+  * Stores canonical columns as tuples.
+
+* `shape(sheet)`
+  * Returns `[[rows, n], [columns, n]]`.
+
+* `columns(sheet)`
+  * Returns column names in deterministic order.
+
+* `rows(sheet)`
+  * Returns deterministic pair-list rows.
+
+* `select(names, sheet)`
+  * Returns a new Sheet with requested columns in requested order.
+  * Rejects duplicate or missing names.
+
+* `where(predicate, sheet)`
+  * Calls the predicate once per row.
+  * Requires boolean predicate results.
+  * Returns a new filtered Sheet.
+
+* `derive(name, function, sheet)`
+  * Calls the function once per row.
+  * Appends the derived column.
+  * Rejects an existing column name.
+  * Stores returned values, including Outcome values, as ordinary cells.
+
+Immutability:
+
+* The canonical representation is tuple-backed.
+* Transformations create new `GeniaSheet` values.
+* Existing Sheet values are not mutated.
+
+Error behavior:
+
+* Sheet validation errors use stable `TypeError` diagnostics.
+* Sheet operation diagnostics opt out of generic pipeline wrapping so shared error specs see the contract-level message.
+
+Rendering:
+
+* Direct Sheet debug/display rendering is deterministic and compact:
+  * `sheet([[name, ["Ann"]], [age, [30]]])`
+
+---
+
+3. FILES CHANGED
+
+---
+
+Added:
+
+* `src/genia/sheet.py`
+
+Modified:
+
+* `src/genia/builtins.py`
+* `src/genia/utf8.py`
+
+No docs were updated in this implementation phase.
+
+No tests were modified in this implementation phase.
+
+---
+
+4. TESTS RUN AND RESULTS
+
+---
+
+Targeted Sheet tests:
+
+```bash
+uv run pytest -q tests/unit/test_sheet.py tests/spec/test_sheet_shared_specs_335.py
+```
+
+Result:
+
+```text
+18 passed
+```
+
+Nearby eval/error shared-spec sweep:
+
+```bash
+uv run pytest -q tests/spec/test_spec_ir_runner_blackbox.py::test_discover_specs_includes_eval_cases tests/spec/test_spec_ir_runner_blackbox.py::test_discover_specs_includes_error_pattern_cases tests/spec/test_spec_ir_runner_blackbox.py::test_eval_spec_fixture tests/spec/test_spec_ir_runner_blackbox.py::test_error_spec_fixture
+```
+
+Result:
+
+```text
+117 passed
+```
+
+Regression run for the `rows()` name collision found by full suite:
+
+```bash
+uv run pytest -q tests/unit/test_sheet.py tests/spec/test_sheet_shared_specs_335.py tests/unit/test_flow_phase1.py::test_keep_some_else_emits_unwrapped_successes_and_routes_original_failures tests/unit/test_fn_stdlib.py::test_autoloaded_rule_helper_composes_directly_with_option_aware_pipelines_in_rules tests/unit/test_cases.py::test_cases
+```
+
+Result:
+
+```text
+115 passed
+```
+
+Lint:
+
+```bash
+uv tool run ruff check src/genia/sheet.py src/genia/builtins.py src/genia/utf8.py tests/unit/test_sheet.py tests/spec/test_sheet_shared_specs_335.py
+```
+
+Result:
+
+```text
+All checks passed!
+```
+
+Full suite:
+
+```bash
+uv run pytest -q
+```
+
+Result:
+
+```text
+2343 passed in 1020.27s (0:17:00)
+```
+
+Note:
+
+* `uv run ruff ...` was attempted first but this environment did not have a `ruff` command available through `uv run`.
+* The equivalent approved command `uv tool run ruff check ...` passed.
+
+---
+
+5. COMPLEXITY CHECK
+
+---
+
+[x] Minimal and direct
+
+The implementation is limited to:
+
+* one small Sheet runtime module
+* public builtin registration
+* deterministic formatting support
+
+No parser, lexer, Core IR, docs, flow semantics, or host adapter behavior was changed.
+
+---
+
+6. BLOCKERS OR AMBIGUITIES
+
+---
+
+None.
+
+One implementation integration issue was found and resolved:
+
+* Registering `rows` as a plain runtime value prevented existing user-defined `rows()` helpers from being defined.
+* The fix registers Sheet helpers as arity-specific `GeniaFunctionGroup` values, allowing `rows(sheet)` to coexist with user-defined `rows/0`.
+
+---
+
+7. TEST STEP NOTES
+
+---
+
+The next Test Verification phase should verify:
+
+* The committed failing tests from `d86bf6a` now pass.
+* Existing user-defined `rows()` functions remain allowed.
+* Sheet helpers remain limited to the approved minimal core.
+* Docs are still not claiming Sheet behavior until the docs phase updates the source-of-truth files.

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -1101,3 +1101,17 @@ For each incoming flow item `x`:
 - ordinary `-c` command mode remains unchanged and evaluates exactly what the user wrote
 - pipe mode bypasses the `main` convention; file mode and `-c` mode keep existing `main/1` then `main/0` behavior
 - pipeline operator semantics are unchanged; this does not add a new operator or runtime meaning for `|>`
+
+## 22) Sheet invariants (Experimental)
+
+- A `GeniaSheet` is an immutable, columnar, named-column runtime value.
+- `sheet(columns)` accepts a list of `[name, values]` two-item pairs; column values must be lists; column names must be unique; all columns must have equal length.
+- `shape`, `columns`, `select`, `where`, `derive`, and `rows` must reject non-Sheet values with a clear `TypeError`.
+- `select(names, sheet)` returns a new Sheet with requested columns in requested order; duplicate or missing names must fail clearly; input Sheet is never mutated.
+- `where(predicate, sheet)` returns a new Sheet containing rows where predicate returns `true`; predicate receives each row as a list of `[name, value]` pairs; non-boolean predicate results must fail clearly.
+- `derive(name, function, sheet)` returns a new Sheet with a new column appended; an existing column name must fail clearly; the row function receives each row as a list of `[name, value]` pairs.
+- All Sheet operations return new `GeniaSheet` values; tuple-backed canonical column storage must not be mutated.
+- `some(...)`, `none(...)`, and `err(...)` values are stored as ordinary cell values; no implicit Outcome propagation is introduced across columns or rows.
+- Sheet errors must set `_genia_preserve_pipeline_error = True` to opt out of generic pipeline error wrapping.
+- Sheets are not Seq-compatible sources and must not be passed to `each`, `collect`, `run`, `map`, `filter`, or `reduce` without explicit conversion in this phase.
+- No new syntax, parser changes, or Core IR nodes are introduced by Sheet.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -319,6 +319,7 @@ This is the current runtime value model in `main`. It is intentionally descripti
 - Map
   - map literals and `map_*` builtins produce the same runtime map value family
   - map values are persistent and opaque at runtime (`<map N>`)
+- Sheet — immutable, columnar, named-column value (**Experimental**)
 
 ### Function / module values
 
@@ -483,6 +484,40 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - Flow remains an explicit runtime value family rather than an implicit pipeline mode
   - host interop is a narrow capability bridge layered onto the same call/pipeline semantics
 - This is still not a full static type/protocol system; the coherence is semantic rather than nominal.
+
+### Sheet values (Experimental)
+
+**LANGUAGE CONTRACT:**
+
+A Sheet is an immutable, columnar, named-column value. It is distinct from Flow, Seq, and ordinary lists.
+
+A Sheet has:
+- zero or more named columns
+- deterministic column order
+- columns represented as ordered sequences of values
+- all columns aligned by row index
+- a deterministic row count
+- immutable update semantics; all operations return new Sheets
+
+A Sheet is not:
+- a lazy or streaming value
+- a reactive or formula-driven spreadsheet
+- a Seq-compatible source in this phase
+- a replacement for Flow or lists
+
+**PYTHON REFERENCE HOST:**
+
+Implemented as `GeniaSheet` — a frozen dataclass with tuple-backed column storage. Column names may be any hashable Genia value (symbols are the intended default). Column order is deterministic from construction order.
+
+**Maturity:** Experimental — minimal immutable columnar core only.
+
+**Explicit limitations:**
+- No reactive cells, formula plans, joins, grouping, sorting, or spreadsheet UI semantics.
+- `some(...)`, `none(...)`, and `err(...)` are stored as ordinary cell values; no automatic Outcome propagation across columns.
+- `derive` rejects an existing column name.
+- `where` predicates must return a boolean; non-boolean predicate results fail clearly.
+- Construction requires lists as column values; other Seq-compatible values are not accepted in this phase.
+- Sheets are not Seq-compatible sources in this phase.
 
 ## 3) Implemented syntax and expression forms
 
@@ -1133,6 +1168,49 @@ Representation System entry points (#185, implemented):
 - #166 owns the broader representation model, including naming boundaries beyond `display` and `debug_repr`, extension points, user-defined representations, registry/strategy behavior, and cross-host treatment of opaque runtime values.
 - #185 must not introduce alternate public representation terms such as `render`, `view`, or `repr`.
 - If #166 later changes the canonical public names, #185 behavior must migrate through the alias-safe rename process: introduce alias, migrate usage incrementally, update tests, then remove the old name in a later phase.
+
+### Sheet builtins (Experimental)
+
+Sheet public helpers are registered directly as arity-specific `GeniaFunctionGroup` builtins in the global environment (not autoloaded). This allows coexistence with user-defined functions at other arities (for example, user-defined `rows/0` may coexist with `rows(sheet)`).
+
+Public helpers:
+
+- `sheet(columns)` — construct a Sheet from a list of `[name, values]` column pairs; column values must be lists; column names must be unique; all columns must have equal length
+- `shape(sheet)` — return `[[rows, n], [columns, n]]`
+- `columns(sheet)` — return column names in deterministic order
+- `select(names, sheet)` — return a new Sheet with requested columns in requested order; rejects duplicate or missing names
+- `where(predicate, sheet)` — return a new Sheet of rows where predicate returns `true`; predicate receives each row as a list of `[name, value]` pairs; predicate must return boolean
+- `derive(name, function, sheet)` — return a new Sheet with a new column appended; row function receives each row as a list of `[name, value]` pairs; rejects existing column names
+- `rows(sheet)` — return a list of rows, each row as a list of `[name, value]` pairs
+
+All Sheet operations return new Sheet values. Existing Sheet values are never mutated.
+
+Construction example:
+
+```genia
+people = sheet([
+  [quote(name), ["Ann", "Bob", "Cara"]],
+  [quote(age), [30, 22, 41]]
+])
+shape(people)
+```
+
+Returns `[[rows, 3], [columns, 2]]`.
+
+Error behavior:
+
+- non-Sheet value passed to a Sheet-only operation: `TypeError`
+- unequal column lengths at construction: `TypeError` with column name
+- duplicate column names at construction or in `select`: `TypeError`
+- missing column in `select`: `TypeError` naming the column
+- non-boolean predicate result in `where`: `TypeError`
+- existing column name in `derive`: `TypeError` naming the column
+- Sheet errors opt out of generic pipeline error wrapping (`_genia_preserve_pipeline_error = True`)
+
+Implementation files:
+- `src/genia/sheet.py` — `GeniaSheet` runtime value and pure helper functions
+- `src/genia/builtins.py` — builtin registration
+- `src/genia/utf8.py` — deterministic Sheet rendering
 
 ### Flow runtime (Phase 1)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository currently provides:
 - a minimal host-backed HTTP serving foundation with prelude helpers (`serve_http`, `get`, `post`, `route_request`, `ok_text`, `json`) (**Python-host-only**)
 - shell pipeline stage `$(command)` for invoking host shell commands inside pipelines (**Python-host-only**, not portable; see below)
 - representation helpers (`display`, `debug_repr`, `format`) and experimental `Format` values for output representation
+- experimental immutable Sheet values for columnar/tabular data (`sheet`, `shape`, `columns`, `select`, `where`, `derive`, `rows`) (**Experimental**)
 - autoloaded prelude libraries (flow helpers, lists, map/ref/process/io helpers, option/string helpers, math helpers, awk helpers, fn helpers, evaluator helpers, cells, actors)
   - `cells` and `actors` are public prelude surfaces in the current Python reference host (**Python-host-only**)
   - flow helpers now include stateful `scan(step, initial_state)` for running totals, buffering, and windowing

--- a/scripts/genia-new.sh
+++ b/scripts/genia-new.sh
@@ -86,6 +86,16 @@ CHANGE SLUG: ${CHANGE_SLUG}
 Handoff directory:
 ${HANDOFF_DIR}/
 
+export HANDOFF_DIR="${HANDOFF_DIR}"
+export CHANGE_SLUG="${CHANGE_SLUG}"
+export ISSUE="${ISSUE}"
+export BRANCH="${BRANCH}"
+export TYPE="${TYPE}"
+export SLUG="${SLUG}"
+
+Post process reports:
+(   git status; git diff ; git log --oneline main..HEAD; cat ${HANDOFF_DIR}/*) | pbcopy
+
 Output pre-flight to:
 ${HANDOFF_DIR}/00-preflight.md
 EOF

--- a/spec/error/error-sheet-derive-duplicate-column.yaml
+++ b/spec/error/error-sheet-derive-duplicate-column.yaml
@@ -1,0 +1,15 @@
+name: error-sheet-derive-duplicate-column
+category: error
+description: derive rejects duplicate derived column names in the minimal Sheet core.
+input:
+  source: |
+    people = sheet([
+      [quote(name), ["Ann"]],
+      [quote(age), [30]]
+    ])
+    people |> derive(quote(age), (row) -> 31)
+expected:
+  stdout: ""
+  stderr: |
+    Error: derive expected a new column name; age already exists
+  exit_code: 1

--- a/spec/error/error-sheet-select-missing-column.yaml
+++ b/spec/error/error-sheet-select-missing-column.yaml
@@ -1,0 +1,15 @@
+name: error-sheet-select-missing-column
+category: error
+description: select fails clearly when a requested Sheet column is absent.
+input:
+  source: |
+    people = sheet([
+      [quote(name), ["Ann"]],
+      [quote(age), [30]]
+    ])
+    people |> select([quote(city)])
+expected:
+  stdout: ""
+  stderr: |
+    Error: select could not find column city
+  exit_code: 1

--- a/spec/error/error-sheet-unequal-column-lengths.yaml
+++ b/spec/error/error-sheet-unequal-column-lengths.yaml
@@ -1,0 +1,14 @@
+name: error-sheet-unequal-column-lengths
+category: error
+description: Sheet construction rejects columns with unequal lengths.
+input:
+  source: |
+    sheet([
+      [quote(name), ["Ann", "Bob"]],
+      [quote(age), [30]]
+    ])
+expected:
+  stdout: ""
+  stderr: |
+    Error: sheet expected all columns to have equal length
+  exit_code: 1

--- a/spec/eval/sheet-derive-core.yaml
+++ b/spec/eval/sheet-derive-core.yaml
@@ -1,0 +1,15 @@
+name: sheet-derive-core
+category: eval
+description: derive appends one value per row, stores Outcome values as cells, and leaves the original Sheet unchanged.
+input:
+  source: |
+    people = sheet([
+      [quote(name), ["Ann", "Bob"]],
+      [quote(age), [30, 22]]
+    ])
+    derived = people |> derive(quote(status), (row) -> some("ok"))
+    [rows(derived), shape(people)]
+expected:
+  stdout: "[[[[name, \"Ann\"], [age, 30], [status, some(\"ok\")]], [[name, \"Bob\"], [age, 22], [status, some(\"ok\")]]], [[rows, 2], [columns, 2]]]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/sheet-empty-core.yaml
+++ b/spec/eval/sheet-empty-core.yaml
@@ -1,0 +1,12 @@
+name: sheet-empty-core
+category: eval
+description: Empty Sheets have zero rows and columns and can be selected with an empty column list.
+input:
+  source: |
+    empty = sheet([])
+    selected = empty |> select([])
+    [shape(empty), columns(empty), rows(empty), shape(selected)]
+expected:
+  stdout: "[[[rows, 0], [columns, 0]], [], [], [[rows, 0], [columns, 0]]]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/sheet-select-immutable.yaml
+++ b/spec/eval/sheet-select-immutable.yaml
@@ -1,0 +1,16 @@
+name: sheet-select-immutable
+category: eval
+description: Selecting columns returns a new Sheet in requested order without mutating the input Sheet.
+input:
+  source: |
+    people = sheet([
+      [quote(name), ["Ann", "Bob"]],
+      [quote(age), [30, 22]],
+      [quote(city), ["Provo", "Ogden"]]
+    ])
+    selected = people |> select([quote(age), quote(name)])
+    [columns(selected), rows(selected), shape(people)]
+expected:
+  stdout: "[[age, name], [[[age, 30], [name, \"Ann\"]], [[age, 22], [name, \"Bob\"]]], [[rows, 2], [columns, 3]]]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/sheet-shape-columns-rows.yaml
+++ b/spec/eval/sheet-shape-columns-rows.yaml
@@ -1,0 +1,14 @@
+name: sheet-shape-columns-rows
+category: eval
+description: Minimal Sheets construct from ordered column pairs and expose shape, columns, and rows deterministically.
+input:
+  source: |
+    people = sheet([
+      [quote(name), ["Ann", "Bob", "Cara"]],
+      [quote(age), [30, 22, 41]]
+    ])
+    [shape(people), columns(people), rows(people)]
+expected:
+  stdout: "[[[rows, 3], [columns, 2]], [name, age], [[[name, \"Ann\"], [age, 30]], [[name, \"Bob\"], [age, 22]], [[name, \"Cara\"], [age, 41]]]]\n"
+  stderr: ""
+  exit_code: 0

--- a/spec/eval/sheet-where-core.yaml
+++ b/spec/eval/sheet-where-core.yaml
@@ -1,0 +1,16 @@
+name: sheet-where-core
+category: eval
+description: where filters rows with boolean predicates while preserving row alignment and input immutability.
+input:
+  source: |
+    people = sheet([
+      [quote(name), ["Ann", "Bob"]],
+      [quote(age), [30, 22]]
+    ])
+    kept = people |> where((row) -> true)
+    dropped = people |> where((row) -> false)
+    [rows(kept), shape(dropped), shape(people)]
+expected:
+  stdout: "[[[[name, \"Ann\"], [age, 30]], [[name, \"Bob\"], [age, 22]]], [[rows, 0], [columns, 2]], [[rows, 2], [columns, 2]]]\n"
+  stderr: ""
+  exit_code: 0

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -64,6 +64,15 @@ if __package__ in (None, ""):
         IrPattern,
         compile_glob_pattern,
     )
+    from genia.sheet import (
+        make_sheet,
+        sheet_columns,
+        sheet_derive,
+        sheet_rows,
+        sheet_select,
+        sheet_shape,
+        sheet_where,
+    )
     from genia.values import (
         OPTION_NONE,
         _RNG_INCREMENT,
@@ -134,6 +143,15 @@ else:
         IrPatWildcard,
         IrPattern,
         compile_glob_pattern,
+    )
+    from .sheet import (
+        make_sheet,
+        sheet_columns,
+        sheet_derive,
+        sheet_rows,
+        sheet_select,
+        sheet_shape,
+        sheet_where,
     )
     from .values import (
         OPTION_NONE,
@@ -2102,6 +2120,29 @@ def make_global_env(
             skip_none_propagation=True,
         )
 
+    def where_fn(predicate: Any, sheet_value: Any) -> Any:
+        return sheet_where(predicate, sheet_value, _invoke_raw_from_builtin)
+
+    def derive_fn(name: Any, function: Any, sheet_value: Any) -> Any:
+        return sheet_derive(name, function, sheet_value, _invoke_raw_from_builtin)
+
+    class _HostFunction:
+        def __init__(self, name: str, arity: int, fn: Callable[..., Any]):
+            self.name = name
+            self.params = [f"arg{i}" for i in range(arity)]
+            self.rest_param = None
+            self.docstring = None
+            self.arity = arity
+            self._fn = fn
+
+        def __call__(self, *args: Any) -> Any:
+            return self._fn(*args)
+
+    def _host_function_group(name: str, arity: int, fn: Callable[..., Any]) -> GeniaFunctionGroup:
+        group = GeniaFunctionGroup(name)
+        group.add_clause(_HostFunction(name, arity, fn))
+        return group
+
     def apply_raw_fn(proc: Any, args: Any) -> Any:
         if not isinstance(args, list):
             raise TypeError(
@@ -2991,6 +3032,13 @@ def make_global_env(
     env.set("help", help_fn)
     env.set("doc", doc_fn)
     env.set("meta", meta_fn)
+    env.set("sheet", _host_function_group("sheet", 1, make_sheet))
+    env.set("shape", _host_function_group("shape", 1, sheet_shape))
+    env.set("columns", _host_function_group("columns", 1, sheet_columns))
+    env.set("select", _host_function_group("select", 2, sheet_select))
+    env.set("where", _host_function_group("where", 2, where_fn))
+    env.set("derive", _host_function_group("derive", 3, derive_fn))
+    env.set("rows", _host_function_group("rows", 1, sheet_rows))
     env.set("pi", math.pi)
     env.set("e", math.e)
     env.set("true", True)

--- a/src/genia/sheet.py
+++ b/src/genia/sheet.py
@@ -1,0 +1,166 @@
+"""Minimal immutable Sheet runtime value."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from .values import GeniaSymbol, symbol
+
+
+def _sheet_error(message: str) -> TypeError:
+    exc = TypeError(message)
+    setattr(exc, "_genia_preserve_pipeline_error", True)
+    return exc
+
+
+@dataclass(frozen=True)
+class GeniaSheet:
+    columns: tuple[tuple[Any, tuple[Any, ...]], ...]
+    row_count: int
+
+    @property
+    def column_names(self) -> tuple[Any, ...]:
+        return tuple(name for name, _ in self.columns)
+
+    @property
+    def column_count(self) -> int:
+        return len(self.columns)
+
+    @property
+    def name_to_values(self) -> dict[Any, tuple[Any, ...]]:
+        return {_freeze_column_name(name): values for name, values in self.columns}
+
+
+def _display_column_name(name: Any) -> str:
+    if isinstance(name, GeniaSymbol):
+        return name.name
+    if isinstance(name, str):
+        return name
+    return repr(name)
+
+
+def _freeze_column_name(name: Any) -> Any:
+    if name is None or isinstance(name, (bool, int, float, str)):
+        return name
+    if isinstance(name, GeniaSymbol):
+        return ("symbol", name.name)
+    if isinstance(name, tuple):
+        return ("tuple", tuple(_freeze_column_name(item) for item in name))
+    if isinstance(name, list):
+        return ("list", tuple(_freeze_column_name(item) for item in name))
+    try:
+        hash(name)
+    except TypeError as exc:
+        raise _sheet_error("sheet expected column names to be hashable values") from exc
+    return name
+
+
+def _ensure_sheet(value: Any, operation: str) -> GeniaSheet:
+    if not isinstance(value, GeniaSheet):
+        raise _sheet_error(f"{operation} expected a Sheet")
+    return value
+
+
+def make_sheet(columns_value: Any) -> GeniaSheet:
+    if not isinstance(columns_value, list):
+        raise _sheet_error("sheet expected a list of [name, values] column pairs")
+
+    columns: list[tuple[Any, tuple[Any, ...]]] = []
+    seen: set[Any] = set()
+    expected_length: int | None = None
+
+    for entry in columns_value:
+        if not isinstance(entry, list) or len(entry) != 2:
+            raise _sheet_error("sheet expected a list of [name, values] column pairs")
+
+        name, values = entry
+        frozen_name = _freeze_column_name(name)
+        if frozen_name in seen:
+            raise _sheet_error("sheet expected unique column names")
+        seen.add(frozen_name)
+
+        if not isinstance(values, list):
+            raise _sheet_error("sheet expected column values to be lists")
+
+        column_values = tuple(values)
+        if expected_length is None:
+            expected_length = len(column_values)
+        elif len(column_values) != expected_length:
+            raise _sheet_error("sheet expected all columns to have equal length")
+
+        columns.append((name, column_values))
+
+    return GeniaSheet(tuple(columns), 0 if expected_length is None else expected_length)
+
+
+def sheet_shape(sheet_value: Any) -> list[list[Any]]:
+    sheet = _ensure_sheet(sheet_value, "shape")
+    return [[symbol("rows"), sheet.row_count], [symbol("columns"), sheet.column_count]]
+
+
+def sheet_columns(sheet_value: Any) -> list[Any]:
+    sheet = _ensure_sheet(sheet_value, "columns")
+    return list(sheet.column_names)
+
+
+def sheet_rows(sheet_value: Any) -> list[list[list[Any]]]:
+    sheet = _ensure_sheet(sheet_value, "rows")
+    return [
+        [[name, values[index]] for name, values in sheet.columns]
+        for index in range(sheet.row_count)
+    ]
+
+
+def sheet_select(names_value: Any, sheet_value: Any) -> GeniaSheet:
+    sheet = _ensure_sheet(sheet_value, "select")
+    if not isinstance(names_value, list):
+        raise _sheet_error("select expected a list of column names")
+
+    source = sheet.name_to_values
+    seen: set[Any] = set()
+    selected: list[tuple[Any, tuple[Any, ...]]] = []
+    for name in names_value:
+        frozen_name = _freeze_column_name(name)
+        if frozen_name in seen:
+            raise _sheet_error("select expected unique column names")
+        seen.add(frozen_name)
+        if frozen_name not in source:
+            raise _sheet_error(f"select could not find column {_display_column_name(name)}")
+        selected.append((name, source[frozen_name]))
+
+    return GeniaSheet(tuple(selected), sheet.row_count)
+
+
+def sheet_where(predicate: Any, sheet_value: Any, invoke: Callable[[Any, list[Any]], Any]) -> GeniaSheet:
+    sheet = _ensure_sheet(sheet_value, "where")
+    if not callable(predicate):
+        raise _sheet_error("where expected a function")
+
+    kept_indexes: list[int] = []
+    row_values = sheet_rows(sheet)
+    for index, row in enumerate(row_values):
+        result = invoke(predicate, [row])
+        if not isinstance(result, bool):
+            raise _sheet_error("where expected predicate to return boolean")
+        if result:
+            kept_indexes.append(index)
+
+    filtered = tuple(
+        (name, tuple(values[index] for index in kept_indexes))
+        for name, values in sheet.columns
+    )
+    return GeniaSheet(filtered, len(kept_indexes))
+
+
+def sheet_derive(name: Any, function: Any, sheet_value: Any, invoke: Callable[[Any, list[Any]], Any]) -> GeniaSheet:
+    sheet = _ensure_sheet(sheet_value, "derive")
+    if not callable(function):
+        raise _sheet_error("derive expected a function")
+
+    frozen_name = _freeze_column_name(name)
+    if frozen_name in sheet.name_to_values:
+        raise _sheet_error(f"derive expected a new column name; {_display_column_name(name)} already exists")
+
+    derived_values = tuple(invoke(function, [row]) for row in sheet_rows(sheet))
+    return GeniaSheet((*sheet.columns, (name, derived_values)), sheet.row_count)

--- a/src/genia/utf8.py
+++ b/src/genia/utf8.py
@@ -45,6 +45,8 @@ def format_display(value: Any) -> str:
         return _format_pair(value, format_display)
     if _is_map(value):
         return _format_map(value, format_display)
+    if _is_sheet(value):
+        return _format_sheet(value, format_display)
     if _is_format(value):
         return "<format>"
     if isinstance(value, str):
@@ -81,6 +83,8 @@ def format_debug(value: Any) -> str:
         return _format_pair(value, format_debug)
     if _is_map(value):
         return _format_map(value, format_debug)
+    if _is_sheet(value):
+        return _format_sheet(value, format_debug)
     if _is_format(value):
         return "<format>"
     if isinstance(value, str):
@@ -130,6 +134,14 @@ def _is_format(value: Any) -> bool:
     return value.__class__.__name__ == "GeniaFormat" and hasattr(value, "template")
 
 
+def _is_sheet(value: Any) -> bool:
+    return (
+        value.__class__.__name__ == "GeniaSheet"
+        and hasattr(value, "columns")
+        and hasattr(value, "row_count")
+    )
+
+
 def _format_pair(value: Any, formatter) -> str:
     parts: list[str] = []
     current = value
@@ -153,6 +165,15 @@ def _format_map_key(key: Any, formatter) -> str:
     if isinstance(key, str) and _GENIA_IDENT_RE.fullmatch(key):
         return key
     return formatter(key)
+
+
+def _format_sheet(value: Any, formatter) -> str:
+    columns = getattr(value, "columns")
+    parts = [
+        "[" + formatter(name) + ", [" + ", ".join(formatter(item) for item in values) + "]]"
+        for name, values in columns
+    ]
+    return "sheet([" + ", ".join(parts) + "])"
 
 
 def _format_option_none(value: Any, formatter) -> str:

--- a/tests/spec/test_sheet_shared_specs_335.py
+++ b/tests/spec/test_sheet_shared_specs_335.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.spec_runner.comparator import compare_spec
+from tools.spec_runner.executor import execute_spec
+from tools.spec_runner.loader import discover_specs, load_spec
+
+
+REPO = Path(__file__).resolve().parents[2]
+EVAL_DIR = REPO / "spec" / "eval"
+ERROR_DIR = REPO / "spec" / "error"
+
+SHEET_EVAL_SPECS = [
+    "sheet-shape-columns-rows.yaml",
+    "sheet-empty-core.yaml",
+    "sheet-select-immutable.yaml",
+    "sheet-where-core.yaml",
+    "sheet-derive-core.yaml",
+]
+
+SHEET_ERROR_SPECS = [
+    "error-sheet-unequal-column-lengths.yaml",
+    "error-sheet-select-missing-column.yaml",
+    "error-sheet-derive-duplicate-column.yaml",
+]
+
+
+def test_discover_specs_includes_sheet_cases() -> None:
+    specs, invalid_specs = discover_specs()
+
+    assert not invalid_specs
+    discovered = {spec.name for spec in specs}
+    expected = {Path(name).stem for name in [*SHEET_EVAL_SPECS, *SHEET_ERROR_SPECS]}
+    assert expected.issubset(discovered)
+
+
+@pytest.mark.parametrize("fname", SHEET_EVAL_SPECS)
+def test_sheet_eval_shared_specs(fname: str) -> None:
+    spec = load_spec(EVAL_DIR / fname)
+    actual = execute_spec(spec)
+    failures = compare_spec(spec, actual)
+
+    assert actual.ir is None
+    assert not failures, f"Failures: {failures}"
+
+
+@pytest.mark.parametrize("fname", SHEET_ERROR_SPECS)
+def test_sheet_error_shared_specs(fname: str) -> None:
+    spec = load_spec(ERROR_DIR / fname)
+    actual = execute_spec(spec)
+    failures = compare_spec(spec, actual)
+
+    assert actual.ir is None
+    assert not failures, f"Failures: {failures}"

--- a/tests/unit/test_sheet.py
+++ b/tests/unit/test_sheet.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+
+from genia.utf8 import format_debug
+
+
+def test_sheet_shape_columns_and_rows_are_deterministic(run):
+    result = run(
+        """
+        people = sheet([
+          [quote(name), ["Ann", "Bob", "Cara"]],
+          [quote(age), [30, 22, 41]]
+        ])
+        [shape(people), columns(people), rows(people)]
+        """
+    )
+
+    assert format_debug(result) == (
+        '[[[rows, 3], [columns, 2]], [name, age], '
+        '[[[name, "Ann"], [age, 30]], [[name, "Bob"], [age, 22]], [[name, "Cara"], [age, 41]]]]'
+    )
+
+
+def test_empty_sheet_has_zero_shape_and_empty_rows(run):
+    result = run(
+        """
+        empty = sheet([])
+        selected = empty |> select([])
+        [shape(empty), columns(empty), rows(empty), shape(selected)]
+        """
+    )
+
+    assert format_debug(result) == "[[[rows, 0], [columns, 0]], [], [], [[rows, 0], [columns, 0]]]"
+
+
+def test_select_reorders_columns_and_preserves_original_sheet(run):
+    result = run(
+        """
+        people = sheet([
+          [quote(name), ["Ann", "Bob"]],
+          [quote(age), [30, 22]],
+          [quote(city), ["Provo", "Ogden"]]
+        ])
+        selected = people |> select([quote(age), quote(name)])
+        [columns(selected), rows(selected), shape(people)]
+        """
+    )
+
+    assert format_debug(result) == (
+        '[[age, name], [[[age, 30], [name, "Ann"]], [[age, 22], [name, "Bob"]]], '
+        '[[rows, 2], [columns, 3]]]'
+    )
+
+
+def test_where_filters_rows_and_preserves_original_sheet(run):
+    result = run(
+        """
+        people = sheet([
+          [quote(name), ["Ann", "Bob"]],
+          [quote(age), [30, 22]]
+        ])
+        kept = people |> where((row) -> true)
+        dropped = people |> where((row) -> false)
+        [rows(kept), shape(dropped), shape(people)]
+        """
+    )
+
+    assert format_debug(result) == (
+        '[[[[name, "Ann"], [age, 30]], [[name, "Bob"], [age, 22]]], '
+        '[[rows, 0], [columns, 2]], [[rows, 2], [columns, 2]]]'
+    )
+
+
+def test_derive_appends_column_stores_outcomes_and_preserves_original_sheet(run):
+    result = run(
+        """
+        people = sheet([
+          [quote(name), ["Ann", "Bob"]],
+          [quote(age), [30, 22]]
+        ])
+        derived = people |> derive(quote(status), (row) -> some("ok"))
+        [rows(derived), shape(people)]
+        """
+    )
+
+    assert format_debug(result) == (
+        '[[[[name, "Ann"], [age, 30], [status, some("ok")]], '
+        '[[name, "Bob"], [age, 22], [status, some("ok")]]], [[rows, 2], [columns, 2]]]'
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "message"),
+    [
+        (
+            """
+            sheet([
+              [quote(name), ["Ann", "Bob"]],
+              [quote(age), [30]]
+            ])
+            """,
+            "sheet expected all columns to have equal length",
+        ),
+        (
+            """
+            sheet([
+              [quote(name), ["Ann"]],
+              [quote(name), ["Bob"]]
+            ])
+            """,
+            "sheet expected unique column names",
+        ),
+        (
+            """
+            people = sheet([[quote(name), ["Ann"]]])
+            people |> select([quote(age)])
+            """,
+            "select could not find column age",
+        ),
+        (
+            """
+            people = sheet([[quote(name), ["Ann"]]])
+            people |> derive(quote(name), (row) -> "Ada")
+            """,
+            "derive expected a new column name; name already exists",
+        ),
+    ],
+)
+def test_sheet_errors_are_clear(run, source, message):
+    with pytest.raises((RuntimeError, TypeError), match=message):
+        run(source)


### PR DESCRIPTION
````md
## Summary

Implements the minimal immutable Sheet core for Genia.

Sheets are now an experimental columnar/tabular runtime value with deterministic named columns, aligned row counts, and immutable transformation helpers.

Added public Sheet helpers:

- `sheet(columns)`
- `shape(sheet)`
- `columns(sheet)`
- `select(names, sheet)`
- `where(predicate, sheet)`
- `derive(name, function, sheet)`
- `rows(sheet)`

Key behavior:

- `sheet(columns)` accepts ordered list-of-pairs input: `[[quote(name), values], ...]`
- column values must be lists
- column names must be unique
- all columns must have equal length
- operations return new Sheets and never mutate the original
- rows are exposed as deterministic `[name, value]` pair lists
- `some(...)`, `none(...)`, and `err(...)` are stored as ordinary cell values
- Sheets are explicitly not Seq-compatible in this phase
- no new syntax, parser changes, or Core IR changes

## Implementation

Added:

- `src/genia/sheet.py`
  - `GeniaSheet`
  - construction validation
  - `shape`, `columns`, `rows`, `select`, `where`, `derive` helpers

Updated:

- `src/genia/builtins.py`
  - registers Sheet helpers as arity-specific `GeniaFunctionGroup` builtins

- `src/genia/utf8.py`
  - adds deterministic Sheet rendering

- `GENIA_STATE.md`
  - documents experimental Sheet values and Sheet builtins

- `GENIA_RULES.md`
  - documents Sheet invariants

- `README.md`
  - adds Sheet to the experimental feature list

## Tests

Added shared specs and unit coverage for:

- construction
- shape inspection
- column inspection
- row projection
- empty Sheets
- select/reorder behavior
- where filtering
- derive behavior
- immutability
- Outcome cell storage
- validation errors

Validation run:

```bash
uv run pytest -q tests/unit/test_sheet.py tests/spec/test_sheet_shared_specs_335.py
````

Result:

```text
18 passed
```

Additional validation:

```bash
uv run pytest -q
```

Result:

```text
2343 passed
```

Doc checks:

```bash
uv run pytest -q tests/unit/test_doc_style_sync.py tests/unit/test_docs_truth_model.py
```

Result:

```text
21 passed
```

Lint:

```bash
uv tool run ruff check src/genia/sheet.py src/genia/builtins.py src/genia/utf8.py tests/unit/test_sheet.py tests/spec/test_sheet_shared_specs_335.py
```

Result:

```text
All checks passed!
```

## Scope notes

This intentionally does **not** add:

* reactive spreadsheet behavior
* formula plans
* mutable cells
* A1 references
* joins/grouping/summaries
* sorting
* vectorized arithmetic
* row dot-access
* Seq/Flow compatibility
* new syntax
* parser/lexer changes
* Core IR changes

```
```
