### PR TITLE
Feature/issue 438 cli expose native test runner outcomes

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -62,12 +62,14 @@ CLI contract summary (actual behavior):
 - command mode: `genia -c 'source' [args ...]`
 - pipe mode: `genia -p 'stage_expr' [args ...]` runs the stage expression over `stdin |> lines`, then consumes the final Flow automatically
 - REPL mode: `genia`
+- native test mode: `genia --test path/to/test_file.genia` (Experimental, Python reference host; see `GENIA_STATE.md` section 9.2)
 - file/command dispatch: call `main(argv())` when `main/1` exists, otherwise call `main()` when `main/0` exists
 - pipe mode bypasses `main`
 - trailing args are exposed through `argv()` as plain strings (including option-like values)
 - in pipe mode, explicit unbound `stdin` and explicit unbound `run` are rejected with clear errors
 - when no `-c`/`-p` mode is selected, the first non-mode argument must be a source file path (`--` stops option parsing for dash-prefixed literal args/paths)
 - `--debug-stdio` accepts exactly one program path and rejects `-c`/`-p` combinations with explicit parser errors
+- `--test` is mutually exclusive with `-c`, `-p`, and `--debug-stdio`; invalid combinations exit with code `2`
 
 **Limitations:**
 - Only the Python host is implemented; all CLI, REPL, and pipe behavior is enforced and tested only for Python.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2248,7 +2248,6 @@ LANGUAGE CONTRACT:
 
 PYTHON REFERENCE HOST:
 - Implemented as `src/genia/test_kernel.py` in the Python reference host.
-- Kernel-only; no CLI runner or shared spec-runner integration exists yet.
 - Provides: `NativeTestFailure`, `TestUnit`, `run_test_unit`, `run_test_suite`, `aggregate_results`, `suite_exit_code`.
 - `TestUnit` is a frozen dataclass with `name` (required non-empty string), `body` (required callable), and optional `location` and `metadata`.
 - `run_test_unit(test_unit)` executes the body, catches `NativeTestFailure` as a `fail` result, and catches other exceptions as `error` results.
@@ -2257,19 +2256,35 @@ PYTHON REFERENCE HOST:
 - `stdout` and `stderr` are stable empty strings in this phase; capture is not implemented.
 - `TestSuiteResult` dictionaries contain: `total`, `passed`, `failed`, `errored`, `results`.
 - `results` preserves input order exactly.
-- Validated by `tests/unit/test_native_test_kernel.py` (5 tests, Python reference host only).
+- Validated by `tests/unit/test_native_test_kernel.py` (6 tests, Python reference host only).
 
 Not implemented in this phase:
 - `skip` result kind
 - `duration` field
-- CLI test runner
 - shared spec-runner integration
 - host adapter for Genia runtime callables
 - parser/lexer/evaluator/Core IR changes
-- public Genia builtins or prelude surface for test authoring
+- public Genia builtins or prelude surface for test authoring beyond the test-mode-only `test(name, body)` helper
 - annotations, lifecycle phases, or fixtures
 - stdout/stderr capture (fields are present but always empty strings)
 - multi-host test execution
+
+## 9.2) Native test CLI (Python reference host, Experimental)
+
+Status: Experimental, Python reference host.
+
+`genia --test <file>` runs native test units registered through the test-mode-only `test(name, body)` helper and reports the existing normalized native test runner outcomes. The CLI prints suite counts before and after per-result lines, reports `PASS`, `FAIL`, and `ERROR` results, and exits `0` when no failures/errors occur, `1` when failures or normalized test errors occur, and `2` for invalid CLI invocation.
+
+PYTHON REFERENCE HOST:
+- Implemented as `src/genia/test_cli.py` in the Python reference host.
+- Test mode registers a test-mode-only `test(name, body)` helper that appends `TestUnit` values to a private list; malformed units are normalized as discovery errors by the existing kernel.
+- `--test` is mutually exclusive with `-c`/`--command`, `-p`/`--pipe`, and `--debug-stdio`.
+- Invalid combinations such as `--debug-stdio --test` are rejected with exit code `2`.
+- Report format: a summary line `total=<t> passed=<p> failed=<f> errored=<e>` appears both before and after per-result lines.
+- Per-result lines: `PASS <name>`, `FAIL <name> phase=<phase> reason=<reason>` (with `expected=<expected> actual=<actual>` when present), `ERROR <name-or-unnamed> phase=<phase> reason=<reason>`.
+- Validated by `tests/unit/test_native_test_cli.py` (6 tests) and `tests/unit/test_interpreter_test_mode.py` (6 tests), Python reference host only.
+
+This does not add test annotations, setup/teardown lifecycle hooks, filtering, parallel execution, JSON/JUnit/TAP output, or multi-host test execution.
 
 ## 10) Explicitly not implemented (current)
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ printf '1\n2\n3\n' | genia -c 'stdin |> lines |> map(parse_int) |> keep_some |> 
   - `genia -c 'source' [args ...]` -> command mode
   - `genia -p 'stage_expr' [args ...]` -> pipe mode
   - `genia` -> REPL mode
