### PR TITLE
docs(strategy): add release roadmap and roadmap-ticketing process phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,10 @@ Prefer references over duplicated semantic rules.
 
 Before proposing or implementing new feature work, read:
 - `docs/strategy/killer-workflow.md`
+- `docs/strategy/release-roadmap.md`
+
+Before creating new issues/tickets, also read:
+- `docs/process/08-roadmap-ticketing.md`
 
 Prefer work that strengthens Genia's first killer workflow:
 **Outcome-aware validated data pipelines.**

--- a/docs/ai/LLM_CONTRACT.md
+++ b/docs/ai/LLM_CONTRACT.md
@@ -76,17 +76,23 @@ When creating Codex or Copilot task prompts for repository work, include instruc
 
 ## Product Priority / Killer Workflow
 
-Before proposing major new work, read `docs/strategy/killer-workflow.md`.
+Before proposing major new work, read:
+- `docs/strategy/killer-workflow.md`
+- `docs/strategy/release-roadmap.md`
+
+Before creating new issues or tickets, also read:
+- `docs/process/08-roadmap-ticketing.md`
 
 Agents must:
 
-- read the killer workflow strategy before proposing or implementing major new work
+- read the killer workflow strategy and release roadmap before proposing or implementing major new work
 - explicitly classify each change's relationship to the killer workflow
+- classify each proposed ticket as: current release, next release, infrastructure, follow-up, or parking lot
 - prefer changes that strengthen Outcome-aware validated data pipelines
 - route unrelated ideas to parking lot unless explicitly approved
-- avoid treating `docs/strategy/killer-workflow.md` as implemented behavior — it is a strategy guide, not a language contract
+- avoid treating `docs/strategy/killer-workflow.md` or `docs/strategy/release-roadmap.md` as implemented behavior — they are strategy and planning guides, not language contracts
 
-The strategy doc does not define implemented behavior. `GENIA_STATE.md` remains final authority.
+The strategy and roadmap docs do not define implemented behavior. `GENIA_STATE.md` remains final authority.
 
 ## Validation
 

--- a/docs/process/08-roadmap-ticketing.md
+++ b/docs/process/08-roadmap-ticketing.md
@@ -1,0 +1,106 @@
+# 08 — Roadmap Ticketing
+
+Status: Process guide.
+
+This phase turns approved roadmap items into GitHub issues.
+
+It happens after strategy/pre-flight planning and before implementation work begins.
+
+## Required Inputs
+
+Read completely:
+
+- AGENTS.md
+- GENIA_STATE.md
+- GENIA_RULES.md
+- GENIA_REPL_README.md
+- README.md
+- docs/strategy/killer-workflow.md
+- docs/strategy/release-roadmap.md
+
+If sources conflict, GENIA_STATE.md wins for implemented behavior.
+
+## Purpose
+
+Create tickets that keep upcoming work aligned with the release roadmap.
+
+This phase prevents agents from turning one approved direction into a pile of unrelated shiny objects.
+
+## Scope
+
+This phase creates or proposes issues.
+
+It does NOT:
+
+- implement code
+- change language behavior
+- update implemented-behavior docs
+- claim planned work is current behavior
+- expand roadmap scope without approval
+
+## Roadmap Classification
+
+Every proposed ticket must be classified as one of:
+
+- Current release
+- Next release
+- Required infrastructure
+- Follow-up
+- Parking lot
+
+If classified as Parking lot, do not create it unless explicitly approved.
+
+## Ticket Shape
+
+Each ticket must include:
+
+- release target
+- roadmap alignment
+- problem statement
+- scope includes
+- scope excludes
+- affected docs/tests/specs
+- acceptance criteria
+- non-goals
+- risk of drift
+- required process phases
+
+## Required Acceptance Criteria
+
+Each ticket must state:
+
+- what behavior is expected
+- how it will be tested
+- which docs may need updates
+- what must not change
+
+## Ticket Ordering
+
+Tickets should be ordered by dependency:
+
+1. contract/spec clarification
+2. failing tests/specs
+3. minimal implementation
+4. docs sync
+5. audit/truth review
+6. migration/follow-up
+
+Do not create broad implementation tickets when smaller staged tickets are safer.
+
+## Output
+
+Produce:
+
+- proposed issue list
+- recommended creation order
+- dependency notes
+- parking-lot items, if any
+
+## Final Check
+
+Before creating tickets, answer:
+
+- Does this support the current or next roadmap release?
+- Is the scope small enough for one process run?
+- Are speculative features clearly excluded?
+- Are docs protected from claiming future behavior?

