### PR TITLE
Feature/issue 383 validated pipelines collect clean records and diagnostics from outcome results

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -220,6 +220,7 @@ CLI contract summary (actual behavior):
   - Python-host-only process runtime helpers are exposed publicly through prelude-backed wrappers: `spawn`, `send`, `process_alive?`
   - phase-1 persistent associative map helpers are exposed publicly through prelude-backed wrappers: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`
   - minimal record validation helpers are exposed publicly through prelude-backed wrappers: `validate_required(field, record)` and `validate_field(field, predicate, expected, record)` return `some(record)` for valid map records and recoverable `err(...)` diagnostics for missing/invalid fields; non-callable predicates remain runtime errors
+  - `collect_validated(results)` is a host-backed terminal builtin (Experimental, issue #383) that accepts a Seq-compatible source of Outcome items and returns `{clean: [...], diagnostics: [...]}`; `some(value)` contributes `value` to clean; `none(...)` and `err(...)` produce structured diagnostics with `index`, `kind` (`quote(skipped)` or `quote(error)`), `reason`, and `context`; does not create Sheets or change Outcome semantics
   - `pairs(xs, ys)` is a pure Genia prelude function (not host-backed): zips two lists into `[[x, y], ...]` bounded by the shorter input; raises `TypeError` on non-list arguments
   - phase-2 primitive option model runtime:
     - `none` remains a runtime literal/value

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -147,6 +147,7 @@ PYTHON REFERENCE HOST:
   - deterministic pattern matching output for currently implemented pattern families (first-match behavior, literals, wildcard/variable binding, list/tuple/map, option, guard, glob, and named reusable pattern forms)
   - deterministic eval failures with exact `stderr` and `exit_code`, including Flow/value boundary errors: `each` given a list, `first` given a Flow, `reduce` given a non-Seq-compatible value (int, string)
   - focused core stdlib list/absence helper behavior: `map` over lists (basic and empty), `filter` over lists (basic, no-match, and Option-element callbacks), `first` (some and empty-list), `last` (some and empty-list), `nth` (in-range and out-of-bounds)
+  - `collect_validated/1` behavior: empty source, all-clean, mixed `some`/`none`/`err`, `some` context ignored on clean path, bare `none`, `err` without context, and Flow-compatible source (Experimental; initial coverage only)
 - Eval normalization is limited to line-ending normalization for `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Eval comparison is otherwise exact: `stdout`, `stderr`, and `exit_code` must match exactly after that line-ending normalization.
 - Error normalization is limited to the same line-ending normalization used for eval `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
@@ -323,6 +324,17 @@ This is the current runtime value model in `main`. It is intentionally descripti
 - Validation helper results are ordinary Outcome values over ordinary map records:
   - `validate_required(field, record)` returns `some(record)` when `record` has `field`, otherwise `err("missing required field", {row: ...?, field: field, reason: "missing required field"})`
   - `validate_field(field, predicate, expected, record)` returns `some(record)` when the field exists and `predicate(value) == true`, otherwise a recoverable diagnostic `err(...)`; non-callable predicates remain runtime errors
+- `collect_validated(results)` is an explicit terminal helper for Outcome-aware validated pipelines (**Experimental**):
+  - accepts a list or Flow (Seq-compatible source)
+  - every item must be an Outcome; non-Outcome items raise a runtime `TypeError`
+  - `some(value)` and `some(value, context)` append `value` to `clean`; `some` context is ignored in this first version
+  - `none(...)` appends a diagnostic with `kind: quote(skipped)`
+  - `err(...)` appends a diagnostic with `kind: quote(error)`
+  - diagnostics have `index` (zero-based source position), `kind` (symbol), `reason`, and `context` (`some(ctx)` when present or `none("nil")` when absent)
+  - result shape: `{clean: [...], diagnostics: [...]}`
+  - does not create Sheets
+  - does not change Outcome semantics or pipeline short-circuit behavior
+  - does not change `keep_some` or existing validation helpers
 
 ### Function / module values
 
@@ -465,6 +477,7 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - these helpers do not force Flow materialization by themselves; they preserve explicit/lazy Flow boundaries unless user-provided side-effect callbacks consume a Flow value
 - public Map/Ref/Process/IO helper names are also prelude-backed wrappers over host-backed runtime primitives, so `help("name")` and higher-order use follow the user-facing stdlib surface rather than raw host bindings.
 - public validation helper names `validate_required` and `validate_field` are prelude-backed wrappers over small host-backed record checks; they return Outcome values for user-data problems and keep programmer misuse as runtime errors.
+- `collect_validated` is a host-backed terminal builtin (Experimental) registered directly in the global environment; it consumes a Seq-compatible source of Outcome items and returns `{clean: [...], diagnostics: [...]}`; it does not alter Outcome semantics, pipeline short-circuit behavior, Sheet semantics, or existing validation helpers.
 - public Web helper names `serve_http`, `get`, `post`, `route_request`, `response`, `json`, `text`, `ok`, `ok_text`, `bad_request`, and `not_found` are also thin prelude wrappers in this phase; the underlying HTTP transport integration remains host-backed
 - public Flow helper names `lines`, `evolve` (experimental), `tee`, `merge`, `zip`, `scan`, `keep_some`, `keep_some_else`, `rules`, `each`, `collect`, and `run` are also thin prelude wrappers in this phase; the underlying Flow behavior remains host-backed and the related underscore kernels are internal to trusted prelude/runtime code
 - limited Python host interop is implemented in this phase:
@@ -1671,6 +1684,29 @@ Behavior:
 - shared specs currently cover valid-record, missing-required-field, invalid-field, and non-callable-predicate misuse cases only
 - multi-record splitting/collection, summary reports, optional-field semantics, nested field paths, and Sheet integration are not implemented by these helpers
 
+### collect_validated helper (**Experimental**, issue #383)
+
+- public name: `collect_validated/1`
+- registered as a host-backed builtin in `src/genia/builtins.py`
+- accepts a Seq-compatible source: list or Flow
+  - non-list/non-Flow input raises a runtime error
+- every item produced by the source must be an Outcome value; non-Outcome items raise `TypeError("collect_validated expected Outcome items, received <type> at index <n>")`
+- `some(value)` and `some(value, context)` append `value` to the `clean` list; the `some` context is ignored in this first version
+- `none(...)` appends a diagnostic with `kind: quote(skipped)`
+- `err(...)` appends a diagnostic with `kind: quote(error)`
+- diagnostic shape:
+  ```
+  {index: n, kind: quote(skipped) | quote(error), reason: reason, context: some(ctx) | none("nil")}
+  ```
+  - `index` is the zero-based source item position
+  - `context` is `some(ctx)` when the Outcome carried a context, or `none("nil")` when absent
+- result shape: `{clean: [...], diagnostics: [...]}`
+- does not create Sheets; Sheet conversion is explicitly deferred
+- does not change Outcome semantics, pipeline short-circuit behavior, `keep_some`, or existing validation helpers
+- `collect_validated` is terminal: it consumes the entire finite source to produce complete output; infinite Flow sources must be bounded before calling `collect_validated`
+- error shared specs cover wrong arity (0 args, 2 args), non-Seq source, and non-Outcome item cases
+- eval shared specs cover empty source, all clean, mixed `some`/`none`/`err`, `some` context ignored, bare `none`, `err` without context, and Flow-compatible source
+
 ### Primitive Option model (Phase 3 canonical access surface on runtime-backed values)
 
 - option values:
@@ -2037,7 +2073,7 @@ Notable autoloaded functions include:
   - `apply_raw(f, args)` — language-contract host primitive; calls `f` with list `args` as positional arguments, bypassing the automatic `none(...)` short-circuit for arguments delivered to `f`; `apply_raw` itself is subject to normal none-propagation on its own two arguments (`apply_raw(f, none("x"))` short-circuits before `apply_raw` runs); `args` must be a list or `TypeError` is raised; return value of `f` is returned as-is with no coercion; exceptions inside `f` propagate unchanged; registered directly in the env (not autoloaded)
 - cli: `cli_parse`, `cli_flag?`, `cli_option`, `cli_option_or`
 - map: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`, `pairs`
