### PR TITLE
Feature/issue 458 r3 contract annotation native tests

### DIFF
--- a/.genia/process/tmp/handoffs/issue-458-r3-contract-annotation-native-tests/03-test.md
+++ b/.genia/process/tmp/handoffs/issue-458-r3-contract-annotation-native-tests/03-test.md
@@ -1,0 +1,104 @@
+# Genia TEST - Issue #458
+
+CHANGE NAME: issue #458 r3-contract-annotation-native-tests  
+CHANGE SLUG: issue-458-r3-contract-annotation-native-tests  
+TYPE: feature  
+ISSUE: 458  
+BRANCH: feature/issue-458-r3-contract-annotation-native-tests  
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-458-r3-contract-annotation-native-tests/`
+
+---
+
+## Branch
+
+Starting branch:
+
+```text
+feature/issue-458-r3-contract-annotation-native-tests
+```
+
+Working branch:
+
+```text
+feature/issue-458-r3-contract-annotation-native-tests
+```
+
+Branch status:
+
+```text
+already existed and was already checked out
+```
+
+---
+
+## Phase Scope
+
+TEST phase only.
+
+Production files were not changed. Documentation was not updated beyond this test handoff.
+
+---
+
+## Files Changed
+
+- `tests/unit/test_interpreter_test_mode.py`
+- `.genia/process/tmp/handoffs/issue-458-r3-contract-annotation-native-tests/03-test.md`
+
+---
+
+## Failing Tests Added
+
+Added focused failing tests for R3 annotation-native test discovery through the existing native test mode report surface:
+
+- annotated zero-argument function discovery and PASS result
+- annotated assertion failure reported as FAIL, not ERROR
+- annotated unexpected runtime error reported as ERROR
+- mixed legacy `test(name, body)` and annotated tests in deterministic order
+- annotated parameterized function reported as discovery ERROR
+- lifecycle non-goal guardrail proving an ordinary unannotated `setup()` function is not treated as a lifecycle hook
+
+The tests use existing prefix annotation syntax:
+
+```genia
+@test "description"
+passes() = assert_true(true)
+```
+
+This avoids adding parser syntax in the TEST phase.
+
+---
+
+## Test Command
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_interpreter_test_mode.py -v
+```
+
+Result:
+
+```text
+6 failed, 9 passed
+```
+
+Expected failure cause:
+
+```text
+Error: Unsupported annotation: @test. Supported annotations: @doc, @meta, @since, @deprecated, @category
+```
+
+Representative failing tests:
+
+```text
+FAILED tests/unit/test_interpreter_test_mode.py::test_test_mode_discovers_annotated_zero_arg_function
+FAILED tests/unit/test_interpreter_test_mode.py::test_test_mode_reports_annotated_assertion_failure_as_failure
+FAILED tests/unit/test_interpreter_test_mode.py::test_test_mode_reports_annotated_runtime_error_as_error
+FAILED tests/unit/test_interpreter_test_mode.py::test_test_mode_runs_legacy_and_annotated_tests_in_deterministic_order
+FAILED tests/unit/test_interpreter_test_mode.py::test_test_mode_reports_annotated_parameterized_function_as_discovery_error
+FAILED tests/unit/test_interpreter_test_mode.py::test_test_mode_does_not_treat_unannotated_setup_as_lifecycle_hook
+```
+
+---
+
+## Next Phase
+
+Implementation phase should make `@test` annotation metadata discoverable by native test mode, validate annotated functions before execution, feed valid annotated tests into the existing native test kernel, and preserve current `test(name, body)` behavior.

