### PR TITLE
feat(json): add outcome-aware JSONL record parser issue #389

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -234,6 +234,7 @@ CLI contract summary (actual behavior):
     - `utf8_encode`, `utf8_decode`
     - internal JSON bridge primitives: `_json_parse`, `_json_stringify`
     - public JSON wrappers: `json_parse`, `json_stringify`, `json_pretty`
+    - public JSONL record helper: `parse_jsonl_record` (**Experimental**)
     - `zip_entries`, `zip_write`
     - `entry_name`, `entry_bytes`, `set_entry_bytes`, `update_entry_bytes`, `entry_json`
   - Python-host-only HTTP serving bridge builtins (phase 1):
@@ -805,6 +806,13 @@ These are blocking/runtime primitives only; they do not introduce scheduler/asyn
   - JSON objects become runtime map values (same family used by `map_new`/`map_put`).
 - `json_stringify(value)` renders deterministic pretty JSON (`indent=2`, sorted keys) or returns `none("json-stringify-error", context)`.
 - `json_pretty(value)` remains a compatibility alias for `json_stringify(value)`.
+- `parse_jsonl_record(line)` (**Experimental**) parses one JSONL string line into an Outcome for record-oriented pipelines:
+  - valid JSON object → `some(parsed_record, context)` with `kind: quote(jsonl_record)`, `status: quote(parsed)`, `reason: quote(parsed)`
+  - blank or whitespace-only line → `none("blank_line", context)` with `kind: quote(jsonl_record)`, `status: quote(skipped)`, `reason: quote(blank_line)`
+  - malformed JSON → `err(quote(invalid_jsonl_record), context)` with `status: quote(error)`
+  - valid JSON that is not an object → `err(quote(jsonl_record_not_object), context)` with `status: quote(error)`
+  - non-string input is a runtime/type misuse error
+  - does not change `json_parse` behavior; additive helper only
 - `zip_entries(path)` returns an eager list of zip entry wrapper values in archive order.
 - `zip_write(entries, path)` writes entries in order and returns `path`.
   - It also accepts `(path, entries)` to stay pipeline-friendly with the current `|>` call-shape rules.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -1938,11 +1938,12 @@ Pattern matching note:
 
 - `utf8_decode(bytes) -> string`
 - `utf8_encode(string) -> bytes`
-- internal JSON bridge primitives: `_json_parse(string) -> value|none`, `_json_stringify(value) -> string|none`
+- internal JSON bridge primitives: `_json_parse(string) -> value|none`, `_json_stringify(value) -> string|none`, `_parse_jsonl_record(line) -> some(record, context)|none("blank_line", context)|err(reason, context)`
 - public JSON helpers from `src/genia/std/prelude/json.genia`:
   - `json_parse(string) -> value | none("json-parse-error", context)`
   - `json_stringify(value) -> string | none("json-stringify-error", context)`
   - `json_pretty(value) -> string | none(...)` (compatibility alias)
+  - `parse_jsonl_record(line) -> some(parsed_record, context) | none("blank_line", context) | err(reason, context)` (**Experimental**)
 - internal file/zip bridge primitives: `_read_file(path)`, `_write_file(path, text)`, `_zip_read(path)`, `_zip_write(path, items)`
 - public file/zip helpers from `src/genia/std/prelude/file.genia`:
   - `read_file(path) -> string | none(...)`
@@ -1966,6 +1967,14 @@ Behavior:
 - JSON objects from `json_parse` are represented as persistent runtime map values (`map_*` bridge type)
 - `json_stringify`/`json_pretty` emit deterministic pretty JSON with 2-space indentation and sorted object keys
 - JSON parse/stringify failures return structured `none(...)` metadata rather than raising parse/stringify exceptions