-- validation: `validate_required`, `validate_field`
+- validation: `validate_required`, `validate_field`; `collect_validated` (host-backed builtin, Experimental)
 - ref: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
 - process: `spawn`, `send`, `process_alive?`
 - io: `write`, `writeln`, `flush`, `clear_screen`, `move_cursor`, `render_grid`

--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,18 @@ write_file("output.json", unwrap_or("{}", result))
 - `validate_field(field, predicate, expected, record)` returns `some(record)` only when the field exists and `predicate(value) == true`; missing or invalid user data returns recoverable `err(...)` diagnostics
 - non-callable predicates remain runtime errors; no schema DSL, Sheet integration, Flow collector, or report helper is added by this surface
 
+### collect_validated terminal helper (**Experimental**, issue #383)
+
+- `collect_validated(results)` is an explicit terminal helper for Outcome-aware validated data pipelines
+- accepts a Seq-compatible source (list or Flow); non-Seq-compatible input is a runtime error
+- every item must be an Outcome; non-Outcome items raise a runtime error with the item index
+- `some(value)` and `some(value, context)` append `value` to `clean`; `some` context is ignored in this first version
+- `none(...)` appends a diagnostic with `kind: quote(skipped)`
+- `err(...)` appends a diagnostic with `kind: quote(error)`
+- diagnostics include `index`, `kind`, `reason`, and `context` (`some(ctx)` or `none("nil")`)
+- returns `{clean: [...], diagnostics: [...]}`
+- does not create Sheets; does not change Outcome semantics, pipeline short-circuit behavior, or existing helpers
+
 ## Autoloaded stdlib highlights
 
 - list helpers: `list`, `first`, `rest`, `append`, `length`, `reverse`, `reduce`, `map`, `filter`, `nth`, `take`, `drop`, `range`, ...