--- a/.genia/process/tmp/handoffs/issue-458-r3-contract-annotation-native-tests/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-458-r3-contract-annotation-native-tests/04-implementation.md
@@ -1,0 +1,155 @@
+# Genia IMPLEMENTATION - Issue #458
+
+CHANGE NAME: issue #458 r3-contract-annotation-native-tests
+CHANGE SLUG: issue-458-r3-contract-annotation-native-tests
+TYPE: feature
+ISSUE: 458
+BRANCH: feature/issue-458-r3-contract-annotation-native-tests
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-458-r3-contract-annotation-native-tests/`
+
+---
+
+## Branch
+
+Starting branch:
+
+```text
+feature/issue-458-r3-contract-annotation-native-tests
+```
+
+Working branch:
+
+```text
+feature/issue-458-r3-contract-annotation-native-tests
+```
+
+Branch status:
+
+```text
+already correct
+```
+
+---
+
+## Files Changed
+
+- `src/genia/evaluator.py`
+- `src/genia/test_cli.py`
+- `src/genia/test_kernel.py`
+- `.genia/process/tmp/handoffs/issue-458-r3-contract-annotation-native-tests/04-implementation.md`
+
+---
+
+## Implementation Summary
+
+- Added `@test` to the existing string annotation metadata path so annotated bindings keep `"test"` metadata instead of failing as unsupported annotations.
+- Extended native test discovery to append `@test` annotated function groups after existing `test(name, body)` registrations.
+- Valid annotated zero-argument functions are adapted into existing `TestUnit` values with the function name as the test name.
+- Malformed annotated declarations are represented as existing native-test discovery errors.
+- `run_native_tests_from_file` now uses the shared discovery helper after source evaluation, so `--test` sees both legacy and annotated tests.
+
+---
+
+## Scope Confirmation
+
+Lifecycle behavior was not added.
+
+No setup, teardown, before, after, fixture, module lifecycle, parameterized-test, parallel-runner, or R4 lifecycle behavior was introduced.
+
+Legacy `test(name, body)` behavior remains supported and continues to run through the existing native test kernel.
+
+---
+
+## Commands Run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_interpreter_test_mode.py -v
+```
+
+Result:
+
+```text
+15 passed
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py -v
+```
+
+Result:
+
+```text
+26 passed
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v
+```
+
+Result:
+
+```text
+6 passed
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py -v
+```
+
+Result:
+
+```text
+6 passed
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py
+```
+
+Result:
+
+```text
+85 passed
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run ruff check src/genia/evaluator.py src/genia/test_cli.py src/genia/test_kernel.py tests/unit/test_interpreter_test_mode.py
+```
+
+Result:
+
+```text
+Failed: ruff was not installed in the uv environment.
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff check src/genia/evaluator.py src/genia/test_cli.py src/genia/test_kernel.py tests/unit/test_interpreter_test_mode.py
+```
+
+Result:
+
+```text
+Failed under sandbox network restrictions while fetching ruff from PyPI.
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff check src/genia/evaluator.py src/genia/test_cli.py src/genia/test_kernel.py tests/unit/test_interpreter_test_mode.py
+```
+
+Result after approved network access:
+
+```text
+All checks passed.
+```
+
+---
+
+## Unexpected Findings
+
+- The first focused run after accepting `@test` metadata still returned empty suites because `--test` was running the pre-evaluation legacy registration list directly. The fix was to route `--test` through the existing `discover_test_units(env)` helper after evaluation.
+
+---
+
+## Next Recommended Phase
+
+DOC SYNC

--- a/GENIA_REPL_README.md
+++ b/GENIA_REPL_README.md
@@ -62,7 +62,7 @@ CLI contract summary (actual behavior):
 - command mode: `genia -c 'source' [args ...]`
 - pipe mode: `genia -p 'stage_expr' [args ...]` runs the stage expression over `stdin |> lines`, then consumes the final Flow automatically
 - REPL mode: `genia`
-- native test mode: `genia test path/to/test_file.genia` (minimal entry point) or legacy `genia --test path/to/test_file.genia` (Experimental, Python reference host; see `GENIA_STATE.md` section 9.2)
+- native test mode: `genia test path/to/test_file.genia` (minimal entry point) or legacy `genia --test path/to/test_file.genia` (Experimental, Python reference host; see `GENIA_STATE.md` section 9.2); native tests may be authored with legacy `test(name, body)` or as `@test "description"` annotated zero-argument functions; annotated tests are discovered only in native test mode
 - file/command dispatch: call `main(argv())` when `main/1` exists, otherwise call `main()` when `main/0` exists
 - pipe mode bypasses `main`
 - trailing args are exposed through `argv()` as plain strings (including option-like values)

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -129,6 +129,7 @@ Required constraints:
   - `@since`
   - `@deprecated`
   - `@category`
+  - `@test`
 - no annotation introduces macros, compile-time transforms, or syntax rewriting in this phase
 
 ## 8.1.2) Prefix annotation runtime semantics
