### PR TITLE
test(cli): add validated record pipeline fixture issue #404

### DIFF
--- a/spec/cli/validated_record_pipeline_killer_workflow.yaml
+++ b/spec/cli/validated_record_pipeline_killer_workflow.yaml
@@ -1,0 +1,27 @@
+id: validated_record_pipeline_killer_workflow
+name: validated_record_pipeline_killer_workflow
+category: cli
+description: Pipe mode validates JSONL stdin records through existing Outcome-aware helpers and collects clean data plus diagnostics.
+input:
+  source: |
+    ((flow) -> { result = flow |> map(parse_jsonl_record) |> ((records) -> validate_each(records, (record) -> validate_record(record, {id: (r) -> validate_field("id", (x) -> x > 0, "positive id", r), name: (r) -> validate_required("name", r)}))) |> collect_validated; print(result); evolve(0, (x) -> x) |> take(0) })
+  file: null
+  command: |
+    ((flow) -> { result = flow |> map(parse_jsonl_record) |> ((records) -> validate_each(records, (record) -> validate_record(record, {id: (r) -> validate_field("id", (x) -> x > 0, "positive id", r), name: (r) -> validate_required("name", r)}))) |> collect_validated; print(result); evolve(0, (x) -> x) |> take(0) })
+  stdin: |-
+    {"id":1,"name":"Ada"}
+
+    {"id":0,"name":"Bad"}
+    {"id":
+    {"id":2,"name":"Grace"}
+  argv: []
+  debug_stdio: false
+expected:
+  stdout: "{clean: [{id: 1, name: Ada}, {id: 2, name: Grace}], diagnostics: [{index: 1, kind: skipped, reason: blank_line, context: some({kind: jsonl_record, status: skipped, reason: blank_line, line: })}, {index: 2, kind: error, reason: record_validation_failed, context: some({diagnostics: [{field: id, status: error, reason: invalid field, context: {field: id, expected: positive id, actual: 0, reason: invalid field}}]})}, {index: 3, kind: error, reason: invalid_jsonl_record, context: some({kind: jsonl_record, status: error, reason: invalid_jsonl_record, line: {\"id\":, message: Expecting value})}]}"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 404
+  contract: CLI pipe-mode fixture proves a narrow Outcome-aware validated-record pipeline using existing JSONL parsing, validation helpers, and collect_validated aggregation.
+  fixture_note: pipe mode requires the stage expression to return a Flow, so the aggregate is printed before returning an empty Flow.
+  non_goal: does not add new runtime behavior, syntax, Sheet support, reporting, or broader killer-workflow implementation.


### PR DESCRIPTION
close #404 
## Summary

Adds one shared CLI fixture for issue #404 proving a narrow Outcome-aware validated-record pipeline through the existing CLI/spec system.

The fixture covers:

- JSONL-ish stdin records
- `parse_jsonl_record`
- `validate_each`
- existing validation helpers
- `collect_validated`
- clean records plus diagnostics
- deterministic `stdout`, `stderr`, and `exit_code`

No production code or docs were changed.

## Validation

- `uv run python -m tools.spec_runner` → `423 passed=423 failed=0 invalid=0`
- `uv run pytest -q tests/spec` → `228 passed`
- `uv run pytest -q tests/unit/test_json_stdlib.py` → `10 passed`
- `uv run pytest -q tests/unit/test_validate_each.py` → `19 passed`
- `uv run pytest -q tests/unit/test_validate_record.py` → `11 passed`
- `uv run pytest -q tests/unit/test_validate_optional.py` → `21 passed`

`tests/unit/test_collect_validated.py` does not exist, so nearest related validation coverage was run instead.

## Audit

Audit result: PASS WITH ISSUES — ready to merge.

Non-blocking follow-ups:

1. Track the pipe-mode limitation where multiline helper definitions require a workaround.
2. Clean up pre-existing tracked issue-335 handoff files on main in a separate issue.

## Scope Notes

This PR adds test coverage only. It does not add new runtime behavior, syntax, docs, Sheet support, or broader killer-workflow implementation.