+- `parse_jsonl_record(line)` (**Experimental**) parses one JSONL string line and returns an Outcome with stable context metadata:
+  - valid JSON object: `some(parsed_record, {kind: quote(jsonl_record), status: quote(parsed), reason: quote(parsed)})`
+  - blank or whitespace-only line: `none("blank_line", {kind: quote(jsonl_record), status: quote(skipped), reason: quote(blank_line)})`
+  - malformed JSON: `err(quote(invalid_jsonl_record), {kind: quote(jsonl_record), status: quote(error), reason: quote(invalid_jsonl_record), message: "..."})`
+  - valid JSON that is not an object: `err(quote(jsonl_record_not_object), {kind: quote(jsonl_record), status: quote(error), reason: quote(jsonl_record_not_object)})`
+  - non-string input is a runtime/type misuse error, not a recoverable Outcome
+  - `parse_jsonl_record` does not change `json_parse` behavior; it is an additive helper
+  - shared semantic spec coverage is active for this helper (see `spec/eval/parse-jsonl-record-*.yaml` and `spec/error/parse-jsonl-record-non-string-error.yaml`)
 - `zip_read` is lazy and returns Flow items shaped as `[filename, bytes]`
 - `zip_write` consumes a Flow (or list) of `[filename, bytes|string]` items
 - file/zip parse/write/read failures return structured `none(...)` metadata for the new prelude API surface

--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,7 @@ Integration note: [design/pipeline-semantics.md](design/pipeline-semantics.md)
 - `json_parse(string) -> value | none("json-parse-error", context)`
 - `json_stringify(value) -> string | none("json-stringify-error", context)`
 - `json_pretty(value) -> string | none(...)` (compatibility alias for `json_stringify`)
+- `parse_jsonl_record(line) -> some(record, context) | none("blank_line", context) | err(reason, context)` — parse one JSONL object line into an Outcome for record pipelines (**Experimental**)
 - `read_file(path) -> string | none(...)`
 - `write_file(path, string) -> path | none(...)`
 - `zip_read(path) -> flow | none(...)`

--- a/docs/cheatsheet/core.md
+++ b/docs/cheatsheet/core.md
@@ -66,6 +66,7 @@ Use explicit Option helpers when you need exact wrap-vs-flat-map control.
 | map access | `get(key, target)`, `get?(key, target)` |
 | option chaining | `map_some(f, opt)`, `flat_map_some(f, opt)` |
 | chain helpers | `then_get(key, target)`, `then_first(target)`, `then_nth(index, target)`, `then_find(needle, target)` |
+| JSONL record parse | `parse_jsonl_record(line)` → `some(record, ctx)` / `none("blank_line", ctx)` / `err(reason, ctx)` — **Experimental** |
 | record validation | `validate_required(field, record)`, `validate_field(field, predicate, expected, record)`, `validate_optional(field, record[, validator])` — **Experimental** |
 | pipeline collection | `collect_validated(results)` — **Experimental** |
 | recovery | `unwrap_or(default, opt)`, `or_else(opt, fallback)`, `or_else_with(opt, thunk)` |
@@ -76,6 +77,8 @@ Outcome values distinguish successful presence (`some(value)`), successful absen
 `validate_required` and `validate_field` are one-record map helpers for minimal Outcome-aware validation. Valid records return `some(record)`; missing or invalid fields return recoverable `err(...)` diagnostics. `field` may be a flat name or simple dot-joined nested path such as `"patient.name"` for validation helper lookup and diagnostic metadata only. Non-callable predicates remain runtime errors.
 
 `validate_optional(field, record[, validator])` (**Experimental**) validates optional record fields: missing field returns `none({field: field, reason: quote(missing_optional_field)})`; present field with no validator returns `some(value, {field: field})`; present field with validator preserves `some(...)`, keeps `err(...)` meaning while prefixing a `field` context entry to the full nested path when applicable, and normalizes validator `none(...)` to `err(quote(optional_field_validator_returned_none), ...)`. Non-map record, non-callable validator, and validator returning non-Outcome are runtime errors.
+
+`parse_jsonl_record(line)` (**Experimental**) parses one JSONL string into an Outcome for record pipelines. Valid JSON objects return `some(record, context)` with `kind: quote(jsonl_record)`, `status: quote(parsed)`, `reason: quote(parsed)`. Blank or whitespace-only lines return `none("blank_line", context)` with `reason: quote(blank_line)` in context. Malformed JSON returns `err(quote(invalid_jsonl_record), context)`. Valid non-object JSON (array, number, string, boolean, null) returns `err(quote(jsonl_record_not_object), context)`. Non-string input is a runtime/type misuse error. Does not change `json_parse` behavior.
 
 `collect_validated(results)` (**Experimental**) is an explicit terminal helper for Outcome-aware validated pipelines. It accepts a list or Flow of Outcome items and returns `{clean: [...], diagnostics: [...]}`. `some(value)` contributes `value` to clean; `none(...)` produces a diagnostic with `kind: quote(skipped)`; `err(...)` produces a diagnostic with `kind: quote(error)`. Diagnostics include `index`, `kind`, `reason`, and `context` (`some(ctx)` or `none("nil")`). Does not create Sheets. Does not change Outcome semantics, pipeline short-circuit behavior, or existing helpers. Infinite Flow sources must be bounded before calling `collect_validated`.
 