@@ -155,13 +156,20 @@ Required constraints:
   - evaluates its value expression after the target binding exists
   - the resulting value must be a string
   - stores metadata under key `"category"`
+- `@test`:
+  - evaluates its value expression after the target binding exists
+  - the resulting value must be a string
+  - stores metadata under key `"test"`
+  - marks the annotated zero-argument function for native test discovery in native test mode
+  - has no effect on language evaluation behavior outside native test mode
+  - annotated functions with one or more parameters are a discovery error, not an evaluation error
 - multiple annotations merge from top to bottom
 - last annotation wins for duplicate metadata keys
 - rebinding without annotations preserves existing binding metadata
 - rebinding with annotations merges new metadata over existing metadata for that binding
 - `doc("name")` returns the current doc string for a bound name or `none("missing-doc", {name: ...})`
 - `meta("name")` returns the current metadata map for a bound name
-- unsupported annotations must fail clearly at runtime
+- annotations not in the supported list above must fail clearly at runtime
 - annotation metadata is ordinary runtime metadata only in this phase:
   - no macros
   - no compile-time transforms

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -707,6 +707,7 @@ Pipeline (Phase 2) evaluation model:
     - `@since "0.4"` -> stores `{"since": "0.4"}`
     - `@deprecated "message"` -> stores `{"deprecated": "message"}`
     - `@category "name"` -> stores `{"category": "name"}`
+    - `@test "description"` -> stores `{"test": "description"}`; marks the annotated zero-argument function for native test discovery in native test mode
   - annotation metadata attaches to the binding name for top-level functions and top-level assignments
   - unannotated rebinding preserves existing metadata on that binding
   - annotated rebinding merges new metadata over existing metadata, with the last annotation winning for duplicate keys
@@ -714,6 +715,7 @@ Pipeline (Phase 2) evaluation model:
   - `meta("name")` returns the metadata map or `none("missing-meta", {name: ...})` for undefined names
   - `help("name")` prefers `@doc` metadata text over legacy function docstrings and also shows selected metadata fields such as category/since/deprecated
   - no macros, compile-time transforms, or annotation-driven evaluator rewrites are implemented
+  - `@test` annotations are discovered by the native test runner; `@test` does not execute by itself and does not affect language evaluation behavior outside native test mode; see section 9.2
 - resolution behavior:
   - exact fixed arity beats varargs
   - if multiple varargs candidates match and neither is more specific, runtime raises `TypeError("Ambiguous function resolution")`
@@ -2243,7 +2245,7 @@ The current native test stack uses four layers:
 
 - **Kernel** (`src/genia/test_kernel.py`): executes already-formed `TestUnit` values and normalizes their outcomes. The kernel distinguishes passing tests, assertion/native-test failures (`NativeTestFailure`), unexpected runtime errors, and malformed/discovery-invalid test units. The kernel does not discover tests, load files, format CLI output, or own process exit codes.
 - **Runner** (`src/genia/native_test_runner.py`): coordinates file/suite-level native test execution for `genia test <file>` by invoking the kernel and aggregating results. The runner does not define assertion semantics or change language runtime behavior.
-- **CLI/test-mode layer** (`src/genia/test_cli.py`): selects the `--test` entry point, loads/evaluates the file in test mode, registers tests through the `test(name, body)` mechanism, formats output via `format_test_suite_report`, and returns process exit codes via `suite_exit_code`. The CLI layer does not own kernel outcome normalization or provide broad discovery or lifecycle support.
+- **CLI/test-mode layer** (`src/genia/test_cli.py`): selects the `--test` entry point, loads/evaluates the file in test mode, registers tests through the `test(name, body)` mechanism, appends `@test` annotated zero-argument functions discovered by `discover_test_units(env)` after evaluation, formats output via `format_test_suite_report`, and returns process exit codes via `suite_exit_code`. The CLI layer does not own kernel outcome normalization or provide broad discovery or lifecycle support.
 - **Assertion helpers** (`src/genia/builtins.py`): `assert_true` and `assert_eq` make passing assertions return `none` (the implemented success value) and make failing assertions raise `NativeTestFailure`, which the kernel reports as a `fail` result rather than an unexpected `error`.
 
 Current native test behavior distinguishes:
@@ -2253,7 +2255,7 @@ Current native test behavior distinguishes:
 - `error`: an unexpected exception occurs during execution (phase `"evaluation"`);
 - discovery error: the test unit has an invalid name or non-callable body (phase `"discovery"`).
 
-Current native test support is not a complete test framework; lifecycle hooks, setup/teardown annotations, fixtures, parameterized tests, broad directory discovery, and multi-host conformance are out of scope in this phase.
+Current native test support is not a complete test framework; lifecycle hooks, `@setup`/`@teardown` annotations, setup/teardown, fixtures, parameterized tests, broad directory discovery, and multi-host conformance are out of scope in this phase.
 
 ## 9.1) Native test kernel core (Python reference host, Experimental)
 
@@ -2282,7 +2284,7 @@ Not implemented in this phase:
 - shared spec-runner integration
 - host adapter for Genia runtime callables
 - parser/lexer/evaluator/Core IR changes
-- broad assertion framework, lifecycle hooks, annotations, or fixtures; only the minimal helpers `assert_true` and `assert_eq` are implemented
+- broad assertion framework, lifecycle hooks, lifecycle annotations (such as `@setup`/`@teardown`), or fixtures; only the minimal helpers `assert_true` and `assert_eq` are implemented; `@test` annotation discovery is handled by the CLI/test-mode layer, not the kernel
 - stdout/stderr capture (fields are present but always empty strings)
 - multi-host test execution
 
@@ -2324,9 +2326,11 @@ A Genia-native fixture now covers the R1 validated pipeline path. Validated by `
 
 Status: Experimental, Python reference host.
 
-`genia --test <file>` runs native test units registered through the test-mode-only `test(name, body)` helper and reports the existing normalized native test runner outcomes. The CLI prints suite counts before and after per-result lines, reports `PASS`, `FAIL`, and `ERROR` results, and exits `0` when no failures/errors occur, `1` when failures or normalized test errors occur, and `2` for invalid CLI invocation.
+`genia --test <file>` runs native test units registered through the test-mode-only `test(name, body)` helper and `@test` annotated zero-argument functions discovered after evaluation, and reports the existing normalized native test runner outcomes. The CLI prints suite counts before and after per-result lines, reports `PASS`, `FAIL`, and `ERROR` results, and exits `0` when no failures/errors occur, `1` when failures or normalized test errors occur, and `2` for invalid CLI invocation.
 
-`genia test <file>` is a minimal native test runner entry point over the same Python reference-host native test kernel. It validates and parses the file, discovers test units through the existing test-mode-only `test(name, body)` registration path, runs the discovered units through the native test kernel, prints one `[PASS|FAIL|ERROR] <name>` line per result followed by `Summary: total=<t> passed=<p> failed=<f> errors=<e>`, and exits `0` when all discovered tests pass, `1` when any test fails/errors, and `2` for file, parse, or no-tests errors.
+`genia test <file>` is a minimal native test runner entry point over the same Python reference-host native test kernel. It validates and parses the file, discovers test units through the existing test-mode-only `test(name, body)` registration path and appends `@test` annotated zero-argument functions discovered after evaluation, runs the discovered units through the native test kernel, prints one `[PASS|FAIL|ERROR] <name>` line per result followed by `Summary: total=<t> passed=<p> failed=<f> errors=<e>`, and exits `0` when all discovered tests pass, `1` when any test fails/errors, and `2` for file, parse, or no-tests errors.
+
+Native tests may be authored with the legacy `test(name, body)` call form. Native tests may also be authored as `@test "description"` annotated zero-argument functions. The `@test "description"` annotation carries the human-readable description; the function name is the test identifier. Annotated native tests are discovered only in native test mode. `@test` marks functions for discovery; it does not execute by itself. Annotated tests use the same native test kernel as legacy tests. Assertion failures are `FAIL`; unexpected runtime exceptions are `ERROR`; malformed annotated tests such as parameterized annotated functions are discovery `ERROR`. Lifecycle hooks are not implemented. Setup/teardown, fixtures, parameterized tests, filtering, parallel native tests, and broad lifecycle semantics are not implemented.
 
 PYTHON REFERENCE HOST:
 - Implemented as `src/genia/test_cli.py` in the Python reference host.
@@ -2336,9 +2340,9 @@ PYTHON REFERENCE HOST:
 - Invalid combinations such as `--debug-stdio --test` are rejected with exit code `2`.
 - Report format: a summary line `total=<t> passed=<p> failed=<f> errored=<e>` appears both before and after per-result lines.
 - Per-result lines: `PASS <name>`, `FAIL <name> phase=<phase> reason=<reason>` (with `expected=<expected> actual=<actual>` when present), `ERROR <name-or-unnamed> phase=<phase> reason=<reason>`.
-- Validated by `tests/unit/test_native_test_cli.py` (6 tests) and `tests/unit/test_interpreter_test_mode.py` (9 tests), Python reference host only.
+- Validated by `tests/unit/test_native_test_cli.py` (6 tests) and `tests/unit/test_interpreter_test_mode.py` (15 tests), Python reference host only.
 
-This does not add test annotations, setup/teardown lifecycle hooks, filtering, parallel execution, JSON/JUnit/TAP output, or multi-host test execution.
+`@test "description"` annotation-driven native test discovery is implemented; annotated zero-argument functions are discovered after legacy `test(name, body)` registrations and run through the same native test kernel. This does not add setup/teardown lifecycle hooks, `@setup` or `@teardown` annotations, filtering, parallel execution, JSON/JUnit/TAP output, or multi-host test execution.
 
 ## 10) Explicitly not implemented (current)
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ printf '1\n2\n3\n' | genia -c 'stdin |> lines |> map(parse_int) |> keep_some |> 
   - `genia` -> REPL mode
   - `genia test path/to/test_file.genia` -> minimal native test runner entry point (Experimental, Python reference host)
   - `genia --test path/to/test_file.genia` -> legacy native test mode (Experimental, Python reference host)
+  - native tests may be authored with legacy `test(name, body)` or as `@test "description"` annotated zero-argument functions; annotated tests are discovered only in native test mode
 
 ### Choose `-p` vs `-c`
 

--- a/docs/contract/semantic_facts.json
+++ b/docs/contract/semantic_facts.json
@@ -14,5 +14,6 @@
   "naming_rule": "new `?`-suffixed APIs are boolean-returning; `get?` remains the current compatibility exception.",
   "annotation_builtins": "`@doc`, `@meta`, `@since`, `@deprecated`, and `@category`",
   "canonical_format_field_path_separator": "Dot (`.`) is the canonical field-path separator for representation/format placeholders; slash (`/`) is not the format field-path separator and remains limited to existing slash operator/Core IR wording.",
-  "canonical_named_access_separator": "Dot (`.`) is the canonical named-access separator; legacy slash named access has been removed and is not general field-path lookup."
+  "canonical_named_access_separator": "Dot (`.`) is the canonical named-access separator; legacy slash named access has been removed and is not general field-path lookup.",
+  "native_test_annotation_discovery": "`@test \"description\"` annotates zero-argument functions for native test discovery; discovery runs after legacy `test(name, body)` registrations."
 }

