### PR TITLE
feat(validation): add optional field Outcome helper issue #384

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -173,7 +173,7 @@ CLI contract summary (actual behavior):
 - autoloaded stdlib functions keyed by `(name, arity)`
   - includes list transforms/helpers such as `reduce`, `map`, `filter`, `first`, `last`, `nth`, `find_opt`, and `range`
   - includes public map helpers from `src/genia/std/prelude/map.genia`: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`, `pairs`
-  - includes public validation helpers from `src/genia/std/prelude/validation.genia`: `validate_required`, `validate_field`
+  - includes public validation helpers from `src/genia/std/prelude/validation.genia`: `validate_required`, `validate_field`, `validate_optional`
   - includes public Python-host-only ref helpers from `src/genia/std/prelude/ref.genia`: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
   - includes public Python-host-only process helpers from `src/genia/std/prelude/process.genia`: `spawn`, `send`, `process_alive?`
   - includes public output sink helpers from `src/genia/std/prelude/io.genia`: `write`, `writeln`, `flush`
@@ -220,6 +220,7 @@ CLI contract summary (actual behavior):
   - Python-host-only process runtime helpers are exposed publicly through prelude-backed wrappers: `spawn`, `send`, `process_alive?`
   - phase-1 persistent associative map helpers are exposed publicly through prelude-backed wrappers: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`
   - minimal record validation helpers are exposed publicly through prelude-backed wrappers: `validate_required(field, record)` and `validate_field(field, predicate, expected, record)` return `some(record)` for valid map records and recoverable `err(...)` diagnostics for missing/invalid fields; non-callable predicates remain runtime errors
