### PR TITLE
docs(process): align LLM workflow around killer workflow

### DIFF
--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -20,12 +20,13 @@ Do not redefine language semantics in this file.
 - Prevent accidental redesign
 
 ## Process
-1. Identify current behavior
-2. Define desired behavior
-3. List impacted files
-4. Identify risks
-5. Define test changes
-6. Define doc changes
+1. Read `docs/strategy/killer-workflow.md` and classify the change's relationship to Outcome-aware validated data pipelines (yes / indirectly / no)
+2. Identify current behavior
+3. Define desired behavior
+4. List impacted files
+5. Identify risks
+6. Define test changes
+7. Define doc changes
 
 ## Rules
 - Do NOT write implementation code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,26 @@ Prefer references over duplicated semantic rules.
 
 ---
 
+## Product Priority
+
+Before proposing or implementing new feature work, read:
+- `docs/strategy/killer-workflow.md`
+
+Prefer work that strengthens Genia's first killer workflow:
+**Outcome-aware validated data pipelines.**
+
+```
+messy records in → clear pipelines → validated shaped output / reports + useful diagnostics
+```
+
+If a proposed change does not support that workflow, treat it as parking-lot/future work
+unless explicitly approved.
+
+The strategy doc is a prioritization guide, not a language contract.
+`GENIA_STATE.md` remains the final authority for implemented behavior.
+
+---
+
 ## Non-Negotiable Rule (CRITICAL)
 
 > Any change to language behavior, syntax, runtime semantics, parser rules, or examples MUST also update:

--- a/docs/ai/LLM_CONTRACT.md
+++ b/docs/ai/LLM_CONTRACT.md
@@ -74,6 +74,20 @@ When creating Codex or Copilot task prompts for repository work, include instruc
 - keep `GENIA_STATE.md` and relevant core docs up to date
 - keep tests synchronized with behavior changes
 
+## Product Priority / Killer Workflow
+
+Before proposing major new work, read `docs/strategy/killer-workflow.md`.
+
+Agents must:
+
+- read the killer workflow strategy before proposing or implementing major new work
+- explicitly classify each change's relationship to the killer workflow
+- prefer changes that strengthen Outcome-aware validated data pipelines
+- route unrelated ideas to parking lot unless explicitly approved
+- avoid treating `docs/strategy/killer-workflow.md` as implemented behavior — it is a strategy guide, not a language contract
+
+The strategy doc does not define implemented behavior. `GENIA_STATE.md` remains final authority.
+
 ## Validation
 
 Repository tooling may validate tool-specific instruction files against this contract.

--- a/docs/parking-lot/README.md
+++ b/docs/parking-lot/README.md
@@ -6,6 +6,14 @@ This directory is for ideas that may influence future Genia design, but **nothin
 
 If anything in this directory conflicts with `GENIA_STATE.md`, then `GENIA_STATE.md` wins.
 
+## Killer Workflow Alignment
+
+Ideas that do not support Genia's first killer workflow — Outcome-aware validated data pipelines —
+should be parked here unless explicitly approved.
+
+Read `docs/strategy/killer-workflow.md` for the full list of preferred alignment areas
+and the areas that belong in parking lot by default.
+
 ## Purpose
 
 Use this directory to capture:
@@ -15,6 +23,7 @@ Use this directory to capture:
 - possible host/runtime directions
 - postponed scope from completed issues
 - ideas that are useful but not ready for pre-flight
+- ideas that do not align with the current killer workflow
 
 ## Non-authoritative rule
 

--- a/docs/process/00-preflight.md
+++ b/docs/process/00-preflight.md
@@ -176,6 +176,32 @@ Notes:
 
 ---
 
+KILLER WORKFLOW ALIGNMENT
+
+Does this change directly strengthen Outcome-aware validated data pipelines?
+
+[ ] Yes
+[ ] Indirectly
+[ ] No
+
+If yes or indirectly, explain how it improves at least one:
+- Flow / Seq
+- Outcome
+- record parsing
+- validation
+- diagnostics
+- Sheets
+- CLI data processing
+- value templates for validation/contracts/shapes
+
+If no:
+- Should this be parking-lot instead?
+- Why is it still worth doing now?
+
+Reference: docs/strategy/killer-workflow.md
+
+---
+
 11. PROMPT PLAN
 
 Pipeline:

--- a/docs/process/06-audit.md
+++ b/docs/process/06-audit.md
@@ -177,6 +177,17 @@ Confirm:
 
 ---
 
+KILLER WORKFLOW DRIFT CHECK
+
+- Did this change stay aligned with the stated killer workflow?
+- Did it add general-purpose machinery not needed for the workflow?
+- Did it pull in actors/UI/lifecycle/multi-host/demo work prematurely?
+- Did docs imply strategic ideas are implemented behavior?
+
+Reference: docs/strategy/killer-workflow.md
+
+---
+
 FINAL VERDICT:
 
 Ready to merge?

--- a/docs/strategy/killer-workflow.md
+++ b/docs/strategy/killer-workflow.md
@@ -1,0 +1,82 @@
+# Genia Killer Workflow — Strategy Guide
+
+Status: **Strategy / prioritization guide.**
+This document does not define implemented Genia language behavior.
+If anything here conflicts with `GENIA_STATE.md`, `GENIA_STATE.md` wins.
+
+---
+
+## First Killer Workflow
+
+Genia's first killer workflow is **Outcome-aware validated data pipelines.**
+
+Core promise:
+
+```
+messy records in → clear pipelines → validated shaped output / reports + useful diagnostics
+```
+
+## Practical Workflow Shape
+
+1. Read messy records from files or stdin
+2. Parse structured data such as CSV, JSON, or JSONL
+3. Transform records through clear pipelines
+4. Validate with Outcome-aware rules
+5. Reshape valid records into Sheets or reportable structures
+6. Emit clean output plus useful diagnostics
+
+## North-Star Example
+
+> **Not a current behavior contract.** Illustrative only.
+
+```
+stdin
+|> lines
+|> map(parse_csv_row)
+|> keep_some(validate_record)
+|> map(reshape_for_report)
+|> each(print)
+```
+
+Current implemented building blocks include `lines`, `map`, `keep_some`, `each`, `print`,
+Outcome constructors `some`/`none`/`err`, and Sheet values. Pipeline composition is implemented.
+The complete workflow above depends on `parse_csv_row` and `validate_record` being defined by the caller.
+
+## Near-Term Preferred Alignment Areas
+
+Changes that strengthen one or more of these areas are preferred:
+
+- **Flow / Seq** — lazy pull-based ordered processing
+- **Outcome** — `some`, `none`, `err` value-level presence/absence/failure
+- **Record parsing** — CSV, JSON, JSONL, field extraction from messy input
+- **Validation** — Outcome-aware rule application to records
+- **Diagnostics** — surfacing which records failed, why, and how
+- **Sheets** — immutable columnar output for reportable structures
+- **CLI-native data processing** — pipe-mode, file-mode, stdout/stderr discipline
+- **Value templates** — when they support validation, contracts, or shapes for record data
+
+## Defer / Parking-Lot Areas
+
+Unless explicitly approved, route proposals in these areas to parking lot:
+
+- actors / process-level concurrency
+- browser UI / playground
+- lifecycle machinery
+- ants / teaching demos
+- multi-host expansion beyond what the killer workflow needs
+- broad runtime architecture not needed for Outcome-aware data pipelines
+
+See `docs/parking-lot/README.md` for the parking-lot process.
+
+## Using This Document
+
+Agents and contributors should read this document before proposing or implementing new work.
+
+Ask: **Does this change help Genia become excellent at Outcome-aware validated data pipelines?**
+
+- If yes: proceed through the normal phase pipeline.
+- If indirectly: document how.
+- If no: park it unless explicitly approved.
+
+This document is a compass, not a language contract. It does not add to, remove from,
+or override anything in `GENIA_STATE.md`.

--- a/scripts/genia-new.sh
+++ b/scripts/genia-new.sh
@@ -79,6 +79,7 @@ echo "Next prompt:"
 echo
 cat <<EOF
 Follow docs/process/00-preflight.md.
+Read docs/strategy/killer-workflow.md before finalizing scope.
 
 CHANGE NAME: issue #${ISSUE} ${SLUG}
 CHANGE SLUG: ${CHANGE_SLUG}

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -995,6 +995,13 @@ def test_preflight_template_includes_killer_workflow_alignment() -> None:
     )
 
 