+  - `genia --test path/to/test_file.genia` -> native test mode (Experimental, Python reference host)
 
 ### Choose `-p` vs `-c`
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -428,7 +428,13 @@ def _select_execution_mode(
     terminator_index: int | None,
     parser: argparse.ArgumentParser,
 ) -> ExecutionMode:
-    if args.command is None and args.pipe is None and remaining_args and remaining_args[0].startswith("-"):
+    if (
+        args.command is None
+        and args.pipe is None
+        and getattr(args, "test", None) is None
+        and remaining_args
+        and remaining_args[0].startswith("-")
+    ):
         if not explicit_terminator_used and terminator_index is None:
             parser.error(
                 "expected a source file path when not using -c/--command or -p/--pipe; "
@@ -437,13 +443,15 @@ def _select_execution_mode(
 
     program_path: Optional[str] = None
     script_args: list[str] = []
-    if args.command is not None or args.pipe is not None:
+    if args.command is not None or args.pipe is not None or getattr(args, "test", None) is not None:
         script_args = remaining_args
     elif remaining_args:
         program_path = remaining_args[0]
         script_args = remaining_args[1:]
 
     if args.debug_stdio:
+        if getattr(args, "test", None) is not None:
+            parser.error("--debug-stdio cannot be used with --test")
         if args.command is not None:
             parser.error("--debug-stdio cannot be used with --command")
         if args.pipe is not None:
@@ -455,6 +463,13 @@ def _select_execution_mode(
         if not Path(program_path).is_file():
             parser.error(f"--debug-stdio program path not found: {program_path}")
         return ExecutionMode(kind="debug_stdio", program_path=program_path)
+
+    if getattr(args, "test", None) is not None:
+        if remaining_args:
+            parser.error("--test accepts exactly one program path")
+        if not Path(args.test).is_file():
+            parser.error(f"--test program path not found: {args.test}")
+        return ExecutionMode(kind="test", program_path=args.test)
 
     if args.pipe is not None:
         return ExecutionMode(kind="pipe", source=args.pipe, script_args=script_args)
@@ -483,6 +498,12 @@ def _run_execution_mode(mode: ExecutionMode) -> int:
     if mode.kind == "debug_stdio":
         assert mode.program_path is not None
         return run_debug_stdio(mode.program_path)
+
+    if mode.kind == "test":
+        assert mode.program_path is not None
+        from .test_cli import run_native_tests_from_file
+
+        return run_native_tests_from_file(mode.program_path)
 
     if mode.kind == "pipe":
         assert mode.source is not None
@@ -545,6 +566,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
 
     parser = argparse.ArgumentParser(
         prog="genia",
+        usage="genia [-h] [-V] [-c COMMAND | -p PIPE] [--debug-stdio]",
         description="Genia CLI: file mode, command mode (-c), pipe mode (-p), or REPL.",
         epilog=(
             "Modes:\n"
@@ -561,6 +583,7 @@ def _main(argv: Optional[list[str]] = None) -> int:
     command_group = parser.add_mutually_exclusive_group()
     command_group.add_argument("-c", "--command", help="Execute inline Genia source")
     command_group.add_argument("-p", "--pipe", help="Execute a pipe-mode stage expression")
+    command_group.add_argument("--test", help="Run native tests from a Genia source file")
     parser.add_argument("--debug-stdio", action="store_true", help="Run debug adapter over stdio for a program file")
     args, remaining_args = parser.parse_known_args(raw_argv)
     if getattr(args, "version", False):

--- a/src/genia/test_cli.py
+++ b/src/genia/test_cli.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from .builtins import make_global_env
+from .errors import GeniaQuietBrokenPipe
+from .test_kernel import TestUnit, run_test_suite, suite_exit_code
+from .utf8 import format_debug
+from .values import GeniaOutputSink
+
+
+def _summary_line(suite: dict[str, Any]) -> str:
+    return (
+        f"total={suite.get('total', 0)} "
+        f"passed={suite.get('passed', 0)} "
+        f"failed={suite.get('failed', 0)} "
+        f"errored={suite.get('errored', 0)}"
+    )
+
+
+def _display_name(result: dict[str, Any]) -> str:
+    name = result.get("name", "")
+    return name if isinstance(name, str) and name else "<unnamed>"
+
+
+def _reason_text(result: dict[str, Any]) -> str:
+    reason = result.get("reason")
+    return "" if reason is None else str(reason)
+
+
+def _format_result_line(result: dict[str, Any]) -> str:
+    kind = result.get("kind")
+    name = _display_name(result)
+
+    if kind == "pass":
+        return f"PASS {name}"
+
+    if kind == "fail":
+        line = f"FAIL {name} phase={result.get('phase')} reason={_reason_text(result)}"
+        if result.get("expected") is not None or result.get("actual") is not None:
+            expected = format_debug(result.get("expected"))
+            actual = format_debug(result.get("actual"))
+            line += f" expected={expected} actual={actual}"
+        return line
+
+    if kind == "error":
+        return f"ERROR {name} phase={result.get('phase')} reason={_reason_text(result)}"
+
+    raise ValueError(f"unknown test result kind: {kind}")
+
+
+def format_test_suite_report(suite: dict[str, Any]) -> str:
+    summary = _summary_line(suite)
+    lines = [summary]
+    lines.extend(_format_result_line(result) for result in suite.get("results", []))
+    lines.append(summary)
+    return "\n".join(lines) + "\n"
+
+
+def make_test_env() -> tuple[Any, list[TestUnit]]:
+    tests: list[TestUnit] = []
+    env = make_global_env(cli_args=[])
+    setattr(env, "_native_test_units", tests)
+
+    def register_test(name: Any, body: Any) -> None:
+        tests.append(TestUnit(name, body))
+        return None
+
+    env.set("test", register_test)
+    return env, tests
+
+
+def discover_test_units(env: Any) -> list[TestUnit]:
+    return list(getattr(env, "_native_test_units", []))
+
+
+def _write_stdout(env: Any, text: str) -> None:
+    sink = env.values.get("stdout")
+    if isinstance(sink, GeniaOutputSink):
+        sink.write_text(text)
+        return
+    sys.stdout.write(text)
+    sys.stdout.flush()
+
+
+def _write_stderr(env: Any, message: str) -> None:
+    sink = env.values.get("stderr")
+    text = message + "\n"
+    if isinstance(sink, GeniaOutputSink):
+        sink.write_text(text)
+        return
+    try:
+        sys.stderr.write(text)
+        sys.stderr.flush()
+    except BrokenPipeError:
+        return
+
+
+def run_native_tests_from_file(program_path: str) -> int:
+    env, tests = make_test_env()
+    try:
+        path = Path(program_path)
+        source = path.read_text(encoding="utf-8")
+        from .interpreter import run_source
+
+        run_source(source, env, filename=str(path.resolve()))
+        suite = run_test_suite(tests)
+        _write_stdout(env, format_test_suite_report(suite))
+        return suite_exit_code(suite)
+    except GeniaQuietBrokenPipe:
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        _write_stderr(env, f"Error: {exc}")
+        return 1

--- a/tests/unit/test_interpreter_test_mode.py
+++ b/tests/unit/test_interpreter_test_mode.py
@@ -1,0 +1,85 @@
+import pytest
+
+from genia.interpreter import _main
+
+
+def test_test_mode_runs_passing_test_file(tmp_path, capsys):
+    program = tmp_path / "passing_test.genia"
+    program.write_text('test("passes", () -> none)\n', encoding="utf-8")
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "total=1 passed=1 failed=0 errored=0\n"
+        "PASS passes\n"
+        "total=1 passed=1 failed=0 errored=0\n"
+    )
+    assert captured.err == ""
+
+
+def test_test_mode_reports_discovery_error_for_non_callable_body(tmp_path, capsys):
+    program = tmp_path / "bad_test.genia"
+    program.write_text('test("bad", "not callable")\n', encoding="utf-8")
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "ERROR bad phase=discovery reason=test unit body must be callable\n" in captured.out
+    assert captured.err == ""
+
+
+def test_test_mode_runs_empty_suite_successfully(tmp_path, capsys):
+    program = tmp_path / "empty_test.genia"
+    program.write_text("none\n", encoding="utf-8")
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "total=0 passed=0 failed=0 errored=0\n"
+        "total=0 passed=0 failed=0 errored=0\n"
+    )
+    assert captured.err == ""
+
+
+def test_test_mode_reports_missing_program_path_as_invalid_invocation(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        _main(["--test", "missing.genia"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert captured.out == ""
+    assert "error:" in captured.err
+    assert "--test program path not found: missing.genia" in captured.err
+
+
+def test_test_mode_rejects_debug_stdio_combination(tmp_path, capsys):
+    program = tmp_path / "program.genia"
+    program.write_text("none\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _main(["--debug-stdio", "--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert captured.out == ""
+    assert "error:" in captured.err
+    assert "--debug-stdio cannot be used with --test" in captured.err
+
+
+def test_test_mode_rejects_extra_trailing_args(tmp_path, capsys):
+    program = tmp_path / "program.genia"
+    program.write_text("none\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _main(["--test", str(program), "extra_arg"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert captured.out == ""
+    assert "error:" in captured.err
+    assert "--test accepts exactly one program path" in captured.err

--- a/tests/unit/test_native_test_cli.py
+++ b/tests/unit/test_native_test_cli.py
@@ -1,0 +1,171 @@
+import pytest
+
+
+def _format_report(suite):
+    from genia.test_cli import format_test_suite_report
+
+    return format_test_suite_report(suite)
+
+
+def test_formats_passing_suite_with_summary_before_and_after_results():
+    report = _format_report(
+        {
+            "total": 1,
+            "passed": 1,
+            "failed": 0,
+            "errored": 0,
+            "results": [
+                {
+                    "kind": "pass",
+                    "name": "passes",
+                    "phase": "evaluation",
+                    "reason": None,
+                    "expected": None,
+                    "actual": None,
+                    "stdout": "",
+                    "stderr": "",
+                    "diagnostics": {},
+                }
+            ],
+        }
+    )
+
+    assert report == (
+        "total=1 passed=1 failed=0 errored=0\n"
+        "PASS passes\n"
+        "total=1 passed=1 failed=0 errored=0\n"
+    )
+
+
+def test_formats_failed_expectation_with_reason_expected_and_actual():
+    report = _format_report(
+        {
+            "total": 1,
+            "passed": 0,
+            "failed": 1,
+            "errored": 0,
+            "results": [
+                {
+                    "kind": "fail",
+                    "name": "fails",
+                    "phase": "evaluation",
+                    "reason": "values differed",
+                    "expected": 3,
+                    "actual": 4,
+                    "stdout": "",
+                    "stderr": "",
+                    "diagnostics": {},
+                }
+            ],
+        }
+    )
+
+    assert report == (
+        "total=1 passed=0 failed=1 errored=0\n"
+        "FAIL fails phase=evaluation reason=values differed expected=3 actual=4\n"
+        "total=1 passed=0 failed=1 errored=0\n"
+    )
+
+
+def test_formats_runtime_error_result():
+    report = _format_report(
+        {
+            "total": 1,
+            "passed": 0,
+            "failed": 0,
+            "errored": 1,
+            "results": [
+                {
+                    "kind": "error",
+                    "name": "errors",
+                    "phase": "evaluation",
+                    "reason": "boom",
+                    "expected": None,
+                    "actual": None,
+                    "stdout": "",
+                    "stderr": "",
+                    "diagnostics": {},
+                }
+            ],
+        }
+    )
+
+    assert report == (
+        "total=1 passed=0 failed=0 errored=1\n"
+        "ERROR errors phase=evaluation reason=boom\n"
+        "total=1 passed=0 failed=0 errored=1\n"
+    )
+
+
+def test_formats_discovery_error_empty_name_as_unnamed():
+    report = _format_report(
+        {
+            "total": 1,
+            "passed": 0,
+            "failed": 0,
+            "errored": 1,
+            "results": [
+                {
+                    "kind": "error",
+                    "name": "",
+                    "phase": "discovery",
+                    "reason": "test unit name must be a non-empty string",
+                    "expected": None,
+                    "actual": None,
+                    "stdout": "",
+                    "stderr": "",
+                    "diagnostics": {},
+                }
+            ],
+        }
+    )
+
+    assert report == (
+        "total=1 passed=0 failed=0 errored=1\n"
+        "ERROR <unnamed> phase=discovery reason=test unit name must be a non-empty string\n"
+        "total=1 passed=0 failed=0 errored=1\n"
+    )
+
+
+def test_formats_empty_suite_with_duplicate_zero_summary_and_one_final_newline():
+    report = _format_report(
+        {
+            "total": 0,
+            "passed": 0,
+            "failed": 0,
+            "errored": 0,
+            "results": [],
+        }
+    )
+
+    assert report == (
+        "total=0 passed=0 failed=0 errored=0\n"
+        "total=0 passed=0 failed=0 errored=0\n"
+    )
+    assert report.endswith("\n")
+    assert not report.endswith("\n\n")
+
+
+def test_formatter_rejects_unknown_result_kind():
+    with pytest.raises(ValueError, match="unknown test result kind: skip"):
+        _format_report(
+            {
+                "total": 1,
+                "passed": 0,
+                "failed": 0,
+                "errored": 0,
+                "results": [
+                    {
+                        "kind": "skip",
+                        "name": "future",
+                        "phase": "evaluation",
+                        "reason": None,
+                        "expected": None,
+                        "actual": None,
+                        "stdout": "",
+                        "stderr": "",
+                        "diagnostics": {},
+                    }
+                ],
+            }
+        )


### PR DESCRIPTION
close #438 

## Summary

Exposes native test runner outcomes through the CLI with:

- `genia --test <file>`
- test-mode-only `test(name, body)` helper
- native test suite report formatting
- deterministic exit codes:
  - `0` for no failures/errors
  - `1` for failed/errored test suites
  - `2` for invalid CLI invocation

The implementation preserves the existing native test kernel semantics and keeps malformed test units normalized by the kernel as discovery errors.

## Changes

- Added `src/genia/test_cli.py`
  - registers the test-mode-only helper
  - runs collected `TestUnit` values through the existing native test kernel
  - formats `PASS`, `FAIL`, and `ERROR` result lines
  - prints summary lines before and after results

- Updated `src/genia/interpreter.py`
  - added `--test <file>` mode selection
  - rejects invalid mode combinations
  - dispatches test mode separately from file/command/pipe/debug modes

- Added tests:
  - formatter/report coverage
  - CLI integration coverage
  - invalid invocation coverage

- Synced docs:
  - `GENIA_STATE.md`
  - `GENIA_REPL_README.md`
  - `README.md`

## Validation

- `uv run pytest -q tests/unit/test_native_test_cli.py` → 6 passed
- `uv run pytest -q tests/unit/test_interpreter_test_mode.py` → 6 passed
- `uv run pytest -q tests/unit/test_native_test_kernel.py` → 6 passed
- `uv run pytest -q tests/unit/test_cli_args.py` → 41 passed
- `uv run pytest -q tests/spec/test_cli_shared_spec_runner.py` → 26 passed
- `uv run pytest -q tests/doc/test_semantic_doc_sync.py` → 84 passed
- `uv run pytest -q tests/unit` → 2083 passed
- `uv run python -m tools.spec_runner` → total=425 passed=425 failed=0 invalid=0

`ruff` was attempted but unavailable in the environment.

## Scope notes

This does **not** add:

- test annotations
- setup/teardown lifecycle hooks
- JSON/JUnit/TAP output
- filtering
- parallel execution
- parser/Core IR changes
- multi-host test execution