--- a/docs/strategy/release-roadmap.md
+++ b/docs/strategy/release-roadmap.md
@@ -1,0 +1,248 @@
+# Genia Release Roadmap
+
+Status: Planning guide — non-authoritative. This is not a language contract.
+
+This document orders upcoming Genia releases. It does not define implemented language behavior.
+Planned items must not be documented as implemented behavior.
+
+Implemented behavior remains defined by:
+
+1. GENIA_STATE.md
+2. GENIA_RULES.md
+3. GENIA_REPL_README.md
+4. README.md
+5. spec/*
+
+This roadmap exists to help LLM agents and maintainers keep planning, issue creation, and release sequencing aligned with the current product direction.
+
+## Product North Star
+
+Genia's first killer workflow is:
+
+> Outcome-aware validated data pipelines.
+
+Plain-language promise:
+
+> messy records in → clear pipelines → validated shaped output / reports + useful diagnostics
+
+New release work should strengthen this workflow unless explicitly approved as infrastructure or parking-lot work.
+
+---
+
+## Release R1 — Killer Workflow Foundation
+
+Theme:
+
+> Make Outcome-aware validated data pipelines feel real, useful, and demonstrable.
+
+Primary outcomes:
+
+- JSONL / CSV / stdin record ingestion path feels smooth.
+- Outcome-aware validation helpers are coherent.
+- Diagnostics are useful for record/field failures.
+- Flow / Seq / Sheet pieces support the data-pipeline story.
+- Examples show messy records becoming clean shaped output.
+
+Includes:
+
+- record parsing helpers
+- validation helper polish
+- collect validated rows
+- diagnostic conventions
+- Sheet landing-zone improvements
+- docs/examples tied to real behavior
+
+Excludes:
+
+- general lifecycle system
+- native unit test framework
+- actors/concurrency expansion
+- browser playground
+- speculative value-template syntax
+
+Exit criteria:
+
+- A small but convincing end-to-end validated data pipeline demo exists.
+- The demo is backed by tests/specs.
+- Docs describe only implemented behavior.
+
+---
+
+## Release R2 — Native Test Kernel
+
+Theme:
+
+> Let Genia test Genia where Genia-level tests make sense.
+
+Primary outcomes:
+
+- Genia-native tests can cover pipeline, Outcome, validation, and Sheet-facing behavior.
+- Native tests complement pytest/specs; they do not replace all Python tests.
+- The first lifecycle shape is introduced through testing only.
+
+Includes:
+
+- `genia test` execution mode or equivalent test runner entry point
+- `@test`
+- minimal assertions
+- test discovery
+- deterministic test result reporting
+- minimal module/test lifecycle:
+  - init
+  - module_before
+  - test_before
+  - test
+  - test_after
+  - module_after
+  - finalize
+- test-scope annotations only:
+  - setup
+  - teardown
+  - test
+
+Excludes:
+
+- arbitrary custom lifecycle definitions
+- server/request/actor lifecycles
+- parallel native test execution
+- property testing
+- snapshot testing
+- full pytest migration
+- changing shared semantic spec authority
+
+Exit criteria:
+
+- Genia-native tests cover part of the validated data pipeline surface.
+- Python pytest remains responsible for host/runtime/parser/spec-runner internals.
+- Lifecycle semantics are documented as partial and test-runner-scoped.
+
+---
+
+## Release R3 — Lifecycle Generalization
+
+Theme:
+
+> Extract the proven test lifecycle shape into a portable lifecycle contract.
+
+Primary outcomes:
+
+- Lifecycle plans become portable Genia-level data/contracts.
+- Annotation discovery is phase-driven and explicit.
+- Execution modes can eventually use lifecycle plans without making import/load behavior spooky.
+
+Includes:
+
+- lifecycle plan shape
+- phase shape
+- scope model
+- cleanup rules
+- failure rules
+- annotation binding model
+- source-order / reverse-source-order execution rules
+- portable docs for execution-mode lifecycle proposals
+
+Excludes:
+
+- server mode implementation
+- actor lifecycle implementation
+- arbitrary plugin system
+- YAML lifecycle runner unless separately approved
+- lifecycle behavior not exercised by tests
+
+Exit criteria:
+
+- Lifecycle is documented as a general model.
+- Test lifecycle remains the first implemented consumer.
+- No annotations execute merely because they exist.
+
+---
+
+## Release R4 — Native Test Expansion / Pytest Migration Wave 1
+
+Theme:
+
+> Move appropriate Genia-facing tests into Genia-native tests.
+
+Primary outcomes:
+
+- More prelude and language-facing behavior is tested in Genia.
+- Python tests remain for Python host internals.
+- The split between native tests and pytest is explicit.
+
+Move candidates:
+
+- Outcome helpers
+- validation helpers
+- Flow/Seq visible behavior
+- Sheet helper behavior
+- prelude-level utilities
+- examples intended to be Genia-facing
+
+Keep in pytest:
+
+- parser internals
+- IR normalization
+- host adapter behavior
+- CLI harness internals
+- spec runner implementation
+- Python-specific exceptions and plumbing
+
+Exit criteria:
+
+- Native test suite proves useful without duplicating every pytest.
+- Documentation explains what belongs in native tests vs pytest.
+
+---
+
+## Release R5 — Data Workflow Hardening
+
+Theme:
+
+> Make validated pipelines feel production-useful.
+
+Possible includes:
+
+- richer diagnostics
+- grouped summaries
+- report helpers
+- Sheet aggregation helpers
+- schema/shape inspection helpers
+- better command-line ergonomics
+- clearer examples for real-world records
+
+Excludes by default:
+
+- actors
+- browser-native runtime
+- full static type system
+- broad value-template implementation
+
+---
+
+## Parking Lot / Later
+
+These are valuable, but not part of the near roadmap unless explicitly promoted:
+
+- actor system
+- browser playground runtime
+- ants / simulation teaching demos
+- full value-template system
+- refinement / shape / contract / variant roadmap
+- multi-host implementation beyond contract scaffolding
+- server mode
+- notebook mode
+- parallel native test execution
+
+---
+
+## Roadmap Rule for Agents
+
+Before proposing new tickets, agents must classify the work as:
+
+- current release
+- next release
+- infrastructure
+- follow-up
+- parking lot
+
+If the work is parking-lot/future, do not create implementation tickets unless explicitly approved.


### PR DESCRIPTION
## Summary

Adds a non-authoritative release roadmap and a roadmap-ticketing process phase so future Genia planning stays aligned with the killer workflow and does not drift into unrelated implementation work.

Changes:
- Add `docs/strategy/release-roadmap.md` as a planning guide for R1–R5.
- Add `docs/process/08-roadmap-ticketing.md` as a pre-issue process phase.
- Update `AGENTS.md` so agents read the roadmap before proposing feature work and the roadmap-ticketing phase before creating issues.
- Update `docs/ai/LLM_CONTRACT.md` with roadmap references and ticket classification rules.

The roadmap is explicitly not a language contract. `GENIA_STATE.md` remains final authority for implemented behavior.

## Release order documented

1. Killer Workflow Foundation
2. Native Test Kernel
3. Lifecycle Generalization
4. Native Test Expansion / Pytest Migration Wave 1
5. Data Workflow Hardening

## Validation

```bash
pytest tests/doc/test_semantic_doc_sync.py tests/unit/test_docs_truth_model.py -q
# 86 passed