### PR TITLE
Feature/issue 359 doc sync update cheatsheets for active spec categories and phase 1 outcome matcher surface

### DIFF
--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -1,4 +1,4 @@
-# Note: Examples in this cheatsheet are validated by the Semantic Spec System where covered. Currently, only the eval category is active for executable shared spec files; other categories are scaffold-only. See GENIA_STATE.md for authoritative status.
+# Note: Examples in this cheatsheet are validated by the Semantic Spec System where covered. Active shared semantic spec categories: parse, ir, eval, cli, flow, error. Coverage is partial and experimental; Python is the only implemented host. See GENIA_STATE.md for authoritative status.
 
 # Genia Core Cheatsheet
 
@@ -32,8 +32,16 @@ Validation: runnable snippets include `[case: <id>]` markers and are executed by
 | tuple | `(x, y)` |
 | list + rest | `[x, ..rest]` |
 | map (partial) | `{name}`, `{name: n}` |
-| option constructor | `some(x)`, `none`, `none(reason)`, `none(reason, ctx)` |
+| Outcome constructor | `some(x)`, `some(x, ctx)`, `none`, `none(reason)`, `none(reason, ctx)`, `err(reason)`, `err(reason, ctx)` |
 | guard | `(x) ? x > 0 -> ...` |
+
+Outcome matcher bodies return `some(...)`, `none(...)`, or `err(...)`; `err(...)` is recoverable failure and does not fall through as absence.
+
+| Matcher form | Meaning |
+| --- | --- |
+| `value @? matcher` | Applies the matcher; returns `some(value)` on success and preserves `none(...)` and `err(...)` unchanged. Not boolean. |
+| `value @! matcher` | Applies the matcher; returns the original value on success and raises on `none(...)` or `err(...)`. |
+| `matcher_a & matcher_b` | Composes matcher functions left-to-right, short-circuiting on `none(...)` or `err(...)`. |
 
 ## Pipeline Rules
 
@@ -49,17 +57,19 @@ Validation: runnable snippets include `[case: <id>]` markers and are executed by
 
 Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 
-## Option And Absence
+## Outcome And Absence
 
 | Constructor / Helper | Shape |
 | --- | --- |
-| constructors | `some(value)`, `none`, `none(reason)`, `none(reason, context)` |
+| constructors | `some(value)`, `some(value, context)`, `none`, `none(reason)`, `none(reason, context)`, `err(reason)`, `err(reason, context)` |
 | predicates | `some?(x)`, `none?(x)`, `is_some?(x)`, `is_none?(x)` |
 | map access | `get(key, target)`, `get?(key, target)` |
 | option chaining | `map_some(f, opt)`, `flat_map_some(f, opt)` |
 | chain helpers | `then_get(key, target)`, `then_first(target)`, `then_nth(index, target)`, `then_find(needle, target)` |
 | recovery | `unwrap_or(default, opt)`, `or_else(opt, fallback)`, `or_else_with(opt, thunk)` |
 | metadata | `absence_reason(opt)`, `absence_context(opt)`, `absence_meta(opt)` |
+
+Outcome values distinguish successful presence (`some(value)`), successful absence (`none(...)`), and recoverable failure (`err(...)`). In pipelines, `none(...)` and `err(...)` short-circuit ordinary stages; err(...) is not converted to `none(...)`.
 
 ## Representation
 

--- a/docs/cheatsheet/piepline-flow-vs-value.md
+++ b/docs/cheatsheet/piepline-flow-vs-value.md
@@ -9,9 +9,11 @@ List is the eager reusable Seq-compatible value.
 Flow is the lazy single-use Seq-compatible value.
 Iterator is a host implementation detail.
 
-Option behavior (`some` / `none`) composes with this rule but does not erase it:
-pipelines auto-lift ordinary stages over `some(x)` and short-circuit on `none(...)`,
-regardless of whether the pipeline carries values or flows.
+Outcome behavior (`some` / `none` / `err`) composes with this rule but does not erase it:
+pipelines auto-lift ordinary stages over `some(x)` and short-circuit on `none(...)` or `err(...)`,
+regardless of whether the pipeline carries values or flows. Outcome values distinguish successful presence
+(`some(value)`), successful absence (`none(...)`), and recoverable failure (`err(...)`);
+err(...) is not converted to `none(...)`.
 
 Legend: 🟢 Value  🔵 Flow  🟣 Bridge  🔴 Sink
 