@@ -1200,7 +1212,7 @@ write_file("output.json", unwrap_or("{}", result))
 - fn helpers: `apply`, `apply_raw`, `compose`
   - `apply_raw(f, args)` — calls `f` with list `args` as positional arguments, bypassing automatic `none(...)` propagation; `args` must be a list
 - map helpers: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`, `pairs`
-- validation helpers: `validate_required`, `validate_field`
+- validation helpers: `validate_required`, `validate_field`; `collect_validated` (host-backed builtin, Experimental)
 - ref helpers: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
 - process helpers: `spawn`, `send`, `process_alive?`, `process_failed?`, `process_error`
 - sink helpers: `write`, `writeln`, `flush`

--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -67,12 +67,21 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 | option chaining | `map_some(f, opt)`, `flat_map_some(f, opt)` |
 | chain helpers | `then_get(key, target)`, `then_first(target)`, `then_nth(index, target)`, `then_find(needle, target)` |
 | record validation | `validate_required(field, record)`, `validate_field(field, predicate, expected, record)` |
+| pipeline collection | `collect_validated(results)` — **Experimental** |
 | recovery | `unwrap_or(default, opt)`, `or_else(opt, fallback)`, `or_else_with(opt, thunk)` |
 | metadata | `absence_reason(opt)`, `absence_context(opt)`, `absence_meta(opt)` |
 
 Outcome values distinguish successful presence (`some(value)`), successful absence (`none(...)`), and recoverable failure (`err(...)`). In pipelines, `none(...)` and `err(...)` short-circuit ordinary stages; err(...) is not converted to `none(...)`.
 
 `validate_required` and `validate_field` are one-record map helpers for minimal Outcome-aware validation. Valid records return `some(record)`; missing or invalid fields return recoverable `err(...)` diagnostics. Non-callable predicates remain runtime errors.
+
+`collect_validated(results)` (**Experimental**) is an explicit terminal helper for Outcome-aware validated pipelines. It accepts a list or Flow of Outcome items and returns `{clean: [...], diagnostics: [...]}`. `some(value)` contributes `value` to clean; `none(...)` produces a diagnostic with `kind: quote(skipped)`; `err(...)` produces a diagnostic with `kind: quote(error)`. Diagnostics include `index`, `kind`, `reason`, and `context` (`some(ctx)` or `none("nil")`). Does not create Sheets. Does not change Outcome semantics, pipeline short-circuit behavior, or existing helpers. Infinite Flow sources must be bounded before calling `collect_validated`.
+
+<!-- [case: core-collect-validated-all-clean] -->
+```genia
+collect_validated([some(1), some(2)])
+```
+Classification: **Valid** (directly tested, Experimental)
 
 ## Representation
 

--- a/docs/cheatsheet/unix-power-mode.md
+++ b/docs/cheatsheet/unix-power-mode.md
@@ -35,6 +35,7 @@ For example, `examples/ants_terminal.genia` accepts `--seed`, `--ants`, `--steps
 | materialize | `collect` |
 | maybe-safe parse | `parse_int`, `flat_map_some`, `unwrap_or` |
 | record validation | `validate_required`, `validate_field` for one map record at a time |
