### PR TITLE
feat(cli): add native test runner entry point issue #432

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -62,7 +62,7 @@ CLI contract summary (actual behavior):
 - command mode: `genia -c 'source' [args ...]`
 - pipe mode: `genia -p 'stage_expr' [args ...]` runs the stage expression over `stdin |> lines`, then consumes the final Flow automatically
 - REPL mode: `genia`
-- native test mode: `genia --test path/to/test_file.genia` (Experimental, Python reference host; see `GENIA_STATE.md` section 9.2)
+- native test mode: `genia test path/to/test_file.genia` (minimal entry point) or legacy `genia --test path/to/test_file.genia` (Experimental, Python reference host; see `GENIA_STATE.md` section 9.2)
 - file/command dispatch: call `main(argv())` when `main/1` exists, otherwise call `main()` when `main/0` exists
 - pipe mode bypasses `main`
 - trailing args are exposed through `argv()` as plain strings (including option-like values)

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2275,8 +2275,11 @@ Status: Experimental, Python reference host.
 
 `genia --test <file>` runs native test units registered through the test-mode-only `test(name, body)` helper and reports the existing normalized native test runner outcomes. The CLI prints suite counts before and after per-result lines, reports `PASS`, `FAIL`, and `ERROR` results, and exits `0` when no failures/errors occur, `1` when failures or normalized test errors occur, and `2` for invalid CLI invocation.
 
+`genia test <file>` is a minimal native test runner entry point over the same Python reference-host native test kernel. It validates and parses the file, discovers test units through the existing test-mode-only `test(name, body)` registration path, runs the discovered units through the native test kernel, prints one `[PASS|FAIL|ERROR] <name>` line per result followed by `Summary: total=<t> passed=<p> failed=<f> errors=<e>`, and exits `0` when all discovered tests pass, `1` when any test fails/errors, and `2` for file, parse, or no-tests errors.
+
 PYTHON REFERENCE HOST:
 - Implemented as `src/genia/test_cli.py` in the Python reference host.
+- The `genia test <file>` entry point is implemented as `src/genia/native_test_runner.py` and routed by `src/genia/interpreter.py`.
 - Test mode registers a test-mode-only `test(name, body)` helper that appends `TestUnit` values to a private list; malformed units are normalized as discovery errors by the existing kernel.
 - `--test` is mutually exclusive with `-c`/`--command`, `-p`/`--pipe`, and `--debug-stdio`.
 - Invalid combinations such as `--debug-stdio --test` are rejected with exit code `2`.

--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ printf '1\n2\n3\n' | genia -c 'stdin |> lines |> map(parse_int) |> keep_some |> 
   - `genia -c 'source' [args ...]` -> command mode
   - `genia -p 'stage_expr' [args ...]` -> pipe mode
   - `genia` -> REPL mode
-  - `genia --test path/to/test_file.genia` -> native test mode (Experimental, Python reference host)
+  - `genia test path/to/test_file.genia` -> minimal native test runner entry point (Experimental, Python reference host)
+  - `genia --test path/to/test_file.genia` -> legacy native test mode (Experimental, Python reference host)
 
 ### Choose `-p` vs `-c`
 

--- a/src/genia/interpreter.py
+++ b/src/genia/interpreter.py
@@ -558,6 +558,15 @@ def _run_execution_mode(mode: ExecutionMode) -> int:
 
 def _main(argv: Optional[list[str]] = None) -> int:
     raw_argv = list(argv) if argv is not None else sys.argv[1:]
+    if raw_argv and raw_argv[0] == "test":
+        if len(raw_argv) != 2:
+            parser = argparse.ArgumentParser(prog="genia test")
+            parser.add_argument("file")
+            parser.error("genia test accepts exactly one file path")
+        from .native_test_runner import run_native_tests
+
+        return run_native_tests(raw_argv[1])
+
     terminator_index: int | None = None
     try:
         terminator_index = raw_argv.index("--")

--- a/src/genia/native_test_runner.py
+++ b/src/genia/native_test_runner.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from .interpreter import Evaluator, Parser, assert_portable_core_ir, lex, lower_program, optimize_program
+from . import test_kernel
+
+
+def run_native_tests(file_path: str) -> int:
+    """
+    Load, parse, and execute native tests from a Genia file.
+
+    Returns exit code 0 when all tests pass, 1 when any test fails or errors,
+    and 2 for file, parse, or no-tests errors.
+    """
+    source, file_error = _validate_file(file_path)
+    if file_error is not None:
+        _write_stderr(file_error)
+        return 2
+
+    declarations, parse_error = _parse_file(source or "", file_path)
+    if parse_error is not None:
+        _write_stderr(parse_error)
+        return 2
+
+    test_units = _identify_tests(declarations or [])
+    if not test_units:
+        sys.stdout.write("Summary: total=0 passed=0 failed=0 errors=0\n")
+        sys.stdout.flush()
+        return 2
+
+    result_summary = _run_tests(test_units)
+    sys.stdout.write(_format_results(result_summary))
+    sys.stdout.flush()
+    return _map_exit_code(result_summary)
+
+
+def _validate_file(file_path: str) -> tuple[str | None, str | None]:
+    path = Path(file_path)
+    if not path.exists() or not path.is_file():
+        return None, f"genia: test: file not found: {file_path}"
+    if not os.access(path, os.R_OK):
+        return None, f"genia: test: cannot read {file_path}: not readable"
+
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except OSError as exc:
+        return None, f"genia: test: cannot read {file_path}: {exc}"
+
+
+def _parse_file(source: str, file_path: str) -> tuple[list[Any] | None, str | None]:
+    try:
+        declarations = Parser(lex(source), source=source, filename=file_path).parse_program()
+    except SyntaxError as exc:
+        return None, f"Parse error: {exc}"
+    return declarations, None
+
+
+def _identify_tests(declarations: list[Any]) -> list[Any]:
+    return native_test_kernel.identify_tests(declarations)
+
+
+def _run_tests(test_units: list[Any]) -> Any:
+    return native_test_kernel.run_tests(test_units)
+
+
+def _format_results(result_summary: Any) -> str:
+    lines = [
+        f"[{_outcome_status(outcome)}] {_outcome_name(outcome)}"
+        for outcome in _get(result_summary, "outcomes", [])
+    ]
+    lines.append(
+        "Summary: "
+        f"total={_get(result_summary, 'total', 0)} "
+        f"passed={_get(result_summary, 'passed', 0)} "
+        f"failed={_get(result_summary, 'failed', 0)} "
+        f"errors={_get(result_summary, 'errors', 0)}"
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _map_exit_code(result_summary: Any) -> int:
+    if _get(result_summary, "total", 0) == 0:
+        return 2
+    if _get(result_summary, "failed", 0) > 0 or _get(result_summary, "errors", 0) > 0:
+        return 1
+    return 0
+
+
+def _write_stderr(message: str) -> None:
+    try:
+        sys.stderr.write(message + "\n")
+        sys.stderr.flush()
+    except BrokenPipeError:
+        return
+
+
+def _get(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _outcome_status(outcome: Any) -> str:
+    status = _get(outcome, "status")
+    if status is not None:
+        return str(status)
+
+    kind = str(_get(outcome, "kind", "")).upper()
+    if kind == "PASS":
+        return "PASS"
+    if kind == "FAIL":
+        return "FAIL"
+    if kind == "ERROR":
+        return "ERROR"
+    return kind
+
+
+def _outcome_name(outcome: Any) -> str:
+    return str(_get(outcome, "name", "<unnamed>") or "<unnamed>")
+
+
+def _kernel_summary_from_suite(suite: dict[str, Any]) -> SimpleNamespace:
+    outcomes = [
+        SimpleNamespace(
+            name=result.get("name", "<unnamed>") or "<unnamed>",
+            status=str(result.get("kind", "")).upper(),
+            message=result.get("reason"),
+        )
+        for result in suite.get("results", [])
+    ]
+    return SimpleNamespace(
+        total=suite.get("total", 0),
+        passed=suite.get("passed", 0),
+        failed=suite.get("failed", 0),
+        errors=suite.get("errored", 0),
+        outcomes=outcomes,
+    )
+
+
+def identify_tests(declarations: list[Any]) -> list[Any]:
+    """Discover registered native tests through the existing test-mode helper."""
+    from .test_cli import discover_test_units, make_test_env
+
+    env, _ = make_test_env()
+    ir_nodes = lower_program(declarations)
+    assert_portable_core_ir(ir_nodes)
+    ir_nodes = optimize_program(ir_nodes)
+    Evaluator(env).eval_program(ir_nodes)
+    return discover_test_units(env)
+
+
+def run_tests(test_units: list[Any]) -> SimpleNamespace:
+    """Run test units through the existing native test kernel."""
+    return _kernel_summary_from_suite(test_kernel.run_test_suite(test_units))
+
+
+native_test_kernel = SimpleNamespace(
+    identify_tests=identify_tests,
+    run_tests=run_tests,
+)

--- a/tests/unit/test_native_test_runner.py
+++ b/tests/unit/test_native_test_runner.py
@@ -1,0 +1,394 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from genia.native_test_runner import run_native_tests
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+
+@pytest.fixture
+def mock_kernel():
+    """Mock native test kernel with identify_tests and run_tests."""
+    kernel = Mock()
+    kernel.identify_tests.return_value = []
+    kernel.run_tests.return_value = SimpleNamespace(
+        total=0,
+        passed=0,
+        failed=0,
+        errors=0,
+        outcomes=[],
+    )
+    return kernel
+
+
+@pytest.fixture
+def temp_genia_file(tmp_path):
+    """Create a temporary .genia file path."""
+    return tmp_path / "test.genia"
+
+
+@pytest.fixture
+def valid_passing_test_file(temp_genia_file):
+    """File with one passing native test registration."""
+    temp_genia_file.write_text('test("passes", () -> none)\n', encoding="utf-8")
+    return temp_genia_file
+
+
+@pytest.fixture
+def no_tests_file(temp_genia_file):
+    """File that parses but discovers no native tests."""
+    temp_genia_file.write_text("x = 42\n", encoding="utf-8")
+    return temp_genia_file
+
+
+@pytest.fixture
+def syntax_error_file(temp_genia_file):
+    """File with invalid Genia syntax."""
+    temp_genia_file.write_text("x = \n", encoding="utf-8")
+    return temp_genia_file
+
+
+def _test_unit(name):
+    """Create a minimal mock test unit."""
+    return SimpleNamespace(name=name)
+
+
+def _outcome(name, status):
+    """Create a minimal mock test outcome."""
+    return SimpleNamespace(name=name, status=status)
+
+
+def _summary(*outcomes):
+    """Create a mock native test summary from outcomes."""
+    return SimpleNamespace(
+        total=len(outcomes),
+        passed=sum(item.status == "PASS" for item in outcomes),
+        failed=sum(item.status == "FAIL" for item in outcomes),
+        errors=sum(item.status == "ERROR" for item in outcomes),
+        outcomes=list(outcomes),
+    )
+
+
+def run_with_kernel(file_path: Path, mock_kernel):
+    """Run the native test runner with a patched native test kernel."""
+    with patch("genia.native_test_runner.native_test_kernel", mock_kernel):
+        return run_native_tests(str(file_path))
+
+
+# ============================================================================
+# TEST CLASSES
+# ============================================================================
+
+
+class TestNativeTestRunnerFileHandling:
+    """Test file I/O and error handling."""
+
+    def test_file_not_found(self, tmp_path, capsys):
+        """Missing file returns exit code 2 and a clear stderr message."""
+        missing_file = tmp_path / "missing.genia"
+
+        exit_code = run_native_tests(str(missing_file))
+
+        captured = capsys.readouterr()
+        assert exit_code == 2, "missing files should return usage/data error code 2"
+        assert "file not found" in captured.err.lower()
+        assert captured.out == ""
+
+    def test_file_not_readable(self, temp_genia_file, capsys):
+        """Unreadable files return exit code 2 and do not write stdout."""
+        temp_genia_file.write_text('test("passes", () -> none)\n', encoding="utf-8")
+        temp_genia_file.chmod(0)
+
+        try:
+            exit_code = run_native_tests(str(temp_genia_file))
+        finally:
+            temp_genia_file.chmod(0o600)
+
+        captured = capsys.readouterr()
+        assert exit_code == 2, "unreadable files should return usage/data error code 2"
+        assert "not readable" in captured.err.lower()
+        assert captured.out == ""
+
+    def test_file_empty(self, temp_genia_file, mock_kernel, capsys):
+        """Empty files parse but discover no tests, so the runner returns 2."""
+        temp_genia_file.write_text("", encoding="utf-8")
+        mock_kernel.identify_tests.return_value = []
+
+        exit_code = run_with_kernel(temp_genia_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert exit_code == 2, "empty files should be treated as no-tests errors"
+        assert captured.out == "Summary: total=0 passed=0 failed=0 errors=0\n"
+        assert captured.err == ""
+        mock_kernel.run_tests.assert_not_called()
+
+
+class TestNativeTestRunnerParsing:
+    """Test parsing and parse-related error reporting."""
+
+    def test_parse_error(self, syntax_error_file, capsys):
+        """Syntax errors return exit code 2 with parse-error stderr."""
+        exit_code = run_native_tests(str(syntax_error_file))
+
+        captured = capsys.readouterr()
+        assert exit_code == 2, "parse errors should return usage/data error code 2"
+        assert captured.err.startswith("Parse error:")
+        assert captured.out == ""
+
+    def test_valid_parse_no_tests(self, no_tests_file, mock_kernel, capsys):
+        """A valid file with no discovered tests returns exit code 2."""
+        mock_kernel.identify_tests.return_value = []
+
+        exit_code = run_with_kernel(no_tests_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert exit_code == 2, "valid files with no tests should return code 2"
+        assert captured.out == "Summary: total=0 passed=0 failed=0 errors=0\n"
+        assert captured.err == ""
+        mock_kernel.run_tests.assert_not_called()
+
+    def test_valid_file_invokes_kernel_for_discovered_tests(
+        self,
+        valid_passing_test_file,
+        mock_kernel,
+        capsys,
+    ):
+        """A valid file delegates discovered tests to the native test kernel."""
+        tests = [_test_unit("passes")]
+        mock_kernel.identify_tests.return_value = tests
+        mock_kernel.run_tests.return_value = _summary(_outcome("passes", "PASS"))
+
+        exit_code = run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        mock_kernel.identify_tests.assert_called_once()
+        mock_kernel.run_tests.assert_called_once_with(tests)
+        assert captured.err == ""
+
+
+class TestNativeTestRunnerExecution:
+    """Test execution and result reporting."""
+
+    def test_all_tests_pass(self, valid_passing_test_file, mock_kernel, capsys):
+        """All passing tests print PASS lines and return exit code 0."""
+        mock_kernel.identify_tests.return_value = [_test_unit("test_passes")]
+        mock_kernel.run_tests.return_value = _summary(_outcome("test_passes", "PASS"))
+
+        exit_code = run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert captured.out == (
+            "[PASS] test_passes\n"
+            "Summary: total=1 passed=1 failed=0 errors=0\n"
+        )
+        assert captured.err == ""
+
+    def test_one_test_fails(self, valid_passing_test_file, mock_kernel, capsys):
+        """Any failing test prints FAIL and returns exit code 1."""
+        mock_kernel.identify_tests.return_value = [_test_unit("test_fails")]
+        mock_kernel.run_tests.return_value = _summary(_outcome("test_fails", "FAIL"))
+
+        exit_code = run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "[FAIL] test_fails\n" in captured.out
+        assert "Summary: total=1 passed=0 failed=1 errors=0\n" in captured.out
+        assert captured.err == ""
+
+    def test_one_test_errors(self, valid_passing_test_file, mock_kernel, capsys):
+        """Any erroring test prints ERROR and returns exit code 1."""
+        mock_kernel.identify_tests.return_value = [_test_unit("test_errors")]
+        mock_kernel.run_tests.return_value = _summary(_outcome("test_errors", "ERROR"))
+
+        exit_code = run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "[ERROR] test_errors\n" in captured.out
+        assert "Summary: total=1 passed=0 failed=0 errors=1\n" in captured.out
+        assert captured.err == ""
+
+    def test_mixed_results(self, valid_passing_test_file, mock_kernel, capsys):
+        """Mixed pass, fail, and error results report counts and return 1."""
+        mock_kernel.identify_tests.return_value = [
+            _test_unit("test_passes"),
+            _test_unit("test_fails"),
+            _test_unit("test_errors"),
+        ]
+        mock_kernel.run_tests.return_value = _summary(
+            _outcome("test_passes", "PASS"),
+            _outcome("test_fails", "FAIL"),
+            _outcome("test_errors", "ERROR"),
+        )
+
+        exit_code = run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert captured.out == (
+            "[PASS] test_passes\n"
+            "[FAIL] test_fails\n"
+            "[ERROR] test_errors\n"
+            "Summary: total=3 passed=1 failed=1 errors=1\n"
+        )
+        assert captured.err == ""
+
+
+class TestNativeTestRunnerFormatting:
+    """Test output formatting."""
+
+    @pytest.mark.parametrize(
+        ("status", "expected_line"),
+        [
+            ("PASS", "[PASS] test_name"),
+            ("FAIL", "[FAIL] test_name"),
+            ("ERROR", "[ERROR] test_name"),
+        ],
+    )
+    def test_output_line_format(
+        self,
+        valid_passing_test_file,
+        mock_kernel,
+        capsys,
+        status,
+        expected_line,
+    ):
+        """Each test result is formatted as '[STATUS] name' on one line."""
+        mock_kernel.identify_tests.return_value = [_test_unit("test_name")]
+        mock_kernel.run_tests.return_value = _summary(_outcome("test_name", status))
+
+        run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert captured.out.splitlines()[0] == expected_line
+
+    def test_summary_format(self, valid_passing_test_file, mock_kernel, capsys):
+        """The summary line matches the exact contracted format."""
+        mock_kernel.identify_tests.return_value = [
+            _test_unit("test_one"),
+            _test_unit("test_two"),
+        ]
+        mock_kernel.run_tests.return_value = _summary(
+            _outcome("test_one", "PASS"),
+            _outcome("test_two", "FAIL"),
+        )
+
+        run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert captured.out.splitlines()[-1] == (
+            "Summary: total=2 passed=1 failed=1 errors=0"
+        )
+
+    def test_output_order(self, valid_passing_test_file, mock_kernel, capsys):
+        """Test results are printed in the source/kernel outcome order."""
+        mock_kernel.identify_tests.return_value = [
+            _test_unit("test_first"),
+            _test_unit("test_second"),
+            _test_unit("test_third"),
+        ]
+        mock_kernel.run_tests.return_value = _summary(
+            _outcome("test_first", "PASS"),
+            _outcome("test_second", "FAIL"),
+            _outcome("test_third", "ERROR"),
+        )
+
+        run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        captured = capsys.readouterr()
+        assert captured.out.splitlines()[:3] == [
+            "[PASS] test_first",
+            "[FAIL] test_second",
+            "[ERROR] test_third",
+        ]
+
+
+class TestNativeTestRunnerExitCodes:
+    """Test exit code mapping for the native test runner contract."""
+
+    @pytest.mark.parametrize(
+        ("suite", "expected_exit_code"),
+        [
+            (_summary(_outcome("test_passes", "PASS")), 0),
+            (_summary(_outcome("test_fails", "FAIL")), 1),
+            (_summary(_outcome("test_errors", "ERROR")), 1),
+            (
+                _summary(
+                    _outcome("test_passes", "PASS"),
+                    _outcome("test_fails", "FAIL"),
+                    _outcome("test_errors", "ERROR"),
+                ),
+                1,
+            ),
+        ],
+    )
+    def test_exit_code_from_execution_summary(
+        self,
+        valid_passing_test_file,
+        mock_kernel,
+        suite,
+        expected_exit_code,
+    ):
+        """Execution summaries map cleanly to exit code 0 or 1."""
+        mock_kernel.identify_tests.return_value = [_test_unit("test_name")]
+        mock_kernel.run_tests.return_value = suite
+
+        exit_code = run_with_kernel(valid_passing_test_file, mock_kernel)
+
+        assert exit_code == expected_exit_code
+
+    def test_exit_0_all_pass(self, valid_passing_test_file, mock_kernel):
+        """Exit code 0 when all tests pass."""
+        mock_kernel.identify_tests.return_value = [_test_unit("test_passes")]
+        mock_kernel.run_tests.return_value = _summary(_outcome("test_passes", "PASS"))
+
+        assert run_with_kernel(valid_passing_test_file, mock_kernel) == 0
+
+    def test_exit_1_any_fail(self, valid_passing_test_file, mock_kernel):
+        """Exit code 1 when any test fails."""
+        mock_kernel.identify_tests.return_value = [_test_unit("test_fails")]
+        mock_kernel.run_tests.return_value = _summary(_outcome("test_fails", "FAIL"))
+
+        assert run_with_kernel(valid_passing_test_file, mock_kernel) == 1
+
+    def test_exit_1_any_error(self, valid_passing_test_file, mock_kernel):
+        """Exit code 1 when any test errors."""
+        mock_kernel.identify_tests.return_value = [_test_unit("test_errors")]
+        mock_kernel.run_tests.return_value = _summary(_outcome("test_errors", "ERROR"))
+
+        assert run_with_kernel(valid_passing_test_file, mock_kernel) == 1
+
+    def test_exit_2_file_not_found(self, tmp_path):
+        """Exit code 2 when the file is missing."""
+        assert run_native_tests(str(tmp_path / "missing.genia")) == 2
+
+    def test_exit_2_file_not_readable(self, temp_genia_file):
+        """Exit code 2 when the file exists but is unreadable."""
+        temp_genia_file.write_text('test("passes", () -> none)\n', encoding="utf-8")
+        temp_genia_file.chmod(0)
+
+        try:
+            exit_code = run_native_tests(str(temp_genia_file))
+        finally:
+            temp_genia_file.chmod(0o600)
+
+        assert exit_code == 2
+
+    def test_exit_2_parse_error(self, syntax_error_file):
+        """Exit code 2 when parsing fails."""
+        assert run_native_tests(str(syntax_error_file)) == 2
+
+    def test_exit_2_no_tests(self, no_tests_file, mock_kernel):
+        """Exit code 2 when no tests are discovered."""
+        mock_kernel.identify_tests.return_value = []
+
+        assert run_with_kernel(no_tests_file, mock_kernel) == 2


### PR DESCRIPTION
close #432 

## Summary

Adds the minimal R2 native test runner entry point:

- Adds `genia test <file>`
- Routes the new entry point through `src/genia/native_test_runner.py`
- Preserves legacy `genia --test <file>`
- Reuses the existing native test kernel/test registration path
- Reports `[PASS|FAIL|ERROR] <name>` result lines plus a final summary
- Returns:
  - `0` when all discovered tests pass
  - `1` when any discovered test fails/errors
  - `2` for file, parse, invalid invocation, or no-tests errors

## Docs

Updated:

- `GENIA_STATE.md`
- `GENIA_REPL_README.md`
- `README.md`

Docs keep the behavior scoped as Experimental / Python reference host and do not claim native tests replace pytest.

## Audit Fix

Audit found and fixed one contract mismatch:

- no-tests now writes `Summary: total=0 passed=0 failed=0 errors=0` to stdout and exits `2`

## Verification

- `uv run pytest -q tests/unit/test_native_test_runner.py -v` → `26 passed`
- `uv run pytest -q tests/unit/test_interpreter_test_mode.py` → `6 passed`
- `uv run pytest -q tests/unit/test_native_test_kernel.py` → `6 passed`
- `uv run pytest -q tests/doc/test_semantic_doc_sync.py` → `84 passed`
- `uv run python -m tools.spec_runner` → `428 passed`
- `uv run pytest -q` → `2488 passed`
- `uv tool run ruff check src/genia/native_test_runner.py src/genia/interpreter.py tests/unit/test_native_test_runner.py` → passed