### PR TITLE
Feature/issue 375 define minimal contract for outcome aware validated data pipelines

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -173,6 +173,7 @@ CLI contract summary (actual behavior):
 - autoloaded stdlib functions keyed by `(name, arity)`
   - includes list transforms/helpers such as `reduce`, `map`, `filter`, `first`, `last`, `nth`, `find_opt`, and `range`
   - includes public map helpers from `src/genia/std/prelude/map.genia`: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`, `pairs`
+  - includes public validation helpers from `src/genia/std/prelude/validation.genia`: `validate_required`, `validate_field`
   - includes public Python-host-only ref helpers from `src/genia/std/prelude/ref.genia`: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
   - includes public Python-host-only process helpers from `src/genia/std/prelude/process.genia`: `spawn`, `send`, `process_alive?`
   - includes public output sink helpers from `src/genia/std/prelude/io.genia`: `write`, `writeln`, `flush`
@@ -218,6 +219,7 @@ CLI contract summary (actual behavior):
   - Python-host-only ref runtime helpers are exposed publicly through prelude-backed wrappers: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
   - Python-host-only process runtime helpers are exposed publicly through prelude-backed wrappers: `spawn`, `send`, `process_alive?`
   - phase-1 persistent associative map helpers are exposed publicly through prelude-backed wrappers: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`
+  - minimal record validation helpers are exposed publicly through prelude-backed wrappers: `validate_required(field, record)` and `validate_field(field, predicate, expected, record)` return `some(record)` for valid map records and recoverable `err(...)` diagnostics for missing/invalid fields; non-callable predicates remain runtime errors
   - `pairs(xs, ys)` is a pure Genia prelude function (not host-backed): zips two lists into `[[x, y], ...]` bounded by the shorter input; raises `TypeError` on non-list arguments
   - phase-2 primitive option model runtime:
     - `none` remains a runtime literal/value

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -320,6 +320,9 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - map literals and `map_*` builtins produce the same runtime map value family
   - map values are persistent and opaque at runtime (`<map N>`)
 - Sheet — immutable, columnar, named-column value (**Experimental**)
+- Validation helper results are ordinary Outcome values over ordinary map records:
+  - `validate_required(field, record)` returns `some(record)` when `record` has `field`, otherwise `err("missing required field", {row: ...?, field: field, reason: "missing required field"})`
+  - `validate_field(field, predicate, expected, record)` returns `some(record)` when the field exists and `predicate(value) == true`, otherwise a recoverable diagnostic `err(...)`; non-callable predicates remain runtime errors
 
 ### Function / module values
 
@@ -461,6 +464,7 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - `tap(fn, value)` runs `fn(value)` for side effects and returns `value` unchanged
   - these helpers do not force Flow materialization by themselves; they preserve explicit/lazy Flow boundaries unless user-provided side-effect callbacks consume a Flow value
 - public Map/Ref/Process/IO helper names are also prelude-backed wrappers over host-backed runtime primitives, so `help("name")` and higher-order use follow the user-facing stdlib surface rather than raw host bindings.
+- public validation helper names `validate_required` and `validate_field` are prelude-backed wrappers over small host-backed record checks; they return Outcome values for user-data problems and keep programmer misuse as runtime errors.
 - public Web helper names `serve_http`, `get`, `post`, `route_request`, `response`, `json`, `text`, `ok`, `ok_text`, `bad_request`, and `not_found` are also thin prelude wrappers in this phase; the underlying HTTP transport integration remains host-backed
 - public Flow helper names `lines`, `evolve` (experimental), `tee`, `merge`, `zip`, `scan`, `keep_some`, `keep_some_else`, `rules`, `each`, `collect`, and `run` are also thin prelude wrappers in this phase; the underlying Flow behavior remains host-backed and the related underscore kernels are internal to trusted prelude/runtime code
 - limited Python host interop is implemented in this phase:
@@ -1640,6 +1644,33 @@ Behavior:
 - tuple keys are supported by the same runtime key-freezing strategy (runtime-level interop values)
 - invalid map arguments and unsupported key types raise clear `TypeError`
 
+### Record validation helpers (Phase 1 minimal Outcome-aware data pipeline surface)
+
+- public validation helpers are exposed from `src/genia/std/prelude/validation.genia`
+  - `validate_required(field, record)`
+  - `validate_field(field, predicate, expected, record)`
+  - the helpers operate on one map record at a time; no schema DSL, Sheet behavior, Flow collector, or report helper is introduced in this phase
+  - the helpers use existing Outcome values: valid records return `some(record)`, and recoverable user-data problems return `err(reason, context)`
+
+Behavior:
+
+- `validate_required(field, record)`:
+  - requires `record` to be a map
+  - returns `some(record)` when `record` contains `field`
+  - returns `err("missing required field", context)` when `field` is absent
+- `validate_field(field, predicate, expected, record)`:
+  - requires `predicate` to be callable; non-callable predicates raise `TypeError("validate_field expected predicate to be callable")`
+  - requires `record` to be a map
+  - returns `err("missing required field", context)` when `field` is absent
+  - calls `predicate(value)` with raw callback invocation when the field is present
+  - returns `some(record)` only when the predicate result is exactly `true`
+  - returns `err("invalid field", context)` when the predicate result is not exactly `true`
+- missing-field diagnostic context includes `row` when the record has a `row` field, plus `field` and `reason`
+- invalid-field diagnostic context includes `row` when present, plus `field`, `expected`, `actual`, and `reason`
+- runtime/programmer misuse remains a runtime error; it is not converted into a recoverable row diagnostic
+- shared specs currently cover valid-record, missing-required-field, invalid-field, and non-callable-predicate misuse cases only
+- multi-record splitting/collection, summary reports, optional-field semantics, nested field paths, and Sheet integration are not implemented by these helpers
+
 ### Primitive Option model (Phase 3 canonical access surface on runtime-backed values)
 
 - option values:
@@ -2006,6 +2037,7 @@ Notable autoloaded functions include:
   - `apply_raw(f, args)` — language-contract host primitive; calls `f` with list `args` as positional arguments, bypassing the automatic `none(...)` short-circuit for arguments delivered to `f`; `apply_raw` itself is subject to normal none-propagation on its own two arguments (`apply_raw(f, none("x"))` short-circuits before `apply_raw` runs); `args` must be a list or `TypeError` is raised; return value of `f` is returned as-is with no coercion; exceptions inside `f` propagate unchanged; registered directly in the env (not autoloaded)
 - cli: `cli_parse`, `cli_flag?`, `cli_option`, `cli_option_or`
 - map: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`, `pairs`
+- validation: `validate_required`, `validate_field`
 - ref: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
 - process: `spawn`, `send`, `process_alive?`
 - io: `write`, `writeln`, `flush`, `clear_screen`, `move_cursor`, `render_grid`

--- a/README.md
+++ b/README.md
@@ -1185,6 +1185,13 @@ write_file("output.json", unwrap_or("{}", result))
 - persistent semantics from Genia perspective (`map_put`/`map_remove` return new map values)
 - `pairs(xs, ys)` is a pure Genia prelude function (not host-backed): zips two lists into `[[x, y], ...]` bounded by the shorter input; raises `TypeError` on non-list arguments
 
+### Minimal record validation helpers
+
+- public validation helpers from `src/genia/std/prelude/validation.genia`: `validate_required`, `validate_field`
+- `validate_required(field, record)` returns `some(record)` when a map record contains `field`; otherwise it returns `err("missing required field", context)`
+- `validate_field(field, predicate, expected, record)` returns `some(record)` only when the field exists and `predicate(value) == true`; missing or invalid user data returns recoverable `err(...)` diagnostics
+- non-callable predicates remain runtime errors; no schema DSL, Sheet integration, Flow collector, or report helper is added by this surface
+
 ## Autoloaded stdlib highlights
 
 - list helpers: `list`, `first`, `rest`, `append`, `length`, `reverse`, `reduce`, `map`, `filter`, `nth`, `take`, `drop`, `range`, ...
@@ -1193,6 +1200,7 @@ write_file("output.json", unwrap_or("{}", result))
 - fn helpers: `apply`, `apply_raw`, `compose`
   - `apply_raw(f, args)` — calls `f` with list `args` as positional arguments, bypassing automatic `none(...)` propagation; `args` must be a list
 - map helpers: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`, `pairs`