+| pipeline collection | `collect_validated(results)` — collects Outcome items into `{clean: [...], diagnostics: [...]}` (**Experimental**) |
 | numeric aggregate | `keep_some(...) |> collect |> sum` or `map((x) -> unwrap_or(...)) |> collect |> sum` |
 
 Flow rules:
@@ -44,7 +45,7 @@ Flow rules:
 - `map` and `filter` are polymorphic: they work on both lists and flows.
 - Pipe mode is only for stage expressions that still produce a Flow.
 - Raw values stay values, flows stay flows, only explicit bridges cross.
-- Minimal validation helpers return `some(record)` for valid map records and recoverable `err(...)` diagnostics for missing or invalid fields; multi-record report collection is not a built-in helper in this phase.
+- Minimal validation helpers return `some(record)` for valid map records and recoverable `err(...)` diagnostics for missing or invalid fields. Use `collect_validated(results)` (Experimental) to collect a finite list or Flow of Outcome items into `{clean: [...], diagnostics: [...]}` for multi-record report collection.
 - See `docs/cheatsheet/piepline-flow-vs-value.md` for the full classification matrix.
 
 ## Working Commands

--- a/spec/error/collect-validated-non-outcome-item-error.yaml
+++ b/spec/error/collect-validated-non-outcome-item-error.yaml
@@ -1,0 +1,13 @@
+name: collect-validated-non-outcome-item-error
+category: error
+description: collect_validated rejects non-Outcome items with the source index
+input:
+  source: |
+    collect_validated([some(1), 2])
+expected:
+  stdout: ""
+  stderr: "Error: collect_validated expected Outcome items, received int at index 1\n"
+  exit_code: 1
+notes: |
+  issue: 383
+  contract: raw records must be wrapped by validation as Outcome values.

--- a/spec/error/collect-validated-non-seq-source-error.yaml
+++ b/spec/error/collect-validated-non-seq-source-error.yaml
@@ -1,0 +1,13 @@
+name: collect-validated-non-seq-source-error
+category: error
+description: collect_validated rejects scalar non-Seq-compatible sources
+input:
+  source: |
+    collect_validated(42)
+expected:
+  stdout: ""
+  stderr: "Error: collect_validated expected a Seq-compatible value (list or Flow); received int.\n"
+  exit_code: 1
+notes: |
+  issue: 383
+  contract: programmer misuse of the source shape remains a runtime error.