+  - `validate_optional(field, record[, validator])` validates optional record fields (**Experimental**): missing field returns `none({field: field, reason: quote(missing_optional_field)})`; present field with no validator returns `some(value, {field: field})`; present field with validator preserves `some(...)` and `err(...)` unchanged and normalizes validator `none(...)` to `err(quote(optional_field_validator_returned_none), ...)`; non-map record, non-callable validator, and validator returning non-Outcome are runtime errors
   - `collect_validated(results)` is a host-backed terminal builtin (Experimental, issue #383) that accepts a Seq-compatible source of Outcome items and returns `{clean: [...], diagnostics: [...]}`; `some(value)` contributes `value` to clean; `none(...)` and `err(...)` produce structured diagnostics with `index`, `kind` (`quote(skipped)` or `quote(error)`), `reason`, and `context`; does not create Sheets or change Outcome semantics
   - `pairs(xs, ys)` is a pure Genia prelude function (not host-backed): zips two lists into `[[x, y], ...]` bounded by the shorter input; raises `TypeError` on non-list arguments
   - phase-2 primitive option model runtime:

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -324,6 +324,11 @@ This is the current runtime value model in `main`. It is intentionally descripti
 - Validation helper results are ordinary Outcome values over ordinary map records:
   - `validate_required(field, record)` returns `some(record)` when `record` has `field`, otherwise `err("missing required field", {row: ...?, field: field, reason: "missing required field"})`
   - `validate_field(field, predicate, expected, record)` returns `some(record)` when the field exists and `predicate(value) == true`, otherwise a recoverable diagnostic `err(...)`; non-callable predicates remain runtime errors
+  - `validate_optional(field, record)` and `validate_optional(field, record, validator)` validate optional record fields (**Experimental**):
+    - missing field returns `none({field: field, reason: quote(missing_optional_field)})`
+    - present field with no validator returns `some(value, {field: field})`
+    - present field with validator: `some(...)` and `err(...)` results are preserved unchanged; `none(...)` result is normalized to `err(quote(optional_field_validator_returned_none), {field: field, validator_result: result})`
+    - non-map record, non-callable validator, and validator returning non-Outcome are runtime errors
 - `collect_validated(results)` is an explicit terminal helper for Outcome-aware validated pipelines (**Experimental**):
   - accepts a list or Flow (Seq-compatible source)
   - every item must be an Outcome; non-Outcome items raise a runtime `TypeError`
@@ -476,7 +481,7 @@ This is the current runtime value model in `main`. It is intentionally descripti
   - `tap(fn, value)` runs `fn(value)` for side effects and returns `value` unchanged
   - these helpers do not force Flow materialization by themselves; they preserve explicit/lazy Flow boundaries unless user-provided side-effect callbacks consume a Flow value
 - public Map/Ref/Process/IO helper names are also prelude-backed wrappers over host-backed runtime primitives, so `help("name")` and higher-order use follow the user-facing stdlib surface rather than raw host bindings.
-- public validation helper names `validate_required` and `validate_field` are prelude-backed wrappers over small host-backed record checks; they return Outcome values for user-data problems and keep programmer misuse as runtime errors.
+- public validation helper names `validate_required`, `validate_field`, and `validate_optional` are prelude-backed wrappers over small host-backed record checks; they return Outcome values for user-data problems and keep programmer misuse as runtime errors.
 - `collect_validated` is a host-backed terminal builtin (Experimental) registered directly in the global environment; it consumes a Seq-compatible source of Outcome items and returns `{clean: [...], diagnostics: [...]}`; it does not alter Outcome semantics, pipeline short-circuit behavior, Sheet semantics, or existing validation helpers.
 - public Web helper names `serve_http`, `get`, `post`, `route_request`, `response`, `json`, `text`, `ok`, `ok_text`, `bad_request`, and `not_found` are also thin prelude wrappers in this phase; the underlying HTTP transport integration remains host-backed
 - public Flow helper names `lines`, `evolve` (experimental), `tee`, `merge`, `zip`, `scan`, `keep_some`, `keep_some_else`, `rules`, `each`, `collect`, and `run` are also thin prelude wrappers in this phase; the underlying Flow behavior remains host-backed and the related underscore kernels are internal to trusted prelude/runtime code

--- a/README.md
+++ b/README.md
@@ -1187,9 +1187,10 @@ write_file("output.json", unwrap_or("{}", result))
 
 ### Minimal record validation helpers
 
-- public validation helpers from `src/genia/std/prelude/validation.genia`: `validate_required`, `validate_field`
+- public validation helpers from `src/genia/std/prelude/validation.genia`: `validate_required`, `validate_field`, `validate_optional`
 - `validate_required(field, record)` returns `some(record)` when a map record contains `field`; otherwise it returns `err("missing required field", context)`
 - `validate_field(field, predicate, expected, record)` returns `some(record)` only when the field exists and `predicate(value) == true`; missing or invalid user data returns recoverable `err(...)` diagnostics
+- `validate_optional(field, record[, validator])` validates optional record fields (**Experimental**): missing field returns `none({field: field, reason: quote(missing_optional_field)})`; present field with no validator returns `some(value, {field: field})`; present field with validator preserves `some(...)` and `err(...)` unchanged and normalizes validator `none(...)` to `err(quote(optional_field_validator_returned_none), ...)`; non-map record, non-callable validator, and validator returning non-Outcome are runtime errors
 - non-callable predicates remain runtime errors; no schema DSL, Sheet integration, Flow collector, or report helper is added by this surface
 
 ### collect_validated terminal helper (**Experimental**, issue #383)
@@ -1212,7 +1213,7 @@ write_file("output.json", unwrap_or("{}", result))
 - fn helpers: `apply`, `apply_raw`, `compose`
   - `apply_raw(f, args)` — calls `f` with list `args` as positional arguments, bypassing automatic `none(...)` propagation; `args` must be a list
 - map helpers: `map_new`, `map_get`, `map_put`, `map_has?`, `map_remove`, `map_count`, `map_items`, `map_item_key`, `map_item_value`, `map_keys`, `map_values`, `pairs`
-- validation helpers: `validate_required`, `validate_field`; `collect_validated` (host-backed builtin, Experimental)
+- validation helpers: `validate_required`, `validate_field`, `validate_optional` (Experimental); `collect_validated` (host-backed builtin, Experimental)
 - ref helpers: `ref`, `ref_get`, `ref_set`, `ref_is_set`, `ref_update`
 - process helpers: `spawn`, `send`, `process_alive?`, `process_failed?`, `process_error`
 - sink helpers: `write`, `writeln`, `flush`

--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -66,7 +66,7 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 | map access | `get(key, target)`, `get?(key, target)` |
 | option chaining | `map_some(f, opt)`, `flat_map_some(f, opt)` |
 | chain helpers | `then_get(key, target)`, `then_first(target)`, `then_nth(index, target)`, `then_find(needle, target)` |
-| record validation | `validate_required(field, record)`, `validate_field(field, predicate, expected, record)` |
+| record validation | `validate_required(field, record)`, `validate_field(field, predicate, expected, record)`, `validate_optional(field, record[, validator])` — **Experimental** |
 | pipeline collection | `collect_validated(results)` — **Experimental** |
 | recovery | `unwrap_or(default, opt)`, `or_else(opt, fallback)`, `or_else_with(opt, thunk)` |
 | metadata | `absence_reason(opt)`, `absence_context(opt)`, `absence_meta(opt)` |
@@ -74,6 +74,8 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 Outcome values distinguish successful presence (`some(value)`), successful absence (`none(...)`), and recoverable failure (`err(...)`). In pipelines, `none(...)` and `err(...)` short-circuit ordinary stages; err(...) is not converted to `none(...)`.
 
 `validate_required` and `validate_field` are one-record map helpers for minimal Outcome-aware validation. Valid records return `some(record)`; missing or invalid fields return recoverable `err(...)` diagnostics. Non-callable predicates remain runtime errors.
+
+`validate_optional(field, record[, validator])` (**Experimental**) validates optional record fields: missing field returns `none({field: field, reason: quote(missing_optional_field)})`; present field with no validator returns `some(value, {field: field})`; present field with validator preserves `some(...)` and `err(...)` unchanged and normalizes validator `none(...)` to `err(quote(optional_field_validator_returned_none), ...)`. Non-map record, non-callable validator, and validator returning non-Outcome are runtime errors.
 
 `collect_validated(results)` (**Experimental**) is an explicit terminal helper for Outcome-aware validated pipelines. It accepts a list or Flow of Outcome items and returns `{clean: [...], diagnostics: [...]}`. `some(value)` contributes `value` to clean; `none(...)` produces a diagnostic with `kind: quote(skipped)`; `err(...)` produces a diagnostic with `kind: quote(error)`. Diagnostics include `index`, `kind`, `reason`, and `context` (`some(ctx)` or `none("nil")`). Does not create Sheets. Does not change Outcome semantics, pipeline short-circuit behavior, or existing helpers. Infinite Flow sources must be bounded before calling `collect_validated`.
 

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -2112,6 +2112,36 @@ def make_global_env(
     def _is_validation_callable(value: Any) -> bool:
         return isinstance(value, (GeniaFunctionGroup, GeniaMap, str)) or callable(value)
 
+    def validate_optional_fn(*args: Any) -> Any:
+        if len(args) not in (2, 3):
+            raise TypeError(f"validate_optional expected 2 or 3 arguments, got {len(args)}")
+
+        field, record = args[0], args[1]
+        validator = args[2] if len(args) == 3 else _UNSET
+
+        record_map = _validate_record_map(record, "validate_optional")
+        if validator is not _UNSET and not _is_validation_callable(validator):
+            raise TypeError("validate_optional expected validator to be callable")
+
+        if not record_map.has(field):
+            reason = GeniaMap().put("field", field).put("reason", symbol("missing_optional_field"))
+            return GeniaOptionNone(reason)
+
+        value = record_map.get(field)
+        if validator is _UNSET:
+            return GeniaOptionSome(value, GeniaMap().put("field", field))
+
+        result = _invoke_raw_from_builtin(validator, [value])
+        if isinstance(result, (GeniaOptionSome, GeniaOptionErr)):
+            return result
+        if isinstance(result, GeniaOptionNone):
+            context = GeniaMap().put("field", field).put("validator_result", result)
+            return GeniaOptionErr(symbol("optional_field_validator_returned_none"), context)
+        raise TypeError(
+            "validate_optional validator must return an Outcome, "
+            f"received {_runtime_type_name(result)}"
+        )
+
     def validate_field_fn(field: Any, predicate: Any, expected: Any, record: Any) -> Any:
         if not _is_validation_callable(predicate):
             raise TypeError("validate_field expected predicate to be callable")
@@ -3213,6 +3243,7 @@ def make_global_env(
     env.set("_map_items", map_items_fn)
     env.set("_pairs_error", pairs_error_fn)
     env.set("_validate_required", validate_required_fn)
+    env.set("_validate_optional", validate_optional_fn)
     env.set("_validate_field", validate_field_fn)
     env.set("_rng", rng_fn)
     env.set("_rand", rand_fn)
@@ -3354,6 +3385,8 @@ def make_global_env(
     env.register_autoload("map_values", 1, "std/prelude/map.genia")
     env.register_autoload("pairs", 2, "std/prelude/map.genia")
     env.register_autoload("validate_required", 2, "std/prelude/validation.genia")
+    env.register_autoload("validate_optional", 2, "std/prelude/validation.genia")
+    env.register_autoload("validate_optional", 3, "std/prelude/validation.genia")
     env.register_autoload("validate_field", 4, "std/prelude/validation.genia")
     env.register_autoload("rng", 1, "std/prelude/random.genia")
     env.register_autoload("rand_flow", 1, "std/prelude/random.genia")

--- a/src/genia/std/prelude/validation.genia
+++ b/src/genia/std/prelude/validation.genia
@@ -11,6 +11,24 @@
 * `err("missing required field", context)` when the field is absent"""
 validate_required(field, record) = _validate_required(field, record)
 
+@doc """Validate an optional record field and return an Outcome.
+
+## Arguments
+
+* `field`: optional field name to validate
+* `record`: map record that may include the field
+* `validator`: optional callable checked with the field value
+
+## Returns
+
+* `none({field: field, reason: quote(missing_optional_field)})` when the field is absent
+* `some(value, {field: field})` when the field is present and no validator is supplied
+* the validator's `some(...)` or `err(...)` unchanged when supplied
+* `err(quote(optional_field_validator_returned_none), context)` when a present field validator returns `none(...)`"""
+validate_optional(field, record) = _validate_optional(field, record)
+
+validate_optional(field, record, validator) = _validate_optional(field, record, validator)
+
 @doc """Validate a record field with a predicate and return an Outcome.
 
 ## Arguments

--- a/tests/unit/test_validate_optional.py
+++ b/tests/unit/test_validate_optional.py
@@ -1,0 +1,125 @@
+import pytest
+
+from genia import make_global_env, run_source
+from genia.utf8 import format_debug
+
+
+def _run(src: str):
+    env = make_global_env([])
+    return run_source(src, env)
+
+
+def test_validate_optional_missing_field_returns_structured_none():
+    result = _run('validate_optional("nickname", {name: "Ada"})')
+
+    assert format_debug(result) == 'none({field: "nickname", reason: missing_optional_field})'
+
+
+def test_validate_optional_present_field_without_validator_returns_some_with_context():
+    result = _run('validate_optional("nickname", {nickname: "Countess"})')
+
+    assert format_debug(result) == 'some("Countess", {field: "nickname"})'
+
+
+def test_validate_optional_preserves_validator_some_outcome():
+    src = """
+    valid(value) = some(value + 1, {source: quote(validator)})
+    validate_optional("age", {age: 41}, valid)
+    """
+
+    assert format_debug(_run(src)) == "some(42, {source: validator})"
+
+
+def test_validate_optional_preserves_validator_err_outcome():
+    src = """
+    invalid(value) = err(quote(bad_age), {actual: value})
+    validate_optional("age", {age: "old"}, invalid)
+    """
+
+    assert format_debug(_run(src)) == 'err(bad_age, {actual: "old"})'
+
+
+def test_validate_optional_validator_none_becomes_err_for_present_field():
+    src = """
+    ambiguous(value) = none("blank", {actual: value})
+    validate_optional("nickname", {nickname: ""}, ambiguous)
+    """
+
+    assert (
+        format_debug(_run(src))
+        == 'err(optional_field_validator_returned_none, {field: "nickname", validator_result: none("blank", {actual: ""})})'
+    )
+
+
+def test_validate_optional_treats_falsey_values_as_present():
+    src = """
+    [
+      validate_optional("flag", {flag: false}),
+      validate_optional("count", {count: 0}),
+      validate_optional("text", {text: ""}),
+      validate_optional("items", {items: []}),
+      validate_optional("meta", {meta: {}}),
+      validate_optional("maybe", {maybe: none("nil")}),
+      validate_optional("problem", {problem: err(quote(bad))})
+    ]
+    """
+
+    assert format_debug(_run(src)) == (
+        '[some(false, {field: "flag"}), '
+        'some(0, {field: "count"}), '
+        'some("", {field: "text"}), '
+        'some([], {field: "items"}), '
+        'some({}, {field: "meta"}), '
+        'some(none("nil"), {field: "maybe"}), '
+        'some(err(bad), {field: "problem"})]'
+    )
+
+
+def test_validate_optional_rejects_non_map_record():
+    with pytest.raises(TypeError, match="validate_optional expected a record map"):
+        _run('validate_optional("age", [1, 2, 3])')
+
+
+def test_validate_optional_rejects_non_callable_validator():
+    with pytest.raises(TypeError, match="validate_optional expected validator to be callable"):
+        _run('validate_optional("age", {age: 42}, 7)')
+
+
+def test_validate_optional_rejects_validator_returning_non_outcome():
+    src = """
+    invalid(value) = value
+    validate_optional("age", {age: 42}, invalid)
+    """
+
+    with pytest.raises(TypeError, match="validate_optional validator must return an Outcome"):
+        _run(src)
+
+
+def test_validate_optional_wrong_arity_is_runtime_misuse():
+    with pytest.raises(TypeError, match="validate_optional"):
+        _run('validate_optional("age")')
+
+
+def test_validate_required_missing_field_behavior_remains_unchanged():
+    result = _run('validate_required("age", {row: 2, name: "Linus"})')
+
+    assert (
+        format_debug(result)
+        == 'err("missing required field", {row: 2, field: "age", reason: "missing required field"})'
+    )
+
+
+def test_collect_validated_behavior_remains_unchanged():
+    src = """
+    collect_validated([
+      some({id: 1}),
+      none("inactive", {id: 2}),
+      err("bad", {id: 3})
+    ])
+    """
+
+    assert format_debug(_run(src)) == (
+        '{clean: [{id: 1}], diagnostics: ['
+        '{index: 1, kind: skipped, reason: "inactive", context: some({id: 2})}, '
+        '{index: 2, kind: error, reason: "bad", context: some({id: 3})}]}'
+    )


### PR DESCRIPTION
close #384 

## Summary

Adds `validate_optional` for Outcome-aware optional field validation.

This helper makes the intended validation semantics explicit:

- missing optional field → `none({field, reason: quote(missing_optional_field)})`
- present valid field → `some(...)`
- present invalid field → `err(...)`
- validator returning `none(...)` for a present field → normalized to `err(quote(optional_field_validator_returned_none), ...)`

## Changes

- Added host-backed `_validate_optional` builtin
- Exposed `validate_optional/2` and `validate_optional/3` through `std/prelude/validation.genia`
- Added focused unit tests for:
  - missing optional fields
  - present valid fields
  - validator `some(...)`, `none(...)`, and `err(...)` results
  - falsey present values
  - misuse/runtime error cases
  - regressions for `validate_required` and `collect_validated`
- Updated docs:
  - `GENIA_STATE.md`
  - `GENIA_REPL_README.md`
  - `README.md`
  - `docs/cheatsheet/core.md`

## Validation

- `uv run pytest -q tests/unit/test_validate_optional.py` → `12 passed`
- `uv run pytest -q tests/unit/test_option.py tests/unit/test_option_semantics.py tests/doc/cheatsheet_validation.py` → `53 passed`
- `uv run pytest -q tests/doc/test_semantic_doc_sync.py` → `84 passed`
- `uv run pytest -q tests/doc/` → `106 passed`
- `uv run pytest -q` → `2379 passed`
- `uv tool run ruff check src/genia/builtins.py tests/unit/test_validate_optional.py` → `All checks passed`

## Audit

Audit verdict: **PASS**

No blocking issues found. Handoff files remain uncommitted.