### PR TITLE
Feature/issue 397 cli add first demoable validated data pipeline milestone

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2251,6 +2251,7 @@ Core IR shape currently includes:
 - `examples/ants_terminal.genia`: blocking terminal developer UI over the same colony simulation with CLI-configurable seed, ant count, step count, delay, world size, and pure/actor mode selection
 - `examples/ants_actor.genia`: actor/coordinator version of the ants simulation — same colony rules, different execution structure
 - `examples/ants_web.genia`: browser visualization over the same ants simulation using the current blocking HTTP helper, JSON endpoints, and a Canvas renderer in plain browser JavaScript
+- `examples/validated_pipeline_demo.genia`: experimental first demo milestone for the Outcome-aware validated data pipeline direction — a file-mode demo covered by shared CLI spec `spec/cli/validated-data-pipeline-demo.yaml`; reads JSONL records from `examples/data/validated_pipeline_demo.jsonl`, validates each record using existing `parse_jsonl_record`, `validate_each`, `validate_record`, and `collect_validated` helpers, and emits clean records plus diagnostics; demonstrates the intended Outcome-aware validated data pipeline direction; does not add new helper/runtime semantics; Experimental
 
 `examples/ants.genia` intentionally uses only currently implemented features:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository currently provides:
   - bundled `.genia` prelude sources are loaded from package resources, so installed `genia` tools can use the same stdlib as repo execution
   - autoloaded function names can also be referenced as higher-order function values, not only called directly
 - debug-stdio adapter support for editor integration (**Python-host-only**)
-- runnable demos under `examples/` (including `tic-tac-toe.genia`, `ants.genia`, `ants_terminal.genia`, `ants_actor.genia`, `ants_web.genia`, and `http_service.genia`)
+- runnable demos under `examples/` (including `tic-tac-toe.genia`, `ants.genia`, `ants_terminal.genia`, `ants_actor.genia`, `ants_web.genia`, `http_service.genia`, and `validated_pipeline_demo.genia`)
 - proper tail-call optimization for calls in tail position
 - multi-host scaffolding docs/manifests under `docs/host-interop/`, `docs/architecture/`, `spec/`, `tools/spec_runner/`, and `hosts/`
 
@@ -351,6 +351,18 @@ The demo serves:
 The ants demos accept explicit seeds for reproducible runs. `examples/ants.genia` is the canonical pure simulation teaching surface: it threads RNG state through an explicit world value, advances with `step(world) -> world2`, and demonstrates nest/home regions, food pickup and return, pheromone deposit/evaporation, and weighted direction-aware movement. `examples/ants_terminal.genia` is the text developer UI for that model: it shows ants, nest, food, pheromone heat, run stats, and a legend, with CLI controls `--seed`, `--ants`, `--steps`, `--delay`, `--size`, and `--mode pure|actor`. Same seed plus same config gives the same progression for a given mode. It is still a blocking text demo built on `clear_screen`, `move_cursor`, `render_grid`, `sleep`, and `cli_parse`; it does not use `stdin_keys` and has no pause/step key controls. `examples/ants_actor.genia` runs the same colony rules using actor-based concurrency: a coordinator actor owns the world state while ant workers request sense data and submit move intents via `actor_call`. That actor mode is an optional coordination comparison, not the first simulation model.
 
 `examples/ants_web.genia` is a browser viewer over that same simulation, served through the current minimal HTTP helper. Run it with `python3 -m genia.interpreter examples/ants_web.genia --port 8082` and open `http://127.0.0.1:8082/`. It serves `GET /`, `/app.js`, `/style.css`, and `/state`, plus `POST /reset` and `/step`. The browser renders JSON snapshots with Canvas and implements run/pause by repeatedly calling `/step`; this is not a browser-native Genia runtime, a playground runtime, WebSockets, or SSE.
+
+## Run the Validated Pipeline Demo (Experimental)
+
+`examples/validated_pipeline_demo.genia` is the experimental first demo milestone for Genia's Outcome-aware validated data pipeline direction.
+
+```bash
+python3 -m genia.interpreter examples/validated_pipeline_demo.genia
+```
+
+The demo reads `examples/data/validated_pipeline_demo.jsonl`, parses each JSONL line using `parse_jsonl_record`, validates each parsed record using `validate_each`, `validate_record`, `validate_required`, and `validate_field`, then collects results with `collect_validated` into `{clean: [...], diagnostics: [...]}`. Clean records and recoverable diagnostics are returned with exit code 0.
+
+This is a file-mode demo covered by shared CLI spec `spec/cli/validated-data-pipeline-demo.yaml`. It demonstrates the intended Outcome-aware validated data pipeline direction using only existing helper/runtime semantics. It does not add new syntax, Sheets, lifecycle, actors, browser work, or a general ETL framework.
 
 ## Build a Game in Genia
 