--- a/spec/error/collect-validated-wrong-arity-two.yaml
+++ b/spec/error/collect-validated-wrong-arity-two.yaml
@@ -1,0 +1,13 @@
+name: collect-validated-wrong-arity-two
+category: error
+description: collect_validated rejects extra arguments through standard arity handling
+input:
+  source: |
+    collect_validated([], [])
+expected:
+  stdout: ""
+  stderr: "Error: No matching function: collect_validated/2. Available: collect_validated/1\n"
+  exit_code: 1
+notes: |
+  issue: 383
+  contract: collect_validated has arity one.

--- a/spec/error/collect-validated-wrong-arity-zero.yaml
+++ b/spec/error/collect-validated-wrong-arity-zero.yaml
@@ -1,0 +1,13 @@
+name: collect-validated-wrong-arity-zero
+category: error
+description: collect_validated rejects missing arguments through standard arity handling
+input:
+  source: |
+    collect_validated()
+expected:
+  stdout: ""
+  stderr: "Error: No matching function: collect_validated/0. Available: collect_validated/1\n"
+  exit_code: 1
+notes: |
+  issue: 383
+  contract: collect_validated has arity one.

--- a/spec/eval/collect-validated-all-clean.yaml
+++ b/spec/eval/collect-validated-all-clean.yaml
@@ -1,0 +1,16 @@
+name: collect-validated-all-clean
+category: eval
+description: collect_validated extracts all some values as clean records
+input:
+  source: |
+    collect_validated([
+      some({id: 1, name: "Ann"}),
+      some({id: 2, name: "Bo"})
+    ])
+expected:
+  stdout: "{clean: [{id: 1, name: \"Ann\"}, {id: 2, name: \"Bo\"}], diagnostics: []}\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 383
+  contract: some(value) contributes value to clean and emits no diagnostic.

--- a/spec/eval/collect-validated-bare-none.yaml
+++ b/spec/eval/collect-validated-bare-none.yaml
@@ -1,0 +1,13 @@
+name: collect-validated-bare-none
+category: eval
+description: collect_validated reports bare none as a skipped diagnostic
+input:
+  source: |
+    collect_validated([none])
+expected:
+  stdout: "{clean: [], diagnostics: [{index: 0, kind: skipped, reason: \"nil\", context: none(\"nil\")}]}\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 383
+  contract: bare none follows current normalization to none("nil") for diagnostic reason and missing context.

--- a/spec/eval/collect-validated-empty-list.yaml
+++ b/spec/eval/collect-validated-empty-list.yaml
@@ -1,0 +1,13 @@
+name: collect-validated-empty-list
+category: eval
+description: collect_validated returns empty clean and diagnostics lists for an empty source
+input:
+  source: |
+    collect_validated([])
+expected:
+  stdout: "{clean: [], diagnostics: []}\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 383
+  contract: empty Seq-compatible sources produce empty clean and diagnostics collections.

--- a/spec/eval/collect-validated-err-without-context.yaml
+++ b/spec/eval/collect-validated-err-without-context.yaml
@@ -1,0 +1,13 @@
+name: collect-validated-err-without-context
+category: eval
+description: collect_validated wraps missing err context as none("nil")
+input:
+  source: |
+    collect_validated([err("bad-row")])
+expected:
+  stdout: "{clean: [], diagnostics: [{index: 0, kind: error, reason: \"bad-row\", context: none(\"nil\")}]}\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 383
+  contract: err(reason) produces an error diagnostic with missing context represented as none("nil").

--- a/spec/eval/collect-validated-flow-source.yaml
+++ b/spec/eval/collect-validated-flow-source.yaml
@@ -1,0 +1,17 @@
+name: collect-validated-flow-source
+category: eval
+description: collect_validated accepts a Flow source through Seq-compatible source behavior
+input:
+  source: |
+    evolve(0, (n) -> n + 1)
+      |> take(3)
+      |> map((n) -> some(n))
+      |> collect_validated
+expected:
+  stdout: "{clean: [0, 1, 2], diagnostics: []}\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 383
+  contract: collect_validated is terminal and consumes finite Flow sources accepted by Seq-compatible helpers.
+  fixture_note: covered as eval because current flow fixture validation recognizes collect/run/reduce terminals only.

