### PR TITLE
Feature/issue 433 issue 433 r2 implementation add minimal assertion helpers

### DIFF
--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -70,6 +70,7 @@ CLI contract summary (actual behavior):
 - when no `-c`/`-p` mode is selected, the first non-mode argument must be a source file path (`--` stops option parsing for dash-prefixed literal args/paths)
 - `--debug-stdio` accepts exactly one program path and rejects `-c`/`-p` combinations with explicit parser errors
 - `--test` is mutually exclusive with `-c`, `-p`, and `--debug-stdio`; invalid combinations exit with code `2`
+- native test assertion helpers (Python reference host, Experimental): `assert_true(value)` and `assert_eq(actual, expected)` are minimal assertion helpers available in native test bodies; passing helpers return `none` and print nothing; inside native test mode, failing helpers are reported as test `FAIL` outcomes rather than evaluation `ERROR` outcomes; incorrect arity remains an evaluation `ERROR`; this is not a full assertion framework; see `GENIA_STATE.md` section 9.1.1
 
 **Limitations:**
 - Only the Python host is implemented; all CLI, REPL, and pipe behavior is enforced and tested only for Python.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2264,10 +2264,41 @@ Not implemented in this phase:
 - shared spec-runner integration
 - host adapter for Genia runtime callables
 - parser/lexer/evaluator/Core IR changes
-- public Genia builtins or prelude surface for test authoring beyond the test-mode-only `test(name, body)` helper
-- annotations, lifecycle phases, or fixtures
+- broad assertion framework, lifecycle hooks, annotations, or fixtures; only the minimal helpers `assert_true` and `assert_eq` are implemented
 - stdout/stderr capture (fields are present but always empty strings)
 - multi-host test execution
+
+## 9.1.1) Native test assertion helpers (Python reference host, Experimental)
+
+PYTHON REFERENCE HOST:
+- The Python reference host provides minimal native-test assertion helpers: `assert_true(value)` and `assert_eq(actual, expected)`.
+- Implemented as builtins registered directly in the global environment via `src/genia/builtins.py`.
+- This is not a full assertion framework. This is the minimal native-test helper surface.
+
+`assert_true(value)`:
+- passes when `value` is truthy according to current runtime truthiness
+- returns `none` on success
+- prints nothing on success
+- raises `NativeTestFailure` on assertion failure
+- inside native test mode, a failing `assert_true` is reported as a test `FAIL` outcome, not an `ERROR` outcome
+
+`assert_eq(actual, expected)`:
+- passes when `actual` equals `expected` according to current Genia equality behavior
+- returns `none` on success
+- prints nothing on success
+- preserves useful actual/expected diagnostics on failure
+- raises `NativeTestFailure` on assertion failure
+- inside native test mode, a failing `assert_eq` is reported as a test `FAIL` outcome, not an `ERROR` outcome
+
+Assertion failure behavior:
+- Inside native test mode, failing helpers are reported as test FAIL outcomes rather than evaluation ERROR outcomes.
+- Incorrect helper arity remains an evaluation ERROR.
+- Later tests in the same suite continue running after an assertion failure.
+
+Not implemented in this phase:
+- `assert_false`, `assert_ne`, `assert_raises`, custom assertion messages, snapshot testing, property testing, soft assertions, or matcher DSLs
+- cross-host implementation; Python is the only implemented host
+- assertion lifecycle hooks, grouping, or count tracking
 
 ## 9.2) Native test CLI (Python reference host, Experimental)
 

--- a/src/genia/builtins.py
+++ b/src/genia/builtins.py
@@ -73,6 +73,7 @@ if __package__ in (None, ""):
         sheet_shape,
         sheet_where,
     )
+    from genia.test_kernel import NativeTestFailure
     from genia.values import (
         OPTION_NONE,
         _RNG_INCREMENT,
@@ -153,6 +154,7 @@ else:
         sheet_shape,
         sheet_where,
     )
