### PR TITLE
Feature/issue 436 issue 436 r2 docs document native test kernel boundaries

### DIFF
--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2336,7 +2336,7 @@ PYTHON REFERENCE HOST:
 - Invalid combinations such as `--debug-stdio --test` are rejected with exit code `2`.
 - Report format: a summary line `total=<t> passed=<p> failed=<f> errored=<e>` appears both before and after per-result lines.
 - Per-result lines: `PASS <name>`, `FAIL <name> phase=<phase> reason=<reason>` (with `expected=<expected> actual=<actual>` when present), `ERROR <name-or-unnamed> phase=<phase> reason=<reason>`.
-- Validated by `tests/unit/test_native_test_cli.py` (6 tests) and `tests/unit/test_interpreter_test_mode.py` (6 tests), Python reference host only.
+- Validated by `tests/unit/test_native_test_cli.py` (6 tests) and `tests/unit/test_interpreter_test_mode.py` (9 tests), Python reference host only.
 
 This does not add test annotations, setup/teardown lifecycle hooks, filtering, parallel execution, JSON/JUnit/TAP output, or multi-host test execution.
 

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2237,6 +2237,24 @@ Core IR shape currently includes:
 - `help("name")` for a string that resolves to a non-Genia host-backed runtime name prints a generic bridge note instead of maintaining a separate raw-host documentation registry
 - `help("missing")` prints a short missing-name note instead of raising an undefined-name traceback
 
+### Native test layer boundaries (Python reference host, Experimental)
+
+The current native test stack uses four layers:
+
+- **Kernel** (`src/genia/test_kernel.py`): executes already-formed `TestUnit` values and normalizes their outcomes. The kernel distinguishes passing tests, assertion/native-test failures (`NativeTestFailure`), unexpected runtime errors, and malformed/discovery-invalid test units. The kernel does not discover tests, load files, format CLI output, or own process exit codes.
+- **Runner** (`src/genia/native_test_runner.py`): coordinates file/suite-level native test execution for `genia test <file>` by invoking the kernel and aggregating results. The runner does not define assertion semantics or change language runtime behavior.
+- **CLI/test-mode layer** (`src/genia/test_cli.py`): selects the `--test` entry point, loads/evaluates the file in test mode, registers tests through the `test(name, body)` mechanism, formats output via `format_test_suite_report`, and returns process exit codes via `suite_exit_code`. The CLI layer does not own kernel outcome normalization or provide broad discovery or lifecycle support.
+- **Assertion helpers** (`src/genia/builtins.py`): `assert_true` and `assert_eq` make passing assertions return `none` (the implemented success value) and make failing assertions raise `NativeTestFailure`, which the kernel reports as a `fail` result rather than an unexpected `error`.
+
+Current native test behavior distinguishes:
+
+- `pass`: the test unit body completes without raising;
+- `fail`: the test unit body raises `NativeTestFailure` (phase `"evaluation"`);
+- `error`: an unexpected exception occurs during execution (phase `"evaluation"`);
+- discovery error: the test unit has an invalid name or non-callable body (phase `"discovery"`).
+
+Current native test support is not a complete test framework; lifecycle hooks, setup/teardown annotations, fixtures, parameterized tests, broad directory discovery, and multi-host conformance are out of scope in this phase.
+
 ## 9.1) Native test kernel core (Python reference host, Experimental)
 
 LANGUAGE CONTRACT:


### PR DESCRIPTION
close #436 

Here’s a clean PR description you can paste:

````md
## Summary

- Documented the native test stack boundaries in `GENIA_STATE.md`.
- Clarified the four current Python reference-host layers:
  - kernel
  - runner
  - CLI/test-mode layer
  - assertion helpers
- Preserved the current outcome distinctions:
  - `pass`
  - `fail`
  - `error`
  - discovery error
- Fixed a doc-truth issue where `tests/unit/test_interpreter_test_mode.py` was listed as 6 tests instead of 9.

## Tests

```text
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q \
  tests/unit/test_native_test_kernel.py \
  tests/unit/test_native_test_runner.py \
  tests/unit/test_native_test_cli.py \
  tests/unit/test_interpreter_test_mode.py \
  tests/doc/test_semantic_doc_sync.py
````

Result:

```text
131 passed in 0.85s
```

## Docs

* Durable docs changed: `GENIA_STATE.md` only.
* Handoff files remain local/uncommitted under `.genia/process/tmp/handoffs/`.

## Known limitations

* Native test support remains Python reference-host, Experimental, and intentionally minimal.
* This change does not add lifecycle hooks, setup/teardown annotations, fixtures, parameterized tests, broad directory discovery, or multi-host native test conformance.

```

Branch is clean and ready for PR/merge based on the closeout: `GENIA_STATE.md` is the only durable repo change, handoff files are not tracked, and focused validation passed. :contentReference[oaicite:0]{index=0}
```