--- a/docs/cheatsheet/unix-power-mode.md
+++ b/docs/cheatsheet/unix-power-mode.md
@@ -34,6 +34,7 @@ For example, `examples/ants_terminal.genia` accepts `--seed`, `--ants`, `--steps
 | side effects | `each(print)`, `each(log)` |
 | materialize | `collect` |
 | maybe-safe parse | `parse_int`, `flat_map_some`, `unwrap_or` |
+| JSONL record parse | `parse_jsonl_record(line)` — `some(record, ctx)` / `none("blank_line", ctx)` / `err(reason, ctx)` per line (**Experimental**) |
 | record validation | `validate_required`, `validate_field` for one map record at a time |
 | pipeline collection | `collect_validated(results)` — collects Outcome items into `{clean: [...], diagnostics: [...]}` (**Experimental**) |
 | numeric aggregate | `keep_some(...) |> collect |> sum` or `map((x) -> unwrap_or(...)) |> collect |> sum` |
@@ -45,6 +46,7 @@ Flow rules:
 - `map` and `filter` are polymorphic: they work on both lists and flows.
 - Pipe mode is only for stage expressions that still produce a Flow.
 - Raw values stay values, flows stay flows, only explicit bridges cross.
+- `parse_jsonl_record(line)` (**Experimental**) parses one JSONL string line into an Outcome: valid JSON objects → `some(record, ctx)`, blank lines → `none("blank_line", ctx)`, malformed or non-object JSON → `err(reason, ctx)`. Non-string input is a runtime error. Does not change `json_parse`.
 - Minimal validation helpers return `some(record)` for valid map records and recoverable `err(...)` diagnostics for missing or invalid fields. Validation `field` arguments may be flat names or simple dot-joined nested paths such as `"patient.name"` for helper lookup and diagnostic metadata only. Use `collect_validated(results)` (Experimental) to collect a finite list or Flow of Outcome items into `{clean: [...], diagnostics: [...]}` for multi-record report collection.
 - See `docs/cheatsheet/piepline-flow-vs-value.md` for the full classification matrix.
 

--- a/spec/error/parse-jsonl-record-non-string-error.yaml
+++ b/spec/error/parse-jsonl-record-non-string-error.yaml
@@ -1,0 +1,15 @@
+name: parse-jsonl-record-non-string-error
+category: error
+description: parse_jsonl_record treats non-string input as runtime API misuse
+input:
+  source: |
+    parse_jsonl_record(42)
+expected:
+  stdout: ""
+  stderr: "Error: parse_jsonl_record expected a string, received int\n"
+  exit_code: 1
+notes: |
+  issue: 389
+  error_phase: eval
+  error_category: TypeError
+  contract: non-string input is programmer misuse, not a recoverable record-level err(...).

--- a/spec/eval/parse-jsonl-record-blank-lines.yaml
+++ b/spec/eval/parse-jsonl-record-blank-lines.yaml
@@ -1,0 +1,20 @@
+name: parse-jsonl-record-blank-lines
+category: eval
+description: parse_jsonl_record returns none(context) for empty and whitespace-only lines
+input:
+  source: |
+    describe(result) =
+      none(_, ctx) -> [ctx.kind, ctx.status, ctx.reason] |
+      _ -> [quote(unexpected)]
+
+    [
+      describe(parse_jsonl_record("")),
+      describe(parse_jsonl_record("   "))
+    ]
+expected:
+  stdout: "[[jsonl_record, skipped, blank_line], [jsonl_record, skipped, blank_line]]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 389
+  contract: empty or whitespace-only record lines are skipped as none(context), not malformed data.

--- a/spec/eval/parse-jsonl-record-invalid-json.yaml
+++ b/spec/eval/parse-jsonl-record-invalid-json.yaml
@@ -1,0 +1,18 @@
+name: parse-jsonl-record-invalid-json
+category: eval
+description: parse_jsonl_record returns err(invalid_jsonl_record, context) for malformed non-blank JSON
+input:
+  source: |
+    describe(result) =
+      err(reason, ctx) -> [reason, ctx.kind, ctx.status, ctx.reason] |
+      _ -> [quote(unexpected)]
+
+    describe(parse_jsonl_record("{\"id\":"))
+expected:
+  stdout: "[invalid_jsonl_record, jsonl_record, error, invalid_jsonl_record]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 389
+  contract: malformed non-blank JSONL records are recoverable err(...) values with stable reason category.
+  fixture_note: parser message text is intentionally not asserted.

--- a/spec/eval/parse-jsonl-record-json-parse-regression.yaml
+++ b/spec/eval/parse-jsonl-record-json-parse-regression.yaml
@@ -1,0 +1,18 @@
+name: parse-jsonl-record-json-parse-regression
+category: eval
+description: existing json_parse invalid-JSON behavior remains none(json-parse-error)
+input:
+  source: |
+    parsed = json_parse("{\"x\":")
+    [
+      none?(parsed),
+      unwrap_or("?", absence_reason(parsed)),
+      unwrap_or("?", absence_context(parsed) |> then_get("source"))
+    ]
+expected:
+  stdout: "[true, \"json-parse-error\", \"json_parse\"]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 389
+  contract: parse_jsonl_record is additive and must not change existing json_parse failure behavior.

--- a/spec/eval/parse-jsonl-record-non-object-json.yaml
+++ b/spec/eval/parse-jsonl-record-non-object-json.yaml
@@ -1,0 +1,23 @@
+name: parse-jsonl-record-non-object-json
+category: eval
+description: parse_jsonl_record returns err(jsonl_record_not_object, context) for valid non-object JSON values
+input:
+  source: |
+    describe(result) =
+      err(reason, ctx) -> [reason, ctx.kind, ctx.status, ctx.reason] |
+      _ -> [quote(unexpected)]
+
+    [
+      describe(parse_jsonl_record("[1,2]")),
+      describe(parse_jsonl_record("123")),
+      describe(parse_jsonl_record("\"text\"")),
+      describe(parse_jsonl_record("true")),
+      describe(parse_jsonl_record("null"))
+    ]
+expected:
+  stdout: "[[jsonl_record_not_object, jsonl_record, error, jsonl_record_not_object], [jsonl_record_not_object, jsonl_record, error, jsonl_record_not_object], [jsonl_record_not_object, jsonl_record, error, jsonl_record_not_object], [jsonl_record_not_object, jsonl_record, error, jsonl_record_not_object], [jsonl_record_not_object, jsonl_record, error, jsonl_record_not_object]]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 389
+  contract: this helper is record-oriented; valid JSON values that are not objects are recoverable record-shape errors.

--- a/spec/eval/parse-jsonl-record-pipeline-shape.yaml
+++ b/spec/eval/parse-jsonl-record-pipeline-shape.yaml
@@ -1,0 +1,24 @@
+name: parse-jsonl-record-pipeline-shape
+category: eval
+description: parse_jsonl_record composes as an ordinary function over record-like list pipelines
+input:
+  source: |
+    classify(result) =
+      some(record, ctx) -> [quote(clean), record.id, ctx.status] |
+      none(_, ctx) -> [quote(skip), ctx.reason] |
+      err(reason, ctx) -> [quote(error), reason, ctx.reason]
+
+    [
+      "{\"id\":1}",
+      "",
+      "{bad}",
+      "[1,2]",
+      "{\"id\":2}"
+    ] |> map((line) -> classify(parse_jsonl_record(line)))
+expected:
+  stdout: "[[clean, 1, parsed], [skip, blank_line], [error, invalid_jsonl_record, invalid_jsonl_record], [error, jsonl_record_not_object, jsonl_record_not_object], [clean, 2, parsed]]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 389
+  contract: the helper is a normal function suitable for record pipelines and does not terminate processing on dirty records.

--- a/spec/eval/parse-jsonl-record-valid-object.yaml
+++ b/spec/eval/parse-jsonl-record-valid-object.yaml
@@ -1,0 +1,17 @@
+name: parse-jsonl-record-valid-object
+category: eval
+description: parse_jsonl_record returns some(record, context) for a valid JSON object line
+input:
+  source: |
+    describe(result) =
+      some(record, ctx) -> [record.id, record.name, ctx.kind, ctx.status, ctx.reason] |
+      _ -> [quote(unexpected)]
+
+    describe(parse_jsonl_record("{\"id\":1,\"name\":\"Ada\"}"))
+expected:
+  stdout: "[1, \"Ada\", jsonl_record, parsed, parsed]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 389
+  contract: valid JSON object lines become some(parsed_record, context) with stable jsonl_record/parsed context fields.

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -2602,6 +2602,49 @@ def make_global_env(
             return make_none("json-parse-error", context)
         return _json_to_runtime(parsed)
 
+    def _jsonl_context(status: str, reason: str) -> GeniaMap:
+        return (
+            GeniaMap()
+            .put("kind", symbol("jsonl_record"))
+            .put("status", symbol(status))
+            .put("reason", symbol(reason))
+        )
+
+    def _jsonl_value_type(value: Any) -> GeniaSymbol:
+        if value is None:
+            return symbol("null")
+        if isinstance(value, bool):
+            return symbol("bool")
+        if isinstance(value, (int, float)):
+            return symbol("number")
+        if isinstance(value, str):
+            return symbol("string")
+        if isinstance(value, list):
+            return symbol("list")
+        if isinstance(value, dict):
+            return symbol("object")
+        return symbol("unknown")
+
+    def parse_jsonl_record_fn(value: Any) -> Any:
+        text = _ensure_string(value, "parse_jsonl_record")
+        if text.strip() == "":
+            return make_none("blank_line", _jsonl_context("skipped", "blank_line"))
+
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            context = _jsonl_context("error", "invalid_jsonl_record").put("message", exc.msg)
+            return GeniaOptionErr(symbol("invalid_jsonl_record"), context)
+
+        runtime_value = _json_to_runtime(parsed)
+        if not isinstance(runtime_value, GeniaMap):
+            context = _jsonl_context("error", "jsonl_record_not_object").put(
+                "value_type", _jsonl_value_type(parsed)
+            )
+            return GeniaOptionErr(symbol("jsonl_record_not_object"), context)
+
+        return GeniaOptionSome(runtime_value, _jsonl_context("parsed", "parsed"))
+
     def json_stringify_fn(value: Any) -> Any:
         try:
             return json.dumps(_json_from_runtime(value), indent=2, ensure_ascii=False, sort_keys=True)
@@ -3328,6 +3371,7 @@ def make_global_env(
     env.set("_resource_meta", resource_meta_fn)
     env.set("_resource_capabilities", resource_capabilities_fn)
     env.set("_json_parse", json_parse_fn)
+    env.set("_parse_jsonl_record", parse_jsonl_record_fn)
     env.set("_json_stringify", json_stringify_fn)
     env.set("_serve_http", serve_http_fn)
     env.set("_zip_read", zip_read_fn)
@@ -3495,6 +3539,7 @@ def make_global_env(
     env.register_autoload("parse_int", 1, "std/prelude/string.genia")
     env.register_autoload("parse_int", 2, "std/prelude/string.genia")
     env.register_autoload("json_parse", 1, "std/prelude/json.genia")
+    env.register_autoload("parse_jsonl_record", 1, "std/prelude/json.genia")
     env.register_autoload("json_stringify", 1, "std/prelude/json.genia")
     env.register_autoload("json_pretty", 1, "std/prelude/json.genia")
     env.register_autoload("read_file", 1, "std/prelude/file.genia")

--- a/src/genia/std/prelude/json.genia
+++ b/src/genia/std/prelude/json.genia
@@ -5,6 +5,14 @@ Returns `none("json-parse-error", context)` on parse/type failures.
 """
 json_parse(value) = _json_parse(value)
 
+@doc """Parse one JSONL object record into an Outcome.
+
+Returns `some(record, context)` for JSON objects.
+Returns `none(context)` for blank lines.
+Returns `err(reason, context)` for malformed JSON or non-object JSON values.
+"""
+parse_jsonl_record(line) = _parse_jsonl_record(line)
+
 @doc """Render a Genia value as deterministic pretty JSON.
 
 Object keys are sorted and output uses 2-space indentation.

--- a/tests/spec/test_parse_jsonl_record_shared_spec_389.py
+++ b/tests/spec/test_parse_jsonl_record_shared_spec_389.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import pytest
+
+from tools.spec_runner.comparator import compare_spec
+from tools.spec_runner.executor import execute_spec
+from tools.spec_runner.loader import discover_specs, load_spec
+
+
+ISSUE_389_EVAL_SPECS = [
+    "parse-jsonl-record-valid-object.yaml",
+    "parse-jsonl-record-blank-lines.yaml",
+    "parse-jsonl-record-invalid-json.yaml",
+    "parse-jsonl-record-non-object-json.yaml",
+    "parse-jsonl-record-pipeline-shape.yaml",
+    "parse-jsonl-record-json-parse-regression.yaml",
+]
+
+ISSUE_389_ERROR_SPECS = [
+    "parse-jsonl-record-non-string-error.yaml",
+]
+
+
+def _assert_spec_passes(path: str) -> None:
+    spec = load_spec(Path(path))
+    actual = execute_spec(spec)
+    failures = compare_spec(spec, actual)
+    assert failures == []
+
+
+def test_issue_389_shared_spec_inventory_is_present() -> None:
+    specs, invalid_specs = discover_specs()
+    names = {spec.path.name for spec in specs}
+
+    assert invalid_specs == []
+    for fname in ISSUE_389_EVAL_SPECS + ISSUE_389_ERROR_SPECS:
+        assert fname in names
+
+
+@pytest.mark.parametrize("fname", ISSUE_389_EVAL_SPECS)
+def test_issue_389_parse_jsonl_record_eval_shared_specs_execute_as_contract(fname: str) -> None:
+    _assert_spec_passes(f"spec/eval/{fname}")
+
+
+@pytest.mark.parametrize("fname", ISSUE_389_ERROR_SPECS)
+def test_issue_389_parse_jsonl_record_error_shared_specs_execute_as_contract(fname: str) -> None:
+    _assert_spec_passes(f"spec/error/{fname}")


### PR DESCRIPTION
close #389 

## Summary

Adds `parse_jsonl_record/1`, an Outcome-aware JSONL record helper for validated record pipelines.

The helper parses one JSONL string line at a time and returns:

- `some(record, context)` for valid JSON object records
- `none("blank_line", context)` for blank or whitespace-only lines
- `err(quote(invalid_jsonl_record), context)` for malformed JSON
- `err(quote(jsonl_record_not_object), context)` for valid JSON that is not an object
- runtime/type misuse error for non-string input

This is additive and preserves existing `json_parse` behavior.

## What changed

- Added host-backed `_parse_jsonl_record` in `src/genia/builtins.py`
- Exposed public `parse_jsonl_record/1` through `src/genia/std/prelude/json.genia`
- Added shared semantic specs for:
  - valid object records
  - blank/whitespace records
  - malformed JSON
  - non-object JSON
  - pipeline-shaped usage
  - `json_parse` regression behavior
  - non-string misuse error
- Updated docs:
  - `GENIA_STATE.md`
  - `GENIA_REPL_README.md`
  - `README.md`
  - `docs/cheatsheet/core.md`
  - `docs/cheatsheet/unix-power-mode.md`

## Scope notes

This does **not** add:

- JSONL file reading
- automatic JSONL CLI mode
- parser/lexer/IR changes
- Flow/Seq/Sheet changes
- Outcome semantic changes
- required source/line metadata

## Validation

- `uv run pytest -q tests/spec/test_parse_jsonl_record_shared_spec_389.py` → `8 passed`
- `uv run pytest -q tests/unit/test_cheatsheet_core.py tests/unit/test_cheatsheet_unix_power_mode.py tests/unit/test_doc_style_sync.py` → `50 passed`
- `uv run python -m tools.spec_runner` → `total=414 passed=414 failed=0 invalid=0`
- `uv run pytest -q` → `2396 passed`