--- a/spec/eval/collect-validated-mixed-some-none-err.yaml
+++ b/spec/eval/collect-validated-mixed-some-none-err.yaml
@@ -1,0 +1,18 @@
+name: collect-validated-mixed-some-none-err
+category: eval
+description: collect_validated separates clean values from skipped and error diagnostics
+input:
+  source: |
+    collect_validated([
+      some({id: 1, name: "Ann"}),
+      none("inactive", {id: 2}),
+      err("missing-name", {id: 3}),
+      some({id: 4, name: "Cara"})
+    ])
+expected:
+  stdout: "{clean: [{id: 1, name: \"Ann\"}, {id: 4, name: \"Cara\"}], diagnostics: [{index: 1, kind: skipped, reason: \"inactive\", context: some({id: 2})}, {index: 2, kind: error, reason: \"missing-name\", context: some({id: 3})}]}\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 383
+  contract: none(...) produces skipped diagnostics and err(...) produces error diagnostics.

--- a/spec/eval/collect-validated-some-context-ignored.yaml
+++ b/spec/eval/collect-validated-some-context-ignored.yaml
@@ -1,0 +1,15 @@
+name: collect-validated-some-context-ignored
+category: eval
+description: collect_validated ignores context on accepted some values
+input:
+  source: |
+    collect_validated([
+      some({id: 1, status: "ok"}, {line: 10})
+    ])
+expected:
+  stdout: "{clean: [{id: 1, status: \"ok\"}], diagnostics: []}\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 383
+  contract: some(value, context) contributes only value to clean in this first version.

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -1420,6 +1420,59 @@ def make_global_env(
             if flow.close_on_early_termination:
                 _finalize_iterable(items, primary_error=primary_error)
 
+    def collect_validated_fn(source: Any) -> GeniaMap:
+        clean: list[Any] = []
+        diagnostics: list[Any] = []
+
+        if isinstance(source, list):
+            items: Iterable[Any] = source
+            close_source: Any = None
+        elif isinstance(source, GeniaFlow):
+            items = source.consume()
+            close_source = source
+        else:
+            _seq_compatible_error("collect_validated", source)
+
+        primary_error = False
+        try:
+            for index, item in enumerate(items):
+                if isinstance(item, GeniaOptionSome):
+                    clean.append(item.value)
+                    continue
+
+                if isinstance(item, GeniaOptionNone):
+                    diagnostics.append(
+                        GeniaMap()
+                        .put("index", index)
+                        .put("kind", symbol("skipped"))
+                        .put("reason", item.reason)
+                        .put("context", GeniaOptionSome(item.context) if item.context is not None else OPTION_NONE)
+                    )
+                    continue
+
+                if isinstance(item, GeniaOptionErr):
+                    diagnostics.append(
+                        GeniaMap()
+                        .put("index", index)
+                        .put("kind", symbol("error"))
+                        .put("reason", item.reason)
+                        .put("context", GeniaOptionSome(item.context) if item.context is not None else OPTION_NONE)
+                    )
+                    continue
+
+                raise TypeError(
+                    "collect_validated expected Outcome items, "
+                    f"received {_runtime_type_name(item)} at index {index}"
+                )
+        except Exception:
+            primary_error = True
+            raise
+        finally:
+            if isinstance(close_source, GeniaFlow) and close_source.close_on_early_termination:
+                _finalize_iterable(items, primary_error=primary_error)
+
+        return GeniaMap().put("clean", clean).put("diagnostics", diagnostics)
+
     def run_fn(source: Any) -> None:
         if isinstance(source, list):
             for _ in source:
@@ -3073,6 +3126,7 @@ def make_global_env(
     env.set_internal("_run", run_fn)
     env.set("_pipe_run", lambda source: run_fn(_ensure_flow(source, "run")))
     env.set_internal("_collect", collect_fn)
+    env.set("collect_validated", _host_function_group("collect_validated", 1, collect_validated_fn))
     env.set("argv", argv_fn)
     env.set("help", help_fn)
     env.set("doc", doc_fn)

--- a/tests/data/cheatsheet_core_cases.json
+++ b/tests/data/cheatsheet_core_cases.json
@@ -88,5 +88,10 @@
     "id": "core-actor-status",
     "source": "handler(state, _msg, _ctx) = [\"ok\", state]\na = actor(0, handler)\nactor_status(a)",
     "expected_result": "\"ready\""
+  },
+  {
+    "id": "core-collect-validated-all-clean",
+    "source": "collect_validated([some(1), some(2)])",
+    "expected_result": "{clean: [1, 2], diagnostics: []}"
   }
 ]


