### PR TITLE
Feature/issue 430 r2 contract define native test kernel behavior

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2237,6 +2237,40 @@ Core IR shape currently includes:
 - `help("name")` for a string that resolves to a non-Genia host-backed runtime name prints a generic bridge note instead of maintaining a separate raw-host documentation registry
 - `help("missing")` prints a short missing-name note instead of raising an undefined-name traceback
 
+## 9.1) Native test kernel core (Python reference host, Experimental)
+
+LANGUAGE CONTRACT:
+- Native test kernel core provides normalized pass/fail/error result dictionaries and suite dictionaries.
+- It normalizes `TestUnit` execution into one of three stable result kinds: `pass`, `fail`, or `error`.
+- It aggregates suite results and maps suite results to kernel-level exit codes.
+- `TestResult` is distinct from Outcome (`some`/`none`/`err`); there is no automatic mapping between them.
+- Exit code `0` means all executed tests passed or the suite was empty; exit code `1` means at least one test failed or errored.
+
+PYTHON REFERENCE HOST:
+- Implemented as `src/genia/test_kernel.py` in the Python reference host.
+- Kernel-only; no CLI runner or shared spec-runner integration exists yet.
+- Provides: `NativeTestFailure`, `TestUnit`, `run_test_unit`, `run_test_suite`, `aggregate_results`, `suite_exit_code`.
+- `TestUnit` is a frozen dataclass with `name` (required non-empty string), `body` (required callable), and optional `location` and `metadata`.
+- `run_test_unit(test_unit)` executes the body, catches `NativeTestFailure` as a `fail` result, and catches other exceptions as `error` results.
+- `run_test_suite(test_units)` runs each unit in given order and aggregates results via `aggregate_results`.
+- Normalized `TestResult` dictionaries contain stable keys: `kind`, `name`, `phase`, `reason`, `expected`, `actual`, `stdout`, `stderr`, `diagnostics`.
+- `stdout` and `stderr` are stable empty strings in this phase; capture is not implemented.
+- `TestSuiteResult` dictionaries contain: `total`, `passed`, `failed`, `errored`, `results`.
+- `results` preserves input order exactly.
+- Validated by `tests/unit/test_native_test_kernel.py` (5 tests, Python reference host only).
+
+Not implemented in this phase:
+- `skip` result kind
+- `duration` field
+- CLI test runner
+- shared spec-runner integration
+- host adapter for Genia runtime callables
+- parser/lexer/evaluator/Core IR changes
+- public Genia builtins or prelude surface for test authoring
+- annotations, lifecycle phases, or fixtures
+- stdout/stderr capture (fields are present but always empty strings)
+- multi-host test execution
+
 ## 10) Explicitly not implemented (current)
 
 - general unrestricted host interop / FFI layer

