### PR TITLE
test(validation): add shared validate_each collect_validated spec iss…

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -150,6 +150,7 @@ PYTHON REFERENCE HOST:
   - selected validation helper behavior: optional field present/absent/invalid outcomes, required field present success, and simple nested validation path success/missing diagnostics (Partial; Python reference host only)
   - `collect_validated/1` behavior: empty source, all-clean, mixed `some`/`none`/`err`, `some` context ignored on clean path, bare `none`, `err` without context, and Flow-compatible source (Experimental; initial coverage only)
   - selected `validate_each/2` behavior: empty list, `some(...)` preservation, and mixed `some(...)` / `none(...)` / `err(...)` preservation (Experimental; initial coverage only)
+  - `validate_each/2` output feeding `collect_validated` directly: shared eval coverage proves mixed Outcome results from validation helpers aggregate into clean values plus skipped/error diagnostics. Experimental; initial coverage only.
 - Eval normalization is limited to line-ending normalization for `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).
 - Eval comparison is otherwise exact: `stdout`, `stderr`, and `exit_code` must match exactly after that line-ending normalization.
 - Error normalization is limited to the same line-ending normalization used for eval `stdout` and `stderr` (`\r\n` and `\r` normalize to `\n`).

--- a/spec/eval/validation-helpers-feed-collect-validated.yaml
+++ b/spec/eval/validation-helpers-feed-collect-validated.yaml
@@ -1,0 +1,18 @@
+name: validation-helpers-feed-collect-validated
+category: eval
+description: validate_each results feed collect_validated cleanly with skipped and error diagnostics
+input:
+  source: |
+    classify(x) =
+      0 -> none("skipped_zero") |
+      n ? n == -1 -> err(quote(invalid_negative), {value: x}) |
+      _ -> some(x)
+
+    collect_validated(validate_each([1, 0, -1, 2], classify))
+expected:
+  stdout: "{clean: [1, 2], diagnostics: [{index: 1, kind: skipped, reason: \"skipped_zero\", context: none(\"nil\")}, {index: 2, kind: error, reason: invalid_negative, context: some({value: -1})}]}\n"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 403
+  contract: validate_each output feeds collect_validated into clean values plus skipped and error diagnostics.


### PR DESCRIPTION
close #403 

````md
## Summary

Adds one shared eval conformance case for issue #403 proving that validation helper output can feed directly into `collect_validated`.

Spec added:

- `spec/eval/validation-helpers-feed-collect-validated.yaml`

The new fixture verifies:

```text
validate_each([1, 0, -1, 2], classify)
  → collect_validated(...)
  → {clean: [1, 2], diagnostics: [...]}
````

This confirms mixed validation Outcomes aggregate correctly:

* `some(...)` values contribute to `clean`
* `none(...)` values produce skipped diagnostics
* `err(...)` values produce error diagnostics

Also updates `GENIA_STATE.md` with one narrow shared eval coverage bullet for the new conformance case.

## Scope

This is a spec/documentation-coverage change only.

No production code changed.

No changes to:

* validation implementation
* `collect_validated`
* prelude files
* parser / lexer / IR
* CLI
* Flow / Seq
* Sheets
* lifecycle
* killer workflow docs

## Validation

Ran:

```bash
uv run pytest -q tests/doc/test_semantic_doc_sync.py
```

Result:

```text
84 passed
```

```bash
uv run python -m tools.spec_runner
```

Result:

```text
Summary: total=422 passed=422 failed=0 invalid=0
```

```bash
uv run pytest -q tests/unit/test_validate_each.py tests/unit/test_validate_optional.py
```

Result:

```text
40 passed
```

## Notes

The new shared spec passed immediately, so no implementation changes were needed. This PR strengthens conformance coverage for the Outcome-aware validated data pipeline path without expanding behavior.