### PR DESCRIPTION
close #383 
````md
## Summary

Implements issue #383 by adding `collect_validated/1`, a small terminal helper for Outcome-aware validated pipelines.

`collect_validated(results)` consumes a finite list or Flow of Outcome items and returns:

```genia
{
  clean: [...],
  diagnostics: [...]
}
````

Behavior:

* `some(value)` / `some(value, context)` → appends `value` to `clean`
* `none(...)` → appends a diagnostic with `kind: quote(skipped)`
* `err(...)` → appends a diagnostic with `kind: quote(error)`
* diagnostics include `index`, `kind`, `reason`, and `context`
* missing context is represented as `none("nil")`
* present context is represented as `some(ctx)`
* non-Outcome items are programmer misuse and raise a runtime error with the item index

This keeps `err(...)` as recoverable value-level data, not a runtime exception, and gives validated data pipelines a clean way to separate accepted records from diagnostics.

## What changed

### Tests

Added shared specs covering:

* empty input
* all clean records
* mixed `some` / `none` / `err`
* ignored `some` context
* bare `none`
* `err` without context
* Flow source input
* non-Seq source error
* non-Outcome item error
* wrong arity

### Runtime

Added a minimal Python reference-host builtin in:

* `src/genia/builtins.py`

Prelude-only was not sufficient because the current public Genia surface does not expose full `err(...)` inspection/extraction or index-aware Outcome item errors while consuming both lists and Flow.

### Docs

Updated:

* `GENIA_STATE.md`
* `GENIA_REPL_README.md`
* `README.md`
* `docs/cheatsheet/core.md`
* `docs/cheatsheet/unix-power-mode.md`
* `tests/data/cheatsheet_core_cases.json`

Docs mark the helper as Experimental and explicitly state that it does not create Sheets, change Outcome semantics, change Flow/Seq semantics, change pipeline short-circuit behavior, or alter existing validation helpers.

## Validation

```bash
uv run python -m tools.spec_runner --verbose
```

```text
Summary: total=401 passed=401 failed=0 invalid=0
```

```bash
uv run pytest -q tests/spec/test_seq_shared_spec_coverage_260.py tests/spec/test_seq_as_seq_shared_spec_308.py tests/unit/test_flow_shared_spec_runner.py tests/spec/test_cli_shared_spec_runner.py
```

```text
35 passed
```

```bash
uv tool run ruff check src/genia/builtins.py
```

```text
All checks passed!
```

```bash
uv run pytest tests/unit/test_cheatsheet_core.py tests/doc/test_semantic_doc_sync.py -q
```

```text
104 passed
```

```bash
uv run pytest tests/unit/test_cheatsheet_unix_power_mode.py -q
```

```text
11 passed
```

```bash
uv run pytest tests/doc/ -q
```

```text
106 passed
```

```bash
uv run pytest -n auto -q
```

```text
2367 passed
```

## Notes

* No changes to `keep_some`
* No changes to existing validation helpers
* No Sheet conversion added
* No global diagnostics framework added
* No pipeline semantics changed
* Handoff files remain uncommitted

```
```