+def test_planner_agent_references_killer_workflow_strategy_doc() -> None:
+    text = read_text(".github/agents/planner.agent.md")
+    assert "docs/strategy/killer-workflow.md" in text, (
+        ".github/agents/planner.agent.md must reference docs/strategy/killer-workflow.md"
+    )
+
+
 def test_audit_template_includes_killer_workflow_drift_check() -> None:
     text = read_text("docs/process/06-audit.md")
     assert "KILLER WORKFLOW DRIFT CHECK" in text, (

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -958,6 +958,50 @@ def test_genia_state_records_capability_registry_exists() -> None:
     )
 
 
+# --- Killer workflow alignment doc-sync tests ---
+
+
+def test_agents_references_killer_workflow_strategy_doc() -> None:
+    text = read_text("AGENTS.md")
+    assert "docs/strategy/killer-workflow.md" in text, (
+        "AGENTS.md must reference docs/strategy/killer-workflow.md"
+    )
+
+
+def test_llm_contract_references_killer_workflow_strategy_doc() -> None:
+    text = read_text("docs/ai/LLM_CONTRACT.md")
+    assert "docs/strategy/killer-workflow.md" in text, (
+        "docs/ai/LLM_CONTRACT.md must reference docs/strategy/killer-workflow.md"
+    )
+
+
+def test_killer_workflow_strategy_doc_is_not_implemented_behavior() -> None:
+    text = read_text("docs/strategy/killer-workflow.md")
+    assert "does not define implemented" in text, (
+        "docs/strategy/killer-workflow.md must clearly state it does not define implemented behavior"
+    )
+    assert "GENIA_STATE.md" in text, (
+        "docs/strategy/killer-workflow.md must reference GENIA_STATE.md as final authority"
+    )
+
+
+def test_preflight_template_includes_killer_workflow_alignment() -> None:
+    text = read_text("docs/process/00-preflight.md")
+    assert "killer workflow" in text.lower() or "KILLER WORKFLOW" in text, (
+        "docs/process/00-preflight.md must include a Killer Workflow Alignment check"
+    )
+    assert "Outcome-aware validated data pipelines" in text, (
+        "docs/process/00-preflight.md must mention Outcome-aware validated data pipelines"
+    )
+
+
+def test_audit_template_includes_killer_workflow_drift_check() -> None:
+    text = read_text("docs/process/06-audit.md")
+    assert "KILLER WORKFLOW DRIFT CHECK" in text, (
+        "docs/process/06-audit.md must include the 'KILLER WORKFLOW DRIFT CHECK' section header"
+    )
+
+
 def test_rules_doc_8_4_mentions_slash_lowering_form() -> None:
     rules = read_text("GENIA_RULES.md")
     marker = "§8.4"


### PR DESCRIPTION
## PR Description

### Summary

Aligns Genia’s LLM/process workflow around the project’s first killer workflow:

> **Outcome-aware validated data pipelines**
> messy records in → clear pipelines → validated shaped output / reports + useful diagnostics

This change adds a small strategy guide and updates process/agent guidance so future work is explicitly checked against that priority before it drifts into broader feature work.

### Changes

* Added `docs/strategy/killer-workflow.md`

  * Defines the killer workflow as a strategy/prioritization guide
  * Clearly states it does **not** define implemented language behavior
  * Preserves `GENIA_STATE.md` as final authority
  * Identifies preferred alignment areas and parking-lot/default-defer areas

* Updated `AGENTS.md`

  * Adds a concise Product Priority section
  * Points agents to the killer workflow strategy doc
  * Routes non-aligned work to parking lot unless explicitly approved

* Updated `docs/ai/LLM_CONTRACT.md`

  * Requires agents to classify major work against the killer workflow
  * Prevents treating strategy guidance as implemented behavior

* Updated process docs

  * `docs/process/00-preflight.md`: adds Killer Workflow Alignment checklist
  * `docs/process/06-audit.md`: adds Killer Workflow Drift Check

* Updated `docs/parking-lot/README.md`

  * Clarifies that ideas not aligned with the current killer workflow should default to parking lot unless approved

* Added doc-sync tests

  * Verifies strategy references and non-authoritative wording
  * Verifies preflight and audit templates include killer workflow checks

### Validation

* `tests/doc/test_semantic_doc_sync.py` — 83 passed
* `tests/unit/test_doc_style_sync.py` — 21 passed
* `tests/doc/` — 105 passed

### Notes

* No language/runtime behavior was implemented.
* No speculative behavior is documented as current.
* No handoff files under `.genia/process/tmp/handoffs/` were committed.