--- a/src/genia/test_kernel.py
+++ b/src/genia/test_kernel.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, ClassVar, Iterable
+
+
+class NativeTestFailure(Exception):
+    def __init__(self, reason: str, expected: Any = None, actual: Any = None):
+        super().__init__(reason)
+        self.reason = reason
+        self.expected = expected
+        self.actual = actual
+
+
+@dataclass(frozen=True)
+class TestUnit:
+    __test__: ClassVar[bool] = False
+
+    name: str
+    body: Callable[[], Any]
+    location: Any = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _result(
+    *,
+    kind: str,
+    name: str,
+    phase: str,
+    reason: str | None,
+    expected: Any = None,
+    actual: Any = None,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "name": name,
+        "phase": phase,
+        "reason": reason,
+        "expected": expected,
+        "actual": actual,
+        "stdout": "",
+        "stderr": "",
+        "diagnostics": {},
+    }
+
+
+def _discovery_error(test_unit: Any, reason: str) -> dict[str, Any]:
+    name = getattr(test_unit, "name", "<unnamed>")
+    if not isinstance(name, str) or name == "":
+        name = "<unnamed>"
+    return _result(
+        kind="error",
+        name=name,
+        phase="discovery",
+        reason=reason,
+    )
+
+
+def run_test_unit(test_unit: TestUnit) -> dict[str, Any]:
+    if not isinstance(getattr(test_unit, "name", None), str) or test_unit.name == "":
+        return _discovery_error(test_unit, "test unit name must be a non-empty string")
+
+    body = getattr(test_unit, "body", None)
+    if not callable(body):
+        return _discovery_error(test_unit, "test unit body must be callable")
+
+    try:
+        body()
+    except NativeTestFailure as failure:
+        return _result(
+            kind="fail",
+            name=test_unit.name,
+            phase="evaluation",
+            reason=failure.reason,
+            expected=failure.expected,
+            actual=failure.actual,
+        )
+    except Exception as exc:
+        return _result(
+            kind="error",
+            name=test_unit.name,
+            phase="evaluation",
+            reason=str(exc),
+        )
+
+    return _result(
+        kind="pass",
+        name=test_unit.name,
+        phase="evaluation",
+        reason=None,
+    )
+
+
+def aggregate_results(results: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    ordered_results = list(results)
+    return {
+        "total": len(ordered_results),
+        "passed": sum(result.get("kind") == "pass" for result in ordered_results),
+        "failed": sum(result.get("kind") == "fail" for result in ordered_results),
+        "errored": sum(result.get("kind") == "error" for result in ordered_results),
+        "results": ordered_results,
+    }
+
+
+def run_test_suite(test_units: Iterable[TestUnit]) -> dict[str, Any]:
+    return aggregate_results(run_test_unit(test_unit) for test_unit in test_units)
+
+
+def suite_exit_code(suite_result: dict[str, Any]) -> int:
+    if suite_result.get("failed", 0) > 0 or suite_result.get("errored", 0) > 0:
+        return 1
+    return 0

--- a/tests/unit/test_native_test_kernel.py
+++ b/tests/unit/test_native_test_kernel.py
@@ -1,0 +1,151 @@
+from genia.test_kernel import (
+    NativeTestFailure,
+    TestUnit,
+    aggregate_results,
+    run_test_suite,
+    run_test_unit,
+    suite_exit_code,
+)
+
+
+def test_passing_test_unit_result_aggregation_and_exit_code():
+    result = run_test_unit(TestUnit("passes", lambda: None))
+
+    assert result == {
+        "kind": "pass",
+        "name": "passes",
+        "phase": "evaluation",
+        "reason": None,
+        "expected": None,
+        "actual": None,
+        "stdout": "",
+        "stderr": "",
+        "diagnostics": {},
+    }
+
+    suite = run_test_suite([TestUnit("passes", lambda: None)])
+    assert suite == {
+        "total": 1,
+        "passed": 1,
+        "failed": 0,
+        "errored": 0,
+        "results": [result],
+    }
+    assert suite_exit_code(suite) == 0
+
+
+def test_failed_expectation_result_aggregation_and_exit_code():
+    def body():
+        raise NativeTestFailure("values differed", expected=3, actual=4)
+
+    result = run_test_unit(TestUnit("fails", body))
+
+    assert result == {
+        "kind": "fail",
+        "name": "fails",
+        "phase": "evaluation",
+        "reason": "values differed",
+        "expected": 3,
+        "actual": 4,
+        "stdout": "",
+        "stderr": "",
+        "diagnostics": {},
+    }
+
+    suite = run_test_suite([TestUnit("fails", body)])
+    assert suite == {
+        "total": 1,
+        "passed": 0,
+        "failed": 1,
+        "errored": 0,
+        "results": [result],
+    }
+    assert suite_exit_code(suite) == 1
+
+
+def test_runtime_error_result_aggregation_and_exit_code():
+    def body():
+        raise RuntimeError("boom")
+
+    result = run_test_unit(TestUnit("errors", body))
+
+    assert result == {
+        "kind": "error",
+        "name": "errors",
+        "phase": "evaluation",
+        "reason": "boom",
+        "expected": None,
+        "actual": None,
+        "stdout": "",
+        "stderr": "",
+        "diagnostics": {},
+    }
+
+    suite = run_test_suite([TestUnit("errors", body)])
+    assert suite == {
+        "total": 1,
+        "passed": 0,
+        "failed": 0,
+        "errored": 1,
+        "results": [result],
+    }
+    assert suite_exit_code(suite) == 1
+
+
+def test_aggregation_preserves_order_and_counts_mixed_results():
+    results = [
+        {
+            "kind": "pass",
+            "name": "passes",
+            "phase": "evaluation",
+            "reason": None,
+            "expected": None,
+            "actual": None,
+            "stdout": "",
+            "stderr": "",
+            "diagnostics": {},
+        },
+        {
+            "kind": "fail",
+            "name": "fails",
+            "phase": "evaluation",
+            "reason": "values differed",
+            "expected": 3,
+            "actual": 4,
+            "stdout": "",
+            "stderr": "",
+            "diagnostics": {},
+        },
+        {
+            "kind": "error",
+            "name": "errors",
+            "phase": "evaluation",
+            "reason": "boom",
+            "expected": None,
+            "actual": None,
+            "stdout": "",
+            "stderr": "",
+            "diagnostics": {},
+        },
+    ]
+
+    assert aggregate_results(results) == {
+        "total": 3,
+        "passed": 1,
+        "failed": 1,
+        "errored": 1,
+        "results": results,
+    }
+
+
+def test_empty_suite_aggregates_as_successful_kernel_result():
+    suite = run_test_suite([])
+
+    assert suite == {
+        "total": 0,
+        "passed": 0,
+        "failed": 0,
+        "errored": 0,
+        "results": [],
+    }
+    assert suite_exit_code(suite) == 0

--- a/tests/unit/test_native_test_kernel.py
+++ b/tests/unit/test_native_test_kernel.py
@@ -92,6 +92,23 @@ def test_runtime_error_result_aggregation_and_exit_code():
     assert suite_exit_code(suite) == 1
 
 
+def test_malformed_named_test_unit_with_non_callable_body_is_discovery_error():
+    result = run_test_unit(TestUnit("bad", "not callable"))
+
+    assert result == {
+        "kind": "error",
+        "name": "bad",
+        "phase": "discovery",
+        "reason": "test unit body must be callable",
+        "expected": None,
+        "actual": None,
+        "stdout": "",
+        "stderr": "",
+        "diagnostics": {},
+    }
+    assert isinstance(result["diagnostics"], dict)
+
+
 def test_aggregation_preserves_order_and_counts_mixed_results():
     results = [
         {


### PR DESCRIPTION
close #430 

Do a final lightweight audit for issue #430.

Verify:
- branch is feature/issue-430-r2-contract-define-native-test-kernel-behavior
- git status is clean except uncommitted handoff files under .genia/process/tmp/handoffs/
- commits on branch include:
  - implementation
  - docs sync
  - audit-fix test
- changed committed files are only:
  - src/genia/test_kernel.py
  - tests/unit/test_native_test_kernel.py
  - GENIA_STATE.md
- 01-contract.md is no longer a copy of 00-preflight.md
- no handoff files are committed
- validation still passes:
  - uv run pytest -q tests/unit/test_native_test_kernel.py
  - uv run pytest -q tests/doc/test_semantic_doc_sync.py
  - uv run python -m tools.spec_runner

Report PASS / FAIL and any blockers.
Do not modify files.