+- validation helpers: `validate_required`, `validate_field`
 - ref helpers: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
 - process helpers: `spawn`, `send`, `process_alive?`, `process_failed?`, `process_error`
 - sink helpers: `write`, `writeln`, `flush`

--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -66,10 +66,13 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 | map access | `get(key, target)`, `get?(key, target)` |
 | option chaining | `map_some(f, opt)`, `flat_map_some(f, opt)` |
 | chain helpers | `then_get(key, target)`, `then_first(target)`, `then_nth(index, target)`, `then_find(needle, target)` |
+| record validation | `validate_required(field, record)`, `validate_field(field, predicate, expected, record)` |
 | recovery | `unwrap_or(default, opt)`, `or_else(opt, fallback)`, `or_else_with(opt, thunk)` |
 | metadata | `absence_reason(opt)`, `absence_context(opt)`, `absence_meta(opt)` |
 
 Outcome values distinguish successful presence (`some(value)`), successful absence (`none(...)`), and recoverable failure (`err(...)`). In pipelines, `none(...)` and `err(...)` short-circuit ordinary stages; err(...) is not converted to `none(...)`.
+
+`validate_required` and `validate_field` are one-record map helpers for minimal Outcome-aware validation. Valid records return `some(record)`; missing or invalid fields return recoverable `err(...)` diagnostics. Non-callable predicates remain runtime errors.
 
 ## Representation
 