--- a/examples/data/validated_pipeline_demo.jsonl
+++ b/examples/data/validated_pipeline_demo.jsonl
@@ -1,0 +1,6 @@
+{"id": 1, "name": "Ann", "age": 30}
+
+{"id": 2, "name": "Ben", "age": -1}
+{"id": 3, "age": 41}
+not-json
+{"id": 4, "name": "Cara", "age": 22}

--- a/examples/validated_pipeline_demo.genia
+++ b/examples/validated_pipeline_demo.genia
@@ -1,0 +1,15 @@
+import resource as res
+
+valid_person(record) =
+  validate_record(record, {
+    id: (r) -> validate_required("id", r),
+    name: (r) -> validate_required("name", r),
+    age: (r) -> validate_field("age", (value) -> value >= 0, "age >= 0", r)
+  })
+
+res.read_text(res.resource_ref("examples/data/validated_pipeline_demo.jsonl"))
+  |> ((text) -> split(text, "\n"))
+  |> lines
+  |> map(parse_jsonl_record)
+  |> ((records) -> validate_each(records, valid_person))
+  |> collect_validated

--- a/spec/cli/validated-data-pipeline-demo.yaml
+++ b/spec/cli/validated-data-pipeline-demo.yaml
@@ -1,0 +1,20 @@
+id: validated-data-pipeline-demo
+name: validated-data-pipeline-demo
+category: cli
+description: File mode runs the first demoable validated JSONL record pipeline milestone.
+input:
+  source: "examples/validated_pipeline_demo.genia"
+  file: "examples/validated_pipeline_demo.genia"
+  command: null
+  stdin: ""
+  argv: []
+  debug_stdio: false
+expected:
+  stdout: "{clean: [{id: 1, name: \"Ann\", age: 30}, {id: 4, name: \"Cara\", age: 22}], diagnostics: [{index: 1, kind: skipped, reason: \"blank_line\", context: some({kind: jsonl_record, status: skipped, reason: blank_line, line: \"\"})}, {index: 2, kind: error, reason: record_validation_failed, context: some({diagnostics: [{field: \"age\", status: error, reason: \"invalid field\", context: {field: \"age\", expected: \"age >= 0\", actual: -1, reason: \"invalid field\"}}]})}, {index: 3, kind: error, reason: record_validation_failed, context: some({diagnostics: [{field: \"name\", status: error, reason: \"missing required field\", context: {field: \"name\", reason: \"missing required field\"}}]})}, {index: 4, kind: error, reason: invalid_jsonl_record, context: some({kind: jsonl_record, status: error, reason: invalid_jsonl_record, line: \"not-json\", message: \"Expecting value\"})}]}"
+  stderr: ""
+  exit_code: 0
+notes: |
+  issue: 397
+  contract: file-mode CLI demo proves a narrow Outcome-aware validated JSONL record pipeline using existing parse_jsonl_record, validate_each, validate_record, and collect_validated behavior.
+  fixture: implementation phase should add examples/validated_pipeline_demo.genia and examples/data/validated_pipeline_demo.jsonl.
+  non_goal: does not add syntax, parser/Core IR changes, Sheets, lifecycle, actors, browser work, or a general ETL framework.


### PR DESCRIPTION
close #397 

## Summary

Adds the first demoable CLI milestone for Genia’s Outcome-aware validated data pipeline direction.

This PR adds a small file-mode JSONL pipeline demo that:

- reads `examples/data/validated_pipeline_demo.jsonl`
- parses JSONL records with existing JSONL/Outcome helpers
- validates records with existing validation helpers
- preserves clean records and recoverable diagnostics
- exits successfully for recoverable data issues
- is covered by a shared CLI spec

## Changes

- Added shared CLI spec:
  - `spec/cli/validated-data-pipeline-demo.yaml`
- Added demo script:
  - `examples/validated_pipeline_demo.genia`
- Added demo fixture:
  - `examples/data/validated_pipeline_demo.jsonl`
- Updated docs:
  - `GENIA_STATE.md`
  - `README.md`

## Scope Notes

This is intentionally narrow.

This PR does **not** add:

- new helper/runtime semantics
- new syntax
- parser, lexer, or Core IR changes
- Sheets
- lifecycle
- actors/concurrency
- browser/playground work
- a general ETL framework

The demo uses existing `resource.read_text` plus `split(text, "\n")` because `lines` does not accept raw strings directly.

## Validation

```bash
uv run python -m tools.spec_runner --verbose