### PR TITLE
Feature/issue 414 spec add shared conformance cases for validate each 2

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -149,12 +149,13 @@ PYTHON REFERENCE HOST:
   - focused core stdlib list/absence helper behavior: `map` over lists (basic and empty), `filter` over lists (basic, no-match, and Option-element callbacks), `first` (some and empty-list), `last` (some and empty-list), `nth` (in-range and out-of-bounds)
   - selected validation helper behavior: optional field present/absent/invalid outcomes, required field present success, and simple nested validation path success/missing diagnostics (Partial; Python reference host only)
   - `collect_validated/1` behavior: empty source, all-clean, mixed `some`/`none`/`err`, `some` context ignored on clean path, bare `none`, `err` without context, and Flow-compatible source (Experimental; initial coverage only)
+  - selected `validate_each/2` behavior: empty list, `some(...)` preservation, and mixed `some(...)` / `none(...)` / `err(...)` preservation (Experimental; initial coverage only)
 - Eval normalization is limited to line-ending normalization for `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Eval comparison is otherwise exact: `stdout`, `stderr`, and `exit_code` must match exactly after that line-ending normalization.
 - Error normalization is limited to the same line-ending normalization used for eval `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Error comparison is otherwise exact in this phase: `stdout` must be `""`, `stderr` must match exactly after that line-ending normalization, and `exit_code` must be `1`.
 - The current shared spec runner also executes IR cases (`spec/ir/`), comparing normalized portable Core IR output before host-local optimization.
-- Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface (including deterministic pattern miss, guard-all-fail, malformed-glob, and named-pattern error cases) and does not machine-assert structured phase/category/message fields.
+- Error shared coverage is active but initial only: the current inventory proves a narrow normalized error surface (including deterministic pattern miss, guard-all-fail, malformed-glob, named-pattern error cases, and selected `validate_each/2` misuse diagnostics: non-list source, non-callable validator, and non-Outcome validator result) and does not machine-assert structured phase/category/message fields.
 - The current shared spec runner executes Parse cases (`spec/parse/`) by calling the Python host parse adapter directly; for `kind: ok` cases the normalized AST is compared exactly; for `kind: error` cases the error type is compared exactly and the message is matched as a substring.
 - The current shared spec runner accepts `-v` / `--verbose`, printing each spec name before execution starts and then a single timing line (`<name>\t<elapsed>s`) after each spec completes.
 - Parse shared coverage is active but initial only: the current inventory covers stable, already-implemented syntax forms, and now includes named pattern declaration (`pattern Name(value) = body`) and named pattern use in case arms (`Name(inner_pattern)`), including error cases for invalid declaration and use arity. Parse spec coverage expands only when new forms are explicitly added and tested.
@@ -1716,7 +1717,7 @@ Behavior:
 - simple nested field paths are supported for validation helper lookup and diagnostic metadata by passing a dot-joined string field such as `"patient.name"` or `"patient.address.zip"`; diagnostics keep that full path in `field`
 - this nested validation path support does not add general field-path syntax, wildcards, recursive descent, list index paths, or a public path value type
 - runtime/programmer misuse remains a runtime error; it is not converted into a recoverable row diagnostic
-- shared specs currently cover selected validation helper behavior only: valid-record, required-field present/missing, optional-field present/absent/invalid, simple nested validation path success/missing diagnostics, invalid-field, and non-callable-predicate misuse cases
+- shared specs currently cover selected validation helper behavior only: valid-record, required-field present/missing, optional-field present/absent/invalid, simple nested validation path success/missing diagnostics, invalid-field, non-callable-predicate misuse cases, selected `validate_each/2` behavior (empty list, `some(...)` preservation, and mixed `some(...)` / `none(...)` / `err(...)` preservation), and selected `validate_each/2` misuse diagnostics (non-list source, non-callable validator, and non-Outcome validator result)
 - multi-record splitting/collection, summary reports, Sheet integration, and broader path semantics are not implemented by these helpers
 
 ### validate_record helper (**Experimental**, issue #391)

--- a/spec/error/validate-each-rejects-non-callable-validator.yaml
+++ b/spec/error/validate-each-rejects-non-callable-validator.yaml
@@ -1,0 +1,15 @@
+name: validate-each-rejects-non-callable-validator
+category: error
+description: validate_each rejects non-callable validators as programmer misuse
+input:
+  source: |
+    validate_each([1, 2], 42)
+expected:
+  stdout: ""
+  stderr: "Error: validate_each expected validator to be callable\n"
+  exit_code: 1
+notes: |
+  issue: 414
+  error_phase: eval
+  error_category: TypeError
+  contract: validate_each requires a callable validator.