+    from .test_kernel import NativeTestFailure
     from .values import (
         OPTION_NONE,
         _RNG_INCREMENT,
@@ -509,6 +511,16 @@ def make_global_env(
 
     def debug_repr_fn(value: Any) -> str:
         return format_debug(value)
+
+    def assert_true_fn(value: Any) -> Any:
+        if not truthy(value):
+            raise NativeTestFailure("assert_true failed")
+        return OPTION_NONE
+
+    def assert_eq_fn(actual: Any, expected: Any) -> Any:
+        if actual != expected:
+            raise NativeTestFailure("assert_eq failed", expected=expected, actual=actual)
+        return OPTION_NONE
 
     def format_constructor(*args: Any) -> GeniaFormat:
         if len(args) not in (1, 2):
@@ -3339,6 +3351,8 @@ def make_global_env(
     env.set("print", print_fn)
     env.set("display", display_fn)
     env.set("debug_repr", debug_repr_fn)
+    env.set("assert_true", _host_function_group("assert_true", 1, assert_true_fn))
+    env.set("assert_eq", _host_function_group("assert_eq", 2, assert_eq_fn))
     env.set("Format", format_constructor)
     env.set("format_template", format_template_fn)
     env.set("format_tag", format_tag_fn)

--- a/tests/unit/test_interpreter_test_mode.py
+++ b/tests/unit/test_interpreter_test_mode.py
@@ -19,6 +19,77 @@ def test_test_mode_runs_passing_test_file(tmp_path, capsys):
     assert captured.err == ""
 
 
+def test_test_mode_runs_passing_assertion_helpers(tmp_path, capsys):
+    program = tmp_path / "passing_assertions.genia"
+    program.write_text(
+        "\n".join(
+            [
+                'test("assert true passes", () -> assert_true(true))',
+                'test("assert eq passes", () -> assert_eq(2 + 2, 4))',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "total=2 passed=2 failed=0 errored=0\n"
+        "PASS assert true passes\n"
+        "PASS assert eq passes\n"
+        "total=2 passed=2 failed=0 errored=0\n"
+    )
+    assert captured.err == ""
+
+
+def test_test_mode_reports_failing_assertions_as_failures_and_continues(tmp_path, capsys):
+    program = tmp_path / "failing_assertions.genia"
+    program.write_text(
+        "\n".join(
+            [
+                'test("assert eq fails", () -> assert_eq(2 + 2, 5))',
+                'test("assert true fails", () -> assert_true(false))',
+                'test("still runs", () -> none)',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    lines = captured.out.splitlines()
+    assert exit_code == 1
+    assert lines[0] == "total=3 passed=1 failed=2 errored=0"
+    assert lines[-1] == "total=3 passed=1 failed=2 errored=0"
+    assert lines[1].startswith(
+        "FAIL assert eq fails phase=evaluation reason=assert_eq failed"
+    )
+    assert "expected=5" in lines[1]
+    assert "actual=4" in lines[1]
+    assert lines[2] == "FAIL assert true fails phase=evaluation reason=assert_true failed"
+    assert lines[3] == "PASS still runs"
+    assert captured.err == ""
+
+
+def test_test_mode_keeps_assertion_helper_arity_as_runtime_error(tmp_path, capsys):
+    program = tmp_path / "bad_assertion_arity.genia"
+    program.write_text('test("bad arity", () -> assert_true())\n', encoding="utf-8")
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "total=1 passed=0 failed=0 errored=1\n" in captured.out
+    assert "ERROR bad arity phase=evaluation reason=" in captured.out
+    assert "FAIL bad arity" not in captured.out
+    assert captured.err == ""
+
+
 def test_test_mode_reports_discovery_error_for_non_callable_body(tmp_path, capsys):
     program = tmp_path / "bad_test.genia"
     program.write_text('test("bad", "not callable")\n', encoding="utf-8")


### PR DESCRIPTION
close #433 

## Summary

Adds the minimal native-test assertion helper surface for issue #433:

- `assert_true(value)`
- `assert_eq(actual, expected)`

These helpers are available in the Python reference host as builtins. Passing assertions return `none` and print nothing. Failing assertions raise `NativeTestFailure`, so native test mode reports them as `FAIL` outcomes rather than evaluation `ERROR` outcomes.

This intentionally does **not** add a full assertion framework, custom messages, matcher DSLs, lifecycle hooks, annotations, parser changes, or new test syntax.

## Changes

- Added failing test coverage first for assertion helper behavior.
- Implemented `assert_true` and `assert_eq` in `src/genia/builtins.py`.
- Documented the implemented behavior in:
  - `GENIA_STATE.md`
  - `GENIA_REPL_README.md`

## Validation

```text
uv run pytest -q tests/doc/test_semantic_doc_sync.py
84 passed

uv run pytest -q tests/unit/test_interpreter_test_mode.py -v
9 passed

uv run pytest -q tests/unit/test_native_test_kernel.py tests/unit/test_native_test_cli.py tests/unit/test_native_test_runner.py -v
38 passed

uv run pytest -q tests/unit
2113 passed

uv run python -m tools.spec_runner
Summary: total=428 passed=428 failed=0 invalid=0

uv tool run ruff check src/genia/builtins.py
All checks passed!