--- a/docs/cheatsheet/unix-power-mode.md
+++ b/docs/cheatsheet/unix-power-mode.md
@@ -34,6 +34,7 @@ For example, `examples/ants_terminal.genia` accepts `--seed`, `--ants`, `--steps
 | side effects | `each(print)`, `each(log)` |
 | materialize | `collect` |
 | maybe-safe parse | `parse_int`, `flat_map_some`, `unwrap_or` |
+| record validation | `validate_required`, `validate_field` for one map record at a time |
 | numeric aggregate | `keep_some(...) |> collect |> sum` or `map((x) -> unwrap_or(...)) |> collect |> sum` |
 
 Flow rules:
@@ -43,6 +44,7 @@ Flow rules:
 - `map` and `filter` are polymorphic: they work on both lists and flows.
 - Pipe mode is only for stage expressions that still produce a Flow.
 - Raw values stay values, flows stay flows, only explicit bridges cross.
+- Minimal validation helpers return `some(record)` for valid map records and recoverable `err(...)` diagnostics for missing or invalid fields; multi-record report collection is not a built-in helper in this phase.
 - See `docs/cheatsheet/piepline-flow-vs-value.md` for the full classification matrix.
 
 ## Working Commands

--- a/spec/error/error-validated-pipeline-predicate-non-callable.yaml
+++ b/spec/error/error-validated-pipeline-predicate-non-callable.yaml
@@ -1,0 +1,15 @@
+name: error-validated-pipeline-predicate-non-callable
+category: error
+description: Validation helper predicate misuse remains a runtime error
+input:
+  source: |
+    validate_field("age", 1, "age must equal 37", {row: 4, name: "Alan", age: 37})
+expected:
+  stdout: ""
+  stderr: "Error: validate_field expected predicate to be callable\n"
+  exit_code: 1
+notes: |
+  issue: 375
+  error_phase: eval
+  error_category: TypeError
+  contract: programmer misuse is not converted into a recoverable row diagnostic.

--- a/spec/eval/validated-pipeline-invalid-field.yaml
+++ b/spec/eval/validated-pipeline-invalid-field.yaml
@@ -1,0 +1,14 @@
+name: validated-pipeline-invalid-field
+category: eval
+description: Invalid record field is represented as a recoverable diagnostic Outcome
+input:
+  source: |
+    validate_field("age", (value) -> value == 37, "age must equal 37", {row: 3, name: "Grace", age: "old"})
+expected:
+  stdout: "err(\"invalid field\", {row: 3, field: \"age\", expected: \"age must equal 37\", actual: \"old\", reason: \"invalid field\"})\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 375
+  helper_surface: validate_field(field, predicate, expected, record)
+  contract: invalid user data is recoverable err data with row, field, expected, actual, and reason context.

--- a/spec/eval/validated-pipeline-missing-required-field.yaml
+++ b/spec/eval/validated-pipeline-missing-required-field.yaml
@@ -1,0 +1,14 @@
+name: validated-pipeline-missing-required-field
+category: eval
+description: Missing required record field is represented as a recoverable diagnostic Outcome
+input:
+  source: |
+    validate_required("age", {row: 2, name: "Linus"})
+expected:
+  stdout: "err(\"missing required field\", {row: 2, field: \"age\", reason: \"missing required field\"})\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 375
+  helper_surface: validate_required(field, record)
+  contract: missing required user data is recoverable err data with row, field, and reason context.

--- a/spec/eval/validated-pipeline-valid-record.yaml
+++ b/spec/eval/validated-pipeline-valid-record.yaml
@@ -1,0 +1,14 @@
+name: validated-pipeline-valid-record
+category: eval
+description: Minimal field validation preserves a valid record as a clean Outcome value
+input:
+  source: |
+    validate_field("age", (value) -> value == 37, "age must equal 37", {row: 1, name: "Ada", age: 37})
+expected:
+  stdout: "some({row: 1, name: \"Ada\", age: 37})\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 375
+  helper_surface: validate_field(field, predicate, expected, record)
+  contract: valid record data is preserved as some(clean_record).

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -2038,6 +2038,51 @@ def make_global_env(
             raise TypeError(f"pairs expected a list as second argument, received {_runtime_type_name(value)}")
         raise TypeError("pairs internal error expected argument position 'first' or 'second'")
 
+    def _validate_record_map(record: Any, name: str) -> GeniaMap:
+        if not isinstance(record, GeniaMap):
+            raise TypeError(f"{name} expected a record map, received {_runtime_type_name(record)}")
+        return record
+
+    def _validate_diagnostic_context(record: GeniaMap, field: Any, reason: str) -> GeniaMap:
+        context = GeniaMap()
+        if record.has("row"):
+            context = context.put("row", record.get("row"))
+        return context.put("field", field).put("reason", reason)
+
+    def validate_required_fn(field: Any, record: Any) -> Any:
+        record_map = _validate_record_map(record, "validate_required")
+        if record_map.has(field):
+            return GeniaOptionSome(record_map)
+        context = _validate_diagnostic_context(record_map, field, "missing required field")
+        return GeniaOptionErr("missing required field", context)
+
+    def _is_validation_callable(value: Any) -> bool:
+        return isinstance(value, (GeniaFunctionGroup, GeniaMap, str)) or callable(value)
+
+    def validate_field_fn(field: Any, predicate: Any, expected: Any, record: Any) -> Any:
+        if not _is_validation_callable(predicate):
+            raise TypeError("validate_field expected predicate to be callable")
+
+        record_map = _validate_record_map(record, "validate_field")
+        if not record_map.has(field):
+            context = _validate_diagnostic_context(record_map, field, "missing required field")
+            return GeniaOptionErr("missing required field", context)
+
+        actual = record_map.get(field)
+        if _invoke_raw_from_builtin(predicate, [actual]) == True:  # noqa: E712
+            return GeniaOptionSome(record_map)
+
+        context = GeniaMap()
+        if record_map.has("row"):
+            context = context.put("row", record_map.get("row"))
+        context = (
+            context.put("field", field)
+            .put("expected", expected)
+            .put("actual", actual)
+            .put("reason", "invalid field")
+        )
+        return GeniaOptionErr("invalid field", context)
+
     def some_fn(*args: Any) -> GeniaOptionSome:
         if len(args) not in (1, 2):
             raise TypeError("some(...) expects 1 or 2 arguments")
@@ -3113,6 +3158,8 @@ def make_global_env(
     env.set("_map_count", map_count_fn)
     env.set("_map_items", map_items_fn)
     env.set("_pairs_error", pairs_error_fn)
+    env.set("_validate_required", validate_required_fn)
+    env.set("_validate_field", validate_field_fn)
     env.set("_rng", rng_fn)
     env.set("_rand", rand_fn)
     env.set("_rand_seeded", seeded_rand_fn)
@@ -3252,6 +3299,8 @@ def make_global_env(
     env.register_autoload("map_keys", 1, "std/prelude/map.genia")
     env.register_autoload("map_values", 1, "std/prelude/map.genia")
     env.register_autoload("pairs", 2, "std/prelude/map.genia")
+    env.register_autoload("validate_required", 2, "std/prelude/validation.genia")
+    env.register_autoload("validate_field", 4, "std/prelude/validation.genia")
     env.register_autoload("rng", 1, "std/prelude/random.genia")
     env.register_autoload("rand_flow", 1, "std/prelude/random.genia")
     env.register_autoload("rand_int_flow", 2, "std/prelude/random.genia")

--- a/src/genia/std/prelude/validation.genia
+++ b/src/genia/std/prelude/validation.genia
@@ -1,0 +1,32 @@
+@doc """Require a record field and return an Outcome.
+
+## Arguments
+
+* `field`: field name to require
+* `record`: map record that may include `row`
+
+## Returns
+
+* `some(record)` when the field is present
+* `err("missing required field", context)` when the field is absent"""
+validate_required(field, record) = _validate_required(field, record)
+
+@doc """Validate a record field with a predicate and return an Outcome.
+
+## Arguments
+
+* `field`: field name to validate
+* `predicate`: callable checked with the field value
+* `expected`: description of the expected condition
+* `record`: map record that may include `row`
+
+## Returns
+
+* `some(record)` when the field is present and the predicate returns `true`
+* `err("missing required field", context)` when the field is absent
+* `err("invalid field", context)` when the predicate does not return `true`
+
+## Errors
+
+* raises when `predicate` is not callable"""
+validate_field(field, predicate, expected, record) = _validate_field(field, predicate, expected, record)


### PR DESCRIPTION
close #375 

## Summary

Implements the minimal Outcome-aware record validation surface for issue #375.

Adds:
- `validate_required(field, record)`
- `validate_field(field, predicate, expected, record)`

Behavior:
- valid map records return `some(record)`
- missing required fields return recoverable `err("missing required field", context)`
- invalid fields return recoverable `err("invalid field", context)`
- non-callable predicates remain runtime errors
- callable predicate semantics follow existing Genia callable behavior, including function groups, maps, strings/projectors, and host callables

Docs updated to describe this as a minimal Phase 1 surface and explicitly exclude:
- schema DSL
- Sheet integration
- Flow collector/report helper
- multi-record split/summary helpers
- nested field paths
- optional-field semantics

## Validation

- `python3 -m tools.spec_runner --verbose` → `390 passed`
- `uv run pytest -q tests/unit/test_cheatsheet_core.py tests/unit/test_cheatsheet_quick_reference.py tests/unit/test_cheatsheet_pipeline_flow_vs_value.py tests/unit/test_cheatsheet_unix_power_mode.py tests/unit/test_cheatsheet_unix_to_genia.py tests/unit/test_doc_style_sync.py` → `115 passed`
- `uv run pytest -q tests/doc/test_semantic_doc_sync.py tests/doc/test_portability_contract_sync.py` → `92 passed`
- `uv tool run ruff check src/genia/builtins.py` → passed