--- a/spec/error/validate-each-rejects-non-list-source.yaml
+++ b/spec/error/validate-each-rejects-non-list-source.yaml
@@ -1,0 +1,16 @@
+name: validate-each-rejects-non-list-source
+category: error
+description: validate_each rejects non-list sources as programmer misuse
+input:
+  source: |
+    ok(x) = some(x)
+    validate_each({a: 1}, ok)
+expected:
+  stdout: ""
+  stderr: "Error: validate_each expected a list source, received map\n"
+  exit_code: 1
+notes: |
+  issue: 414
+  error_phase: eval
+  error_category: TypeError
+  contract: validate_each source input is list-only in this phase.

--- a/spec/error/validate-each-rejects-non-outcome-validator-result.yaml
+++ b/spec/error/validate-each-rejects-non-outcome-validator-result.yaml
@@ -1,0 +1,16 @@
+name: validate-each-rejects-non-outcome-validator-result
+category: error
+description: validate_each rejects validators that return non-Outcome values
+input:
+  source: |
+    bad(x) = x
+    validate_each([1], bad)
+expected:
+  stdout: ""
+  stderr: "Error: validate_each validator must return an Outcome, received int at index 0\n"
+  exit_code: 1
+notes: |
+  issue: 414
+  error_phase: eval
+  error_category: TypeError
+  contract: validate_each validators must return some(...), none(...), or err(...).

--- a/spec/eval/validate-each-empty-list.yaml
+++ b/spec/eval/validate-each-empty-list.yaml
@@ -1,0 +1,14 @@
+name: validate-each-empty-list
+category: eval
+description: validate_each returns an empty list for an empty source
+input:
+  source: |
+    ok(x) = some(x)
+    validate_each([], ok)
+expected:
+  stdout: "[]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 414
+  contract: empty list validation produces no synthetic Outcome or diagnostic.

--- a/spec/eval/validate-each-preserves-none-and-err-results.yaml
+++ b/spec/eval/validate-each-preserves-none-and-err-results.yaml
@@ -1,0 +1,18 @@
+name: validate-each-preserves-none-and-err-results
+category: eval
+description: validate_each preserves mixed Outcome results without aggregating diagnostics
+input:
+  source: |
+    classify(x) =
+      0 -> none("skipped_zero") |
+      n ? n == -1 -> err(quote(invalid_negative), {value: x}) |
+      _ -> some(x)
+
+    validate_each([1, 0, -1, 2], classify)
+expected:
+  stdout: "[some(1), none(\"skipped_zero\"), err(invalid_negative, {value: -1}), some(2)]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 414
+  contract: none(...) and err(...) are preserved as item Outcomes; aggregation remains collect_validated.

--- a/spec/eval/validate-each-preserves-some-results.yaml
+++ b/spec/eval/validate-each-preserves-some-results.yaml
@@ -1,0 +1,14 @@
+name: validate-each-preserves-some-results
+category: eval
+description: validate_each preserves per-item some results in source order
+input:
+  source: |
+    ok(x) = some(x)
+    validate_each([1, 2, 3], ok)
+expected:
+  stdout: "[some(1), some(2), some(3)]\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 414
+  contract: validate_each returns a list of Outcome values and preserves source order.


### PR DESCRIPTION
close #414 

## Summary

Adds shared conformance coverage for `validate_each/2`.

This PR adds six shared spec cases covering selected successful and misuse behavior for the existing experimental `validate_each/2` helper, then updates `GENIA_STATE.md` to record that narrow shared coverage.

## Changes

- Added eval shared specs for:
  - `validate-each-preserves-some-results`
  - `validate-each-empty-list`
  - `validate-each-preserves-none-and-err-results`

- Added error shared specs for:
  - `validate-each-rejects-non-list-source`
  - `validate-each-rejects-non-callable-validator`
  - `validate-each-rejects-non-outcome-validator-result`

- Updated `GENIA_STATE.md` to document selected `validate_each/2` shared coverage:
  - empty list behavior
  - `some(...)` preservation
  - mixed `some(...)` / `none(...)` / `err(...)` preservation
  - selected misuse diagnostics

## Scope

This is a spec/docs-only change.

No implementation files were changed. This PR does not add:

- `validate_each/3`
- Flow input support
- Sheet input support
- aggregation behavior inside `validate_each`
- validation DSL behavior
- context merging

## Validation

Passed:

```bash
uv run pytest -q tests/unit/test_validate_each.py
# 8 passed

uv run pytest -q tests/unit/test_validate_record.py
# 11 passed

uv run pytest -q tests/unit/test_validate_optional.py
# 21 passed

uv run python -m tools.spec_runner
# total=420 passed=420 failed=0 invalid=0

uv run pytest -q tests/doc/test_semantic_doc_sync.py
# 84 passed