@@ -56,6 +58,7 @@ These invariants are enforced by the pipeline evaluator and locked by tests unde
 | 4 | **`none(...)` metadata is preserved exactly.** Reason and context survive short-circuit unchanged. | `none("timeout", {retry: 3}) \|> f \|> g` keeps both fields |
 | 5 | **Final result preserves Option structure.** The pipeline boundary does not strip or add wrappers. | `some(5) \|> add1` → `some(6)`, not `6` |
 | 6 | **Flow vs Value is orthogonal to Option.** Option propagation works the same in both worlds. | Use `keep_some` for per-item Option filtering in flows |
+| 7 | **`err(...)` is recoverable failure.** err(...) is not converted to `none(...)`; it short-circuits ordinary stages. | `err("bad") \|> f` keeps `err("bad")` |
 
 Recovery pattern: wrap the pipeline, not a single stage.
 

--- a/docs/cheatsheet/quick-reference.md
+++ b/docs/cheatsheet/quick-reference.md
@@ -1,4 +1,4 @@
-# Note: Examples in this cheatsheet are validated by the Semantic Spec System where covered. Active categories: eval, ir, cli, flow, error, parse (coverage varies by category). See GENIA_STATE.md for authoritative status.
+# Note: Examples in this cheatsheet are validated by the Semantic Spec System where covered. Active shared semantic spec categories: parse, ir, eval, cli, flow, error. Coverage is partial and experimental; Python is the only implemented host. See GENIA_STATE.md for authoritative status.
 # Genia Quick Reference
 
 Implemented features only.
@@ -11,7 +11,7 @@ Validation: runnable snippets include `[case: <id>]` markers and are executed by
 - immutable by default
 - pattern matching is primary branching
 - pipeline operator: `|>`
-- explicit absence values: `some(...)`, `none(...)`
+- explicit Outcome values: `some(...)`, `none(...)`, `err(...)`
 - Flow values are lazy, pull-based, single-use
 
 ## Core Syntax
@@ -32,7 +32,9 @@ sum([x, ..rest]) = x + sum(rest)
 head([x, .._]) = x
 ```
 
-## Option / Absence
+## Outcome / Absence
+
+Outcome values distinguish successful presence (`some(value)`), successful absence (`none(...)`), and recoverable failure (`err(...)`). err(...) is not converted to `none(...)`.
 
 [case: quick-option-constructors]
 ```genia
@@ -48,6 +50,7 @@ Pipeline rule reminder:
 - `none(...)` short-circuits and preserves reason/context metadata
 - ordinary stages lift over `some(x)` automatically
 - lifted non-Option results are wrapped back into `some(...)`; Option stage results are preserved as-is
+- err(...) is not converted to `none(...)`; it short-circuits ordinary stages
 - direct calls still receive explicit `some(...)` values unchanged
 - explicitly Option-aware helpers (`unwrap_or`, `map_some`, `flat_map_some`, `then_*`) still receive Option values directly
 
@@ -212,6 +215,14 @@ first_or_none(xs) =
 - compare: `== != < <= > >=`
 - boolean: `&& || !`
 - pipeline: `|>`
+
+Outcome matcher operators:
+
+| Form | Meaning |
+| --- | --- |
+| `value @? matcher` | Applies the matcher; returns `some(value)` on success and preserves `none(...)` and `err(...)` unchanged. Not boolean. |
+| `value @! matcher` | Applies the matcher; returns the original value on success and raises on `none(...)` or `err(...)`. |
+| `matcher_a & matcher_b` | Composes matcher functions left-to-right, short-circuiting on `none(...)` or `err(...)`. |
 
 ## Shell Stage (Python-host-only)
 

--- a/docs/cheatsheet/unix-power-mode.md
+++ b/docs/cheatsheet/unix-power-mode.md
@@ -1,4 +1,4 @@
-# Note: Examples in this cheatsheet are validated by the Semantic Spec System where covered. Active categories: eval, ir, cli, flow, error, parse (coverage varies by category). See GENIA_STATE.md for authoritative status.
+# Note: Examples in this cheatsheet are validated by the Semantic Spec System where covered. Active shared semantic spec categories: parse, ir, eval, cli, flow, error. Coverage is partial and experimental; Python is the only implemented host. See GENIA_STATE.md for authoritative status.
 
 # Genia CLI Cheatsheet: Unix Power Mode
 

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -257,6 +257,65 @@ def test_pipeline_flow_vs_value_cheatsheet_uses_current_option_wording() -> None
 @pytest.mark.parametrize(
     "relpath",
     [
+        "docs/cheatsheet/core.md",
+        "docs/cheatsheet/quick-reference.md",
+        "docs/cheatsheet/unix-power-mode.md",
+    ],
+)
+def test_cheatsheets_list_current_active_shared_spec_categories(relpath: str) -> None:
+    text = normalize(read_text(relpath))
+
+    assert normalize("parse, ir, eval, cli, flow, error") in text
+    assert normalize("partial") in text
+    assert normalize("Python") in text and normalize("only implemented host") in text
+
+
+@pytest.mark.parametrize(
+    "relpath",
+    [
+        "docs/cheatsheet/core.md",
+        "docs/cheatsheet/quick-reference.md",
+        "docs/cheatsheet/piepline-flow-vs-value.md",
+    ],
+)
+def test_cheatsheets_document_outcome_presence_absence_and_failure(relpath: str) -> None:
+    text = normalize(read_text(relpath))
+
+    assert normalize("Outcome") in text
+    assert normalize("some(value)") in text
+    assert normalize("none(...)") in text
+    assert normalize("err(...)") in text
+    assert normalize("recoverable failure") in text
+    assert normalize("err(...) is not converted to `none(...)`") in text
+
+
+@pytest.mark.parametrize(
+    "relpath",
+    [
+        "docs/cheatsheet/core.md",
+        "docs/cheatsheet/quick-reference.md",
+    ],
+)
+def test_cheatsheets_document_phase1_outcome_matcher_operator_surface(relpath: str) -> None:
+    text = normalize(read_text(relpath))
+
+    required = [
+        "`value @? matcher`",
+        "returns `some(value)`",
+        "preserves `none(...)` and `err(...)` unchanged",
+        "not boolean",
+        "`value @! matcher`",
+        "raises",
+        "`matcher_a & matcher_b`",
+        "composes matcher functions",
+    ]
+    for excerpt in required:
+        assert normalize(excerpt) in text
+
+
+@pytest.mark.parametrize(
+    "relpath",
+    [
         "README.md",
         "docs/cheatsheet/quick-reference.md",
         "docs/cheatsheet/core.md",


### PR DESCRIPTION
## Summary

close #359 

- Updated cheatsheets to list the current active shared semantic spec categories: `parse`, `ir`, `eval`, `cli`, `flow`, and `error`
- Updated stale Option-only wording to current Outcome terminology where appropriate
- Documented the Phase-1 Outcome matcher operator surface: `@?`, `@!`, and `&`
- Clarified that `@?` returns the matcher Outcome unchanged, not boolean
- Clarified that `err(...)` is recoverable failure and is not converted to `none(...)`
- Added semantic doc-sync coverage to prevent future cheatsheet drift

## Files changed

- `docs/cheatsheet/core.md`
- `docs/cheatsheet/quick-reference.md`
- `docs/cheatsheet/unix-power-mode.md`
- `docs/cheatsheet/piepline-flow-vs-value.md`
- `tests/doc/test_semantic_doc_sync.py`

## Validation

```text
PYTHONPATH=src pytest -q tests/doc/test_semantic_doc_sync.py --maxfail=20
# 77 passed

PYTHONPATH=src pytest -q tests/unit/test_cheatsheet_*.py
# 96 passed

PYTHONPATH=src pytest -q tests/unit/test_doc_style_sync.py
# 19 passed

Combined focused validation:

PYTHONPATH=src python -m pytest tests/doc/test_semantic_doc_sync.py tests/unit/test_cheatsheet_core.py tests/unit/test_cheatsheet_quick_reference.py tests/unit/test_cheatsheet_unix_power_mode.py tests/unit/test_cheatsheet_pipeline_flow_vs_value.py tests/unit/test_doc_style_sync.py -q
# 176 passed
Notes
No runtime, parser, IR, host, spec-runner, runnable example, or sidecar JSON changes.
Existing docs/cheatsheet/piepline-flow-vs-value.md filename preserved; rename is out of scope.