--- a/docs/strategy/release-roadmap.md
+++ b/docs/strategy/release-roadmap.md
@@ -127,26 +127,26 @@ Theme:
 
 > Grow native test coverage over Genia-facing behavior without touching parser/IR/host internals.
 
-Desired test syntax:
+Implemented annotation-driven test syntax (issue #458):
 
 ```genia
-@test("basic math works")
+@test "basic math works"
 test1() = assert_eq(1+1, 2)
 ```
 
-R2 currently uses the implemented `test(name, body)` call form. R3 plans to adopt the annotation + named-function style as the preferred authoring shape after it is separately contracted, tested, implemented, and reflected in `GENIA_STATE.md`. The planned annotation carries the human-readable description; the function name is intended for identification and filtering.
+R2 introduced the `test(name, body)` call form. R3 adds `@test "description"` annotation-driven native test discovery (issue #458): `@test` annotated zero-argument functions are discovered after legacy `test(name, body)` registrations and run through the same native test kernel. The annotation carries the human-readable description; the function name is the test identifier.
 
 Primary outcomes:
 
+- `@test "description"` annotation-driven native test discovery is implemented (issue #458). ✓ done
 - Validation helpers are covered by native tests.
 - Outcome constructors and rendering behavior are tested at the Genia level.
 - JSONL helper behavior is exercised by native tests.
 - One or two pipeline examples demonstrate native tests on real workflow behavior.
-- Planned preferred tests are authored in the `@test("description") / name() = body` form only after that surface exists.
 
 Includes:
 
-- planned `@test("description")` annotation + named-function syntax work
+- `@test "description"` annotation + named-function discovery (issue #458) ✓ implemented
 - native tests for validation helpers
 - native tests for Outcome constructors and rendering
 - native tests for JSONL helper behavior
@@ -163,7 +163,7 @@ Excludes:
 
 Exit criteria:
 
-- Native tests use the `@test("description") / name() = body` syntax after that syntax is implemented and documented as current behavior.
+- Native tests use the `@test "description" / name() = body` form for annotation-driven discovery. The annotation syntax is implemented and documented as current behavior (issue #458). ✓ done
 - Native tests cover validation helpers, Outcome constructors/rendering, and JSONL helper behavior.
 - At least one pipeline example is backed by a native test.
 - No parser, IR, or host internals are touched.

--- a/src/genia/evaluator.py
+++ b/src/genia/evaluator.py
@@ -650,7 +650,7 @@ class Evaluator:
                 continue
             raise RuntimeError(
                 "Unsupported annotation: "
-                f"@{annotation.name}. Supported annotations: @doc, @meta, @since, @deprecated, @category"
+                f"@{annotation.name}. Supported annotations: @doc, @meta, @since, @deprecated, @category, @test"
             )
         return metadata
 

--- a/src/genia/evaluator.py
+++ b/src/genia/evaluator.py
@@ -633,6 +633,7 @@ class Evaluator:
             "since": "since",
             "deprecated": "deprecated",
             "category": "category",
+            "test": "test",
         }
         for annotation in annotations:
             value = self.eval(annotation.value)

--- a/src/genia/test_cli.py
+++ b/src/genia/test_cli.py
@@ -5,10 +5,11 @@ from pathlib import Path
 from typing import Any
 
 from .builtins import make_global_env
+from .callable import GeniaFunctionGroup
 from .errors import GeniaQuietBrokenPipe
 from .test_kernel import TestUnit, run_test_suite, suite_exit_code
 from .utf8 import format_debug
-from .values import GeniaOutputSink
+from .values import GeniaMap, GeniaOutputSink
 
 
 def _summary_line(suite: dict[str, Any]) -> str:
@@ -73,7 +74,39 @@ def make_test_env() -> tuple[Any, list[TestUnit]]:
 
 
 def discover_test_units(env: Any) -> list[TestUnit]:
-    return list(getattr(env, "_native_test_units", []))
+    return [
+        *list(getattr(env, "_native_test_units", [])),
+        *discover_annotated_test_units(env),
+    ]
+
+
+def discover_annotated_test_units(env: Any) -> list[TestUnit]:
+    test_units: list[TestUnit] = []
+    for name, value in env.values.items():
+        metadata = env.binding_metadata.get(name)
+        if not _is_test_metadata(metadata):
+            continue
+        if not isinstance(value, GeniaFunctionGroup):
+            test_units.append(_discovery_error_test_unit(name, "@test must annotate a function"))
+            continue
+        description = metadata.get("test")
+        if not isinstance(description, str) or description == "":
+            test_units.append(_discovery_error_test_unit(name, "@test description must be a non-empty string"))
+            continue
+        body = value.get(0)
+        if body is None or value.sorted_arities() != [0]:
+            test_units.append(_discovery_error_test_unit(name, "@test functions must take zero arguments"))
+            continue
+        test_units.append(TestUnit(name, body, metadata={"description": description}))
+    return test_units
+
+
+def _is_test_metadata(metadata: Any) -> bool:
+    return isinstance(metadata, GeniaMap) and metadata.has("test")
+
+
+def _discovery_error_test_unit(name: str, reason: str) -> TestUnit:
+    return TestUnit(name, None, metadata={"discovery_error": reason})
 
 
 def _write_stdout(env: Any, text: str) -> None:
@@ -99,13 +132,14 @@ def _write_stderr(env: Any, message: str) -> None:
 
 
 def run_native_tests_from_file(program_path: str) -> int:
-    env, tests = make_test_env()
+    env, _ = make_test_env()
     try:
         path = Path(program_path)
         source = path.read_text(encoding="utf-8")
         from .interpreter import run_source
 
         run_source(source, env, filename=str(path.resolve()))
+        tests = discover_test_units(env)
         suite = run_test_suite(tests)
         _write_stdout(env, format_test_suite_report(suite))
         return suite_exit_code(suite)

--- a/src/genia/test_kernel.py
+++ b/src/genia/test_kernel.py
@@ -60,6 +60,12 @@ def run_test_unit(test_unit: TestUnit) -> dict[str, Any]:
     if not isinstance(getattr(test_unit, "name", None), str) or test_unit.name == "":
         return _discovery_error(test_unit, "test unit name must be a non-empty string")
 
+    discovery_error = getattr(test_unit, "discovery_error", None)
+    if discovery_error is None and isinstance(getattr(test_unit, "metadata", None), dict):
+        discovery_error = test_unit.metadata.get("discovery_error")
+    if discovery_error is not None:
+        return _discovery_error(test_unit, str(discovery_error))
+
     body = getattr(test_unit, "body", None)
     if not callable(body):
         return _discovery_error(test_unit, "test unit body must be callable")

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -53,6 +53,7 @@ def test_semantic_facts_file_stays_small_and_complete() -> None:
         "host_status",
         "naming_rule",
         "annotation_builtins",
+        "native_test_annotation_discovery",
         CANONICAL_FIELD_PATH_SEPARATOR_FACT,
         CANONICAL_NAMED_ACCESS_SEPARATOR_FACT,
     }
@@ -1053,9 +1054,9 @@ def test_r3_native_test_roadmap_stays_separate_from_r4_lifecycle_generalization(
     assert "test(name, body)" in state, (
         "GENIA_STATE.md must preserve the current native-test registration path"
     )
-    assert "This does not add test annotations" in state, (
-        "GENIA_STATE.md must not imply R3 annotation syntax is implemented"
+    assert "annotation-driven native test discovery is implemented" in state, (
+        "GENIA_STATE.md must document @test annotation-driven native test discovery"
     )
-    assert "lifecycle hooks, annotations, or fixtures" in state, (
-        "GENIA_STATE.md must keep native-test lifecycle/annotation limits visible"
+    assert "setup/teardown lifecycle hooks" in state, (
+        "GENIA_STATE.md must keep lifecycle non-goals visible"
     )

--- a/tests/unit/test_interpreter_test_mode.py
+++ b/tests/unit/test_interpreter_test_mode.py
@@ -102,6 +102,135 @@ def test_test_mode_reports_discovery_error_for_non_callable_body(tmp_path, capsy
     assert captured.err == ""
 
 
+def test_test_mode_discovers_annotated_zero_arg_function(tmp_path, capsys):
+    program = tmp_path / "annotated_passing_test.genia"
+    program.write_text(
+        '@test "passes through annotation discovery"\n'
+        "passes() = assert_true(true)\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "total=1 passed=1 failed=0 errored=0\n"
+        "PASS passes\n"
+        "total=1 passed=1 failed=0 errored=0\n"
+    )
+    assert captured.err == ""
+
+
+def test_test_mode_reports_annotated_assertion_failure_as_failure(tmp_path, capsys):
+    program = tmp_path / "annotated_failing_test.genia"
+    program.write_text(
+        '@test "assertion failures stay failures"\n'
+        "fails() = assert_eq(1, 2)\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "total=1 passed=0 failed=1 errored=0\n" in captured.out
+    assert "FAIL fails phase=evaluation reason=assert_eq failed" in captured.out
+    assert "ERROR fails" not in captured.out
+    assert captured.err == ""
+
+
+def test_test_mode_reports_annotated_runtime_error_as_error(tmp_path, capsys):
+    program = tmp_path / "annotated_erroring_test.genia"
+    program.write_text(
+        '@test "runtime errors stay errors"\n'
+        "errors() = missing_name\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "total=1 passed=0 failed=0 errored=1\n" in captured.out
+    assert "ERROR errors phase=evaluation reason=Undefined name: missing_name" in captured.out
+    assert "FAIL errors" not in captured.out
+    assert captured.err == ""
+
+
+def test_test_mode_runs_legacy_and_annotated_tests_in_deterministic_order(
+    tmp_path,
+    capsys,
+):
+    program = tmp_path / "mixed_native_tests.genia"
+    program.write_text(
+        'test("legacy registration", () -> assert_true(true))\n'
+        '@test "annotation registration"\n'
+        "annotated() = assert_eq(2 + 2, 4)\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "total=2 passed=2 failed=0 errored=0\n"
+        "PASS legacy registration\n"
+        "PASS annotated\n"
+        "total=2 passed=2 failed=0 errored=0\n"
+    )
+    assert captured.err == ""
+
+
+def test_test_mode_reports_annotated_parameterized_function_as_discovery_error(
+    tmp_path,
+    capsys,
+):
+    program = tmp_path / "annotated_parameterized_test.genia"
+    program.write_text(
+        '@test "parameterized tests are unsupported"\n'
+        "with_param(x) = assert_true(x)\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "total=1 passed=0 failed=0 errored=1\n" in captured.out
+    assert (
+        "ERROR with_param phase=discovery reason=@test functions must take zero arguments"
+        in captured.out
+    )
+    assert captured.err == ""
+
+
+def test_test_mode_does_not_treat_unannotated_setup_as_lifecycle_hook(
+    tmp_path,
+    capsys,
+):
+    program = tmp_path / "no_lifecycle_hooks.genia"
+    program.write_text(
+        "setup() = missing_name\n"
+        '@test "ordinary annotated test still passes"\n'
+        "passes() = assert_true(true)\n",
+        encoding="utf-8",
+    )
+
+    exit_code = _main(["--test", str(program)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "total=1 passed=1 failed=0 errored=0\n"
+        "PASS passes\n"
+        "total=1 passed=1 failed=0 errored=0\n"
+    )
+    assert "setup" not in captured.out
+    assert captured.err == ""
+
+
 def test_test_mode_runs_empty_suite_successfully(tmp_path, capsys):
     program = tmp_path / "empty_test.genia"
     program.write_text("none\n", encoding="utf-8")


### PR DESCRIPTION
close #458 

Audit is done and **issue #458 is ready to merge**.

Current branch state from the audit report:

* Working tree clean
* Commits on branch:

  * `73c46f9` test coverage
  * `0f831cb` implementation
  * `9dbe345` doc sync
  * `e0573be` audit fix
* Validation passed:

  * `132` pytest tests
  * `428` spec cases
* Verdict: **READY TO MERGE** 

Next likely step is **PR description**.

Use this:

````md
## Summary

Implements R3 annotation-native test discovery for issue #458.

Native tests can now be authored as `@test "description"` annotated zero-argument functions. Annotated tests are discovered after legacy `test(name, body)` registrations and run through the existing native test kernel.

This preserves existing native-test behavior while adding the preferred R3 authoring shape.

## Changes

- Added `@test` as supported annotation metadata.
- Added annotated native-test discovery.
- Appended annotated tests after legacy `test(name, body)` registrations.
- Used function names as native test names.
- Preserved existing PASS / FAIL / ERROR / discovery ERROR semantics.
- Added failing-first coverage for annotated discovery, FAIL vs ERROR classification, mixed ordering, malformed parameterized tests, and lifecycle non-goals.
- Updated docs to describe the implemented `@test "description"` syntax and avoid claiming lifecycle/setup/teardown behavior.
- Fixed an audit truth issue where the unsupported-annotation error message omitted `@test`.

## Scope Guardrails

This does **not** add:

- setup / teardown
- fixtures
- parameterized tests
- filtering
- parallel native test execution
- general lifecycle behavior
- `@setup` / `@teardown`
- parser or IR redesign
- multi-host native-test conformance

## Validation

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py
````

Result: `85 passed`

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_interpreter_test_mode.py tests/unit/test_native_test_runner.py tests/unit/test_native_test_cli.py -v
```

Result: `47 passed`

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run python -m tools.spec_runner
```

Result: `428 passed`

After audit fix:

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_interpreter_test_mode.py tests/unit/test_native_test_runner.py tests/unit/test_native_test_cli.py tests/doc/test_semantic_doc_sync.py
```

Result: `132 passed`

## Commits

* `73c46f9` test(native-tests): add failing @test discovery coverage issue #458
* `0f831cb` feat(native-tests): discover @test annotated functions issue #458
* `9dbe345` docs(native-tests): document @test discovery issue #458
* `e0573be` audit(native-tests): fix @test discovery truth issue #458

```

Tiny victory lap permitted. No lifecycle gremlins escaped the enclosure.
```
