### PR TITLE
Feature/issue 434 issue 434 r2 tests add first genia native tests for r1 validated pipeline behavior

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2300,6 +2300,8 @@ Not implemented in this phase:
 - cross-host implementation; Python is the only implemented host
 - assertion lifecycle hooks, grouping, or count tracking
 
+A Genia-native fixture now covers the R1 validated pipeline path. Validated by `tests/unit/test_r1_validated_pipeline_native_tests.py` (1 test, Python reference host only); the fixture is `tests/native/r1_validated_pipeline.genia`. Validated pipeline behavior is covered by a native test fixture using `parse_jsonl_record`, `validate_each`, `validate_record`, `collect_validated`, and `assert_eq`.
+
 ## 9.2) Native test CLI (Python reference host, Experimental)
 
 Status: Experimental, Python reference host.

--- a/tests/native/r1_validated_pipeline.genia
+++ b/tests/native/r1_validated_pipeline.genia
@@ -1,0 +1,35 @@
+valid_person(record) =
+  validate_record(record, {
+    id: (r) -> validate_field("id", (x) -> x > 0, "positive id", r),
+    name: (r) -> validate_required("name", r)
+  })
+
+test("validated pipeline collects clean records and diagnostics", () -> {
+  lines = [
+    "{\"id\":1,\"name\":\"Ada\"}",
+    "",
+    "{\"id\":0,\"name\":\"Bad\"}",
+    "{\"id\":",
+    "{\"id\":2,\"name\":\"Grace\"}"
+  ]
+
+  result =
+    lines
+      |> map(parse_jsonl_record)
+      |> ((records) -> validate_each(records, valid_person))
+      |> collect_validated
+
+  diagnostics = result("diagnostics")
+  skipped = unwrap_or({}, diagnostics |> nth(0))
+  invalid = unwrap_or({}, diagnostics |> nth(1))
+  malformed = unwrap_or({}, diagnostics |> nth(2))
+
+  assert_eq(display(result("clean")), "[{id: 1, name: Ada}, {id: 2, name: Grace}]")
+  assert_eq(count(diagnostics), 3)
+  assert_eq(display(skipped("kind")), "skipped")
+  assert_eq(display(skipped("reason")), "blank_line")
+  assert_eq(display(invalid("kind")), "error")
+  assert_eq(display(invalid("reason")), "record_validation_failed")
+  assert_eq(display(malformed("kind")), "error")
+  assert_eq(display(malformed("reason")), "invalid_jsonl_record")
+})

--- a/tests/unit/test_r1_validated_pipeline_native_tests.py
+++ b/tests/unit/test_r1_validated_pipeline_native_tests.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from genia.native_test_runner import run_native_tests
+
+
+def test_r1_validated_pipeline_native_tests_pass(capsys):
+    fixture = Path("tests/native/r1_validated_pipeline.genia")
+
+    exit_code = run_native_tests(str(fixture))
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "[PASS] validated pipeline collects clean records and diagnostics\n"
+        "Summary: total=1 passed=1 failed=0 errors=0\n"
+    )
+    assert captured.err == ""


### PR DESCRIPTION
close #434 

## Summary

Adds the first Genia-native test fixture for the R1 validated pipeline path.

This change verifies that existing Genia behavior can express an Outcome-aware validated record pipeline using native tests. No runtime, parser, Flow, Outcome, validation-helper, or CLI behavior changed.

## Changes

- Added `tests/native/r1_validated_pipeline.genia`
  - Uses `test(...)`
  - Exercises `parse_jsonl_record`
  - Uses `validate_each`
  - Uses `validate_record`
  - Aggregates with `collect_validated`
  - Asserts stable scalar/rendered outputs with `assert_eq`

- Added `tests/unit/test_r1_validated_pipeline_native_tests.py`
  - Runs the native fixture through `run_native_tests`
  - Asserts the existing native test runner output

- Updated `GENIA_STATE.md`
  - Records that a Genia-native fixture now covers the R1 validated pipeline path
  - Documents coverage only, not new runtime behavior

## Implementation Notes

No implementation changes were required.

The approved native validated-pipeline fixture already passes against existing behavior, so this PR adds test coverage and truth-aligned documentation only.

## Validation

```text
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r1_validated_pipeline_native_tests.py -v
1 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py -v
26 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py -v
6 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_interpreter_test_mode.py -v
9 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_json_stdlib.py tests/unit/test_validate_each.py -v
30 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py -v
84 passed