### PR TITLE
Feature/issue 464 r3 native tests validation helpers

### DIFF
--- a/.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/03-test.md
+++ b/.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/03-test.md
@@ -1,0 +1,70 @@
+# Genia TEST — Issue #464
+
+CHANGE NAME: issue #464 r3-native-tests-validation-helpers  
+CHANGE SLUG: issue-464-r3-native-tests-validation-helpers  
+ISSUE: 464  
+BRANCH: feature/issue-464-r3-native-tests-validation-helpers  
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/`
+
+## Branch
+
+- Starting branch: `feature/issue-464-r3-native-tests-validation-helpers`
+- Working branch: `feature/issue-464-r3-native-tests-validation-helpers`
+- Branch existed before this TEST phase: YES
+
+## Files Changed
+
+- `tests/native/r3_validation_helpers.genia`
+- `tests/unit/test_r3_validation_helpers_native_tests.py`
+- `.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/03-test.md`
+
+## Test Fixture
+
+- `tests/native/r3_validation_helpers.genia`
+
+## Pytest Wrapper
+
+- `tests/unit/test_r3_validation_helpers_native_tests.py`
+
+## Scope Confirmation
+
+- TEST phase only.
+- No production implementation files changed.
+- No parser, evaluator, Core IR, CLI, native test runner, or validation-helper runtime files changed.
+- No source-of-truth docs changed.
+
+## Commands Run
+
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validation_helpers_native_tests.py -v`
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validation_helpers_native_tests.py -v -s`
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run python -c $'from genia.native_test_runner import run_native_tests\ncode = run_native_tests("tests/native/r3_validation_helpers.genia")\nprint("EXIT", code)'`
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run python -c $'from pathlib import Path\nfrom genia.native_test_runner import _parse_file, _identify_tests\nfrom genia.test_kernel import run_test_suite\npath="tests/native/r3_validation_helpers.genia"\nsource=Path(path).read_text()\ndecls, err = _parse_file(source, path)\nassert err is None, err\nunits = _identify_tests(decls)\nsummary = run_test_suite(units)\nfor outcome in summary["results"]:\n    print(outcome["name"], outcome["kind"], outcome["phase"], repr(outcome["reason"]), "expected=", repr(outcome["expected"]), "actual=", repr(outcome["actual"]))'`
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r1_validated_pipeline_native_tests.py -v`
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py -v`
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v`
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py -v`
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_validate_each.py tests/unit/test_validate_record.py tests/unit/test_validate_optional.py -v`
+
+## Observed Output
+
+- Initial focused wrapper runs failed while calibrating the fixture to current runtime behavior:
+  - first run: `1 failed`, native output showed five `ERROR` outcomes from invalid fixture assumptions (`outcome("kind")` access and `none(map)` construction)
+  - second run: `1 failed`, low-level outcome inspection showed two remaining fixture errors around unwrapping `nth(...)` results
+- Final focused wrapper:
+  - `tests/unit/test_r3_validation_helpers_native_tests.py`: `1 passed`
+- Related suites:
+  - `tests/unit/test_r1_validated_pipeline_native_tests.py`: `1 passed`
+  - `tests/unit/test_native_test_runner.py`: `26 passed`
+  - `tests/unit/test_native_test_cli.py`: `6 passed`
+  - `tests/unit/test_native_test_kernel.py`: `6 passed`
+  - `tests/unit/test_validate_each.py tests/unit/test_validate_record.py tests/unit/test_validate_optional.py`: `51 passed`
+
+## Expected Failure Status
+
+- No expected implementation failure remains.
+- The new native fixture passes immediately after adjusting illustrative design assertions to current runtime-supported access patterns.
+- No production behavior was changed.
+
+## Failing-Test Commit
+
+- None. No failing-test commit was created because the selected behavior is already implemented and the focused wrapper passes.

--- a/.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/04-implementation.md
@@ -1,0 +1,92 @@
+# Genia Implementation — Issue #464
+
+CHANGE NAME: issue #464 r3-native-tests-validation-helpers
+CHANGE SLUG: issue-464-r3-native-tests-validation-helpers
+TYPE: feature
+ISSUE: 464
+BRANCH: feature/issue-464-r3-native-tests-validation-helpers
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/`
+
+---
+
+## Branch
+
+- Starting branch: `feature/issue-464-r3-native-tests-validation-helpers`
+- Working branch: `feature/issue-464-r3-native-tests-validation-helpers`
+- Branch existed before this IMPLEMENTATION phase: YES
+
+---
+
+## Implementation Decision
+
+- Implementation required: NO
+- Reason: Selected issue #464 behavior already exists. The TEST phase passed after fixture calibration to current runtime-supported access patterns. No production behavior gap was identified.
+- Failing-test commit SHA: none
+- TEST-phase commit: `f161faecb89a6ecbefb9ff1a46ac5ebcf4e8ef1f`
+- Production files changed: none
+
+---
+
+## Implementation Summary
+
+No-op. The selected validation-helper behavior covered by issue #464 is already implemented in the Python reference host. The Genia-native fixture (`tests/native/r3_validation_helpers.genia`) passes without any changes to:
+
+- parser
+- lexer
+- evaluator
+- Core IR
+- CLI
+- native test runner
+- validation helpers
+- host adapters
+
+No new validation helper APIs, Outcome behavior, or native-test lifecycle behavior was added.
+
+---
+
+## Validation Commands Run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validation_helpers_native_tests.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r1_validated_pipeline_native_tests.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_validate_each.py tests/unit/test_validate_record.py tests/unit/test_validate_optional.py -v
+```
+
+---
+
+## Validation Results Observed
+
+| Command | Result |
+|---|---|
+| `test_r3_validation_helpers_native_tests.py` | 1 passed |
+| `test_r1_validated_pipeline_native_tests.py` | 1 passed |
+| `test_native_test_runner.py` | 26 passed |
+| `test_native_test_cli.py` | 6 passed |
+| `test_native_test_kernel.py` | 6 passed |
+| `test_validate_each.py test_validate_record.py test_validate_optional.py` | 51 passed |
+
+All validation commands passed. No failures or errors.
+
+---
+
+## Confirmation
+
+- No runtime/source files were changed in this IMPLEMENTATION phase.
+- No production implementation changes were made.
+- The working tree was clean before and after this phase.
+- `git status` confirmed: nothing to commit, working tree clean.
+
+---
+
+## Files Changed
+
+- `.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/04-implementation.md` (this file)
+
+---
+
+## Next Recommended Phase
+
+DOCS phase — if any source-of-truth documentation needs updating to record the added native-test coverage for validation helpers. If no public behavior changed and `GENIA_STATE.md` already describes the covered behavior accurately, the docs phase may also be a no-op or limited to noting the new native fixture in GENIA_STATE.md under the relevant validation-helper coverage section.

--- a/.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/06-doc-sync.md
+++ b/.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/06-doc-sync.md
@@ -1,0 +1,85 @@
+# Genia Doc Sync — Issue #464
+
+CHANGE NAME: issue #464 r3-native-tests-validation-helpers
+CHANGE SLUG: issue-464-r3-native-tests-validation-helpers
+ISSUE: 464
+BRANCH: feature/issue-464-r3-native-tests-validation-helpers
+
+---
+
+## Branch
+
+- Starting branch: `feature/issue-464-r3-native-tests-validation-helpers`
+- Working branch: `feature/issue-464-r3-native-tests-validation-helpers`
+- Branch existed before this DOC SYNC phase: YES
+
+---
+
+## Phase Commits
+
+- TEST-phase commit SHA: `f161faecb89a6ecbefb9ff1a46ac5ebcf4e8ef1f`
+- IMPLEMENTATION-phase commit SHA: `7863016`
+
+---
+
+## Docs Decision
+
+**Option B: Tiny docs update.**
+
+`GENIA_STATE.md` already records R1 validated-pipeline and Outcome native fixture coverage at lines 2324–2326. The R3 validation helpers fixture (issue #464) is analogous and should be noted consistently.
+
+The existing pattern calls for a single-sentence note per fixture that identifies the fixture file, the pytest wrapper, the scope of coverage, and a maturity/limitation caveat.
+
+No change to `docs/contract/semantic_facts.json` was needed: the protected facts cover pipeline/flow/host semantics, not fixture inventory. The doc sync tests confirmed no drift.
+
+---
+
+## Files Changed
+
+- `GENIA_STATE.md` — added one paragraph after the Outcome native fixture note recording the R3 validation helpers native fixture.
+- `.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/06-doc-sync.md` — this file.
+
+---
+
+## GENIA_STATE.md Change Summary
+
+Added after the Outcome fixture note:
+
+> A Genia-native fixture covers selected validation-helper behavior for the R3 validated-pipeline surface, including required/field/optional/record validation, `validate_each` Outcome-boundary behavior, and `collect_validated` aggregation. Validated by `tests/unit/test_r3_validation_helpers_native_tests.py` (1 test, Python reference host only); the fixture is `tests/native/r3_validation_helpers.genia`. This is selected native coverage only and does not change validation, Outcome, Flow, or native-test semantics.
+
+---
+
+## Validation Commands Run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validation_helpers_native_tests.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r1_validated_pipeline_native_tests.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py -v
+```
+
+---
+
+## Validation Results Observed
+
+| Command | Result |
+|---|---|
+| `test_r3_validation_helpers_native_tests.py` | 1 passed |
+| `test_r1_validated_pipeline_native_tests.py` | 1 passed |
+| `test_semantic_doc_sync.py` | 85 passed |
+
+All validation commands passed. No failures or errors.
+
+---
+
+## Confirmation
+
+- No production/runtime files were changed in this DOC SYNC phase.
+- No parser, lexer, evaluator, Core IR, CLI, native test runner, validation helpers, or host adapters were changed.
+- No new validation helper APIs, Outcome behavior, or native-test lifecycle behavior was added.
+- Only `GENIA_STATE.md` (one paragraph added) and this handoff file changed.
+
+---
+
+## Next Recommended Phase
+
+AUDIT phase — verify truth alignment of all phase artifacts against `GENIA_STATE.md`.

--- a/.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/07-audit.md
+++ b/.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/07-audit.md
@@ -1,0 +1,201 @@
+# Genia Audit — Issue #464
+
+CHANGE NAME: issue #464 r3-native-tests-validation-helpers
+CHANGE SLUG: issue-464-r3-native-tests-validation-helpers
+TYPE: feature
+ISSUE: 464
+BRANCH: feature/issue-464-r3-native-tests-validation-helpers
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/`
+
+---
+
+## Branch
+
+- Starting branch: `feature/issue-464-r3-native-tests-validation-helpers`
+- Working branch: `feature/issue-464-r3-native-tests-validation-helpers`
+- Branch was pre-existing (not newly created in this phase)
+
+---
+
+## Commits Audited
+
+| SHA | Phase | Message |
+|---|---|---|
+| `f161faecb89a6ecbefb9ff1a46ac5ebcf4e8ef1f` | TEST | `test(native-tests): cover validation helpers issue #464` |
+| `78630165d814215eb4c0567f8cdee1f7996ddb9b` | IMPLEMENTATION | `feat(native-tests): record no-op implementation issue #464` |
+| `a09201b135659b1e58e4488f50c39c9e2338ffbe` | DOC SYNC | `docs(native-tests): note validation helper native coverage issue #464` |
+
+---
+
+## Files Changed (branch vs main)
+
+```
+.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/03-test.md         (new)
+.genia/process/tmp/handoffs/issue-464-r3-native-tests-validation-helpers/04-implementation.md  (new)
+GENIA_STATE.md                                                                                (+2 lines)
+tests/native/r3_validation_helpers.genia                                                      (new)
+tests/unit/test_r3_validation_helpers_native_tests.py                                         (new)
+```
+
+Total: 5 files changed, 301 insertions.
+
+---
+
+## Audit Verdict
+
+**PASS WITH ISSUES**
+
+The implementation is correct and passes all validation. One process trail issue is noted: `06-doc-sync.md` was written but never committed because `.genia/process/tmp` is gitignored. This is resolved by including `06-doc-sync.md` in the audit commit. See the handoff tracking note below.
+
+---
+
+## Contract vs Implementation/Test Result
+
+**PASS.**
+
+The contract (01-contract.md) defines behavior for `validate_required`, `validate_field`, `validate_optional`, `validate_record`, `validate_each`, and `collect_validated`. The five native tests in `tests/native/r3_validation_helpers.genia` cover exactly these helpers:
+
+1. `validate_required` and `validate_field` — present/missing/valid/invalid outcomes.
+2. `validate_optional` — missing, present without validator, present with validator.
+3. `validate_record` — valid composition, invalid field, missing required field.
+4. `validate_each` — list order/length, upstream `none(...)` and `err(...)` preservation (validator not invoked), upstream `some(payload)` unwrapping before invocation.
+5. `collect_validated` — `{clean, diagnostics}` aggregation shape, kind/reason fields.
+
+Key contract invariants verified:
+
+- `validate_each` preserves upstream `none(...)` and `err(...)` without calling the validator — proven by the `must_not_run` helper, which would produce a test FAIL if invoked.
+- `validate_each` unwraps `some(payload)` before validator invocation.
+- `validate_each` does not aggregate; `collect_validated` aggregates.
+- Assertion failures are reported as `FAIL`, not `ERROR` — confirmed by existing suite `test_native_test_kernel.py` (6 passed).
+
+No contract surface is missed or overstated. The fixture does not invent new semantics.
+
+---
+
+## Design vs Implementation/Test Result
+
+**PASS.**
+
+The design (02-design.md) called for:
+
+- `tests/native/r3_validation_helpers.genia` — present and correct.
+- `tests/unit/test_r3_validation_helpers_native_tests.py` — present and correct.
+- No production changes — confirmed.
+- No docs changes beyond phase handoffs in TEST phase — confirmed.
+- Five native tests with the exact names specified in section 6 and section 8 — all five present; names match exactly; Python wrapper expected stdout matches design section 8.
+
+The design noted that illustrative assertions might need adjustment to current runtime behavior. The TEST phase correctly calibrated `display(...)` strings and outcome access patterns (using fixture-local `outcome_kind`/`outcome_reason` helpers instead of direct map-key access). This is expected and consistent with the design's mitigation guidance. It does not represent scope deviation.
+
+---
+
+## Implementation No-Op Claim
+
+**VERIFIED.**
+
+`04-implementation.md` claims no production files were changed. The git diff confirms this: only `03-test.md`, `04-implementation.md`, `GENIA_STATE.md`, `tests/native/r3_validation_helpers.genia`, and `tests/unit/test_r3_validation_helpers_native_tests.py` changed on the branch. No files under `src/genia/`, `hosts/`, or `spec/` were touched.
+
+---
+
+## Docs Sync Truthfulness Result
+
+**PASS.**
+
+`06-doc-sync.md` records that `GENIA_STATE.md` was updated with a one-paragraph note after the existing Outcome fixture note. The git diff confirms the paragraph was committed in `a09201b`:
+
+> A Genia-native fixture covers selected validation-helper behavior for the R3 validated-pipeline surface, including required/field/optional/record validation, `validate_each` Outcome-boundary behavior, and `collect_validated` aggregation. Validated by `tests/unit/test_r3_validation_helpers_native_tests.py` (1 test, Python reference host only); the fixture is `tests/native/r3_validation_helpers.genia`. This is selected native coverage only and does not change validation, Outcome, Flow, or native-test semantics.
+
+Wording assessment:
+
+- Does not claim complete coverage. ✓
+- Does not use banned certainty phrases. ✓
+- Correctly labels maturity as selected native coverage only. ✓
+- Correctly labels scope as Python reference host only. ✓
+- Does not redefine validation, Outcome, Flow, or native-test semantics. ✓
+- The "(1 test, Python reference host only)" correctly refers to the single Python pytest wrapper (which runs five Genia-native subtests internally). ✓
+
+`tests/doc/test_semantic_doc_sync.py` passed (85 tests), confirming no semantic fact drift was introduced.
+
+---
+
+## GENIA_STATE.md Wording
+
+**PASS.** The added paragraph is accurate, conservative, and consistent with surrounding Outcome/R1 coverage wording. No overclaiming detected.
+
+---
+
+## Production/Runtime Change Confirmation
+
+**No production or runtime files changed.**
+
+Verified unchanged: `src/genia/`, `hosts/`, `spec/`, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, `docs/book/`, `docs/cheatsheet/`, `docs/contract/semantic_facts.json`.
+
+Only `GENIA_STATE.md` (documentation) was updated, under the DOC SYNC phase.
+
+---
+
+## Scope Creep Check
+
+**None detected.**
+
+The branch adds exactly the files planned in the design: one Genia fixture, one Python wrapper, two phase handoffs, and one GENIA_STATE.md paragraph. No new validation helper APIs, Outcome behaviors, assertion helpers, Core IR nodes, parser changes, or native-test lifecycle features were introduced.
+
+---
+
+## Misleading Coverage Claims Check
+
+**None found.**
+
+`GENIA_STATE.md` says "selected native coverage only." `03-test.md` says "No expected implementation failure remains" and records no fabricated failing-test commit. `04-implementation.md` correctly identifies the implementation as a no-op. No file claims complete validation-helper coverage or full native-test framework support.
+
+---
+
+## Validation Commands Run and Results
+
+All commands run on `feature/issue-464-r3-native-tests-validation-helpers` during this audit phase:
+
+| Command | Result |
+|---|---|
+| `pytest -q tests/unit/test_r3_validation_helpers_native_tests.py -v` | **1 passed** |
+| `pytest -q tests/unit/test_r1_validated_pipeline_native_tests.py -v` | **1 passed** |
+| `pytest -q tests/unit/test_native_test_runner.py -v` | **26 passed** |
+| `pytest -q tests/unit/test_native_test_cli.py -v` | **6 passed** |
+| `pytest -q tests/unit/test_native_test_kernel.py -v` | **6 passed** |
+| `pytest -q tests/unit/test_validate_each.py tests/unit/test_validate_record.py tests/unit/test_validate_optional.py -v` | **51 passed** |
+| `pytest -q tests/doc/test_semantic_doc_sync.py -v` | **85 passed** |
+
+All commands clean. No failures or errors.
+
+---
+
+## Handoff File Tracking Note
+
+**Issue: `06-doc-sync.md` was written but not committed.**
+
+`.genia/process/tmp` is gitignored, so `06-doc-sync.md` exists on disk but was absent from the git log before this audit. The file was read and verified during this audit — its content is accurate and matches the `GENIA_STATE.md` change committed in `a09201b`.
+
+**Decision: include `06-doc-sync.md` in the audit commit for trail consistency.**
+
+Rationale: other phase handoffs (`03-test.md`, `04-implementation.md`) were force-added. Leaving `06-doc-sync.md` uncommitted creates an inconsistent trail where the DOC SYNC phase has no committed artifact despite making a tracked change (`GENIA_STATE.md`).
+
+`06-doc-sync.md` was written during the DOC SYNC phase and committed retroactively during the AUDIT phase for trail completeness — not as a correction to its content.
+
+---
+
+## Blocking Issues
+
+**None.**
+
+---
+
+## Recommended Follow-Up
+
+None required for correctness. Optional future work (separate issues):
+
+- Expand native fixture to cover programmer misuse error cases (`non-callable validator`, `non-Outcome validator result`) if a native mechanism for expected runtime errors is added to the test surface.
+- Add Flow-input native coverage for `validate_each` once a clean native flow fixture pattern is established.
+
+---
+
+## Next Recommended Phase
+
+**DISTILLATION** — if process artifacts or doc changes require cleanup or summary after merge. Otherwise this branch is ready for PR/merge review.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2325,6 +2325,8 @@ A Genia-native fixture now covers the R1 validated pipeline path. Validated by `
 
 A Genia-native fixture now covers selected Outcome constructor, representation, predicate, and structured absence inspection behavior. Validated by `tests/unit/test_outcome_native_tests.py` (6 tests, Python reference host only); the fixture is `tests/native/outcome_rendering.genia`. The fixture uses `@test` annotated zero-argument functions and `assert_eq` to cover selected current behavior for `some(...)`, `none(...)`, `err(...)`, `display(...)`, `debug_repr(...)`, `some?`, `none?`, `absence_reason`, and `absence_context`. This is selected native coverage only; it does not change Outcome semantics or native-test report semantics.
 
+A Genia-native fixture covers selected validation-helper behavior for the R3 validated-pipeline surface, including required/field/optional/record validation, `validate_each` Outcome-boundary behavior, and `collect_validated` aggregation. Validated by `tests/unit/test_r3_validation_helpers_native_tests.py` (1 test, Python reference host only); the fixture is `tests/native/r3_validation_helpers.genia`. This is selected native coverage only and does not change validation, Outcome, Flow, or native-test semantics.
+
 ## 9.2) Native test CLI (Python reference host, Experimental)
 
 Status: Experimental, Python reference host.

--- a/tests/native/r3_validation_helpers.genia
+++ b/tests/native/r3_validation_helpers.genia
@@ -1,0 +1,116 @@
+valid_person(record) =
+  validate_record(record, {
+    id: (r) -> validate_field("id", (x) -> x > 0, "positive id", r),
+    name: (r) -> validate_required("name", r)
+  })
+
+outcome_kind(result) =
+  some(_) -> "some" |
+  none(_) -> "skipped" |
+  err(_) -> "error"
+
+outcome_reason(result) =
+  none(reason) -> reason |
+  err(reason) -> reason
+
+optional_absence_reason(result) =
+  none(reason) -> reason("reason")
+
+validated_value(result) =
+  some(value) -> value |
+  _ -> {}
+
+outcome_at(items, index) =
+  unwrap_or(none, items |> nth(index))
+
+validated_value_at(items, index) =
+  validated_value(outcome_at(items, index))
+
+map_at(items, index) =
+  unwrap_or({}, items |> nth(index))
+
+must_not_run(_value) =
+  assert_eq("validator should not run", "validator ran")
+
+test("validate_required and validate_field return current outcomes", () -> {
+  present = validate_required("name", {name: "Ada"})
+  missing = validate_required("name", {id: 1})
+  valid_id = validate_field("id", (x) -> x > 0, "positive id", {id: 1})
+  invalid_id = validate_field("id", (x) -> x > 0, "positive id", {id: 0})
+
+  assert_eq(display(present), "some({name: Ada})")
+  assert_eq(outcome_kind(missing), "error")
+  assert_eq(display(outcome_reason(missing)), "missing required field")
+  assert_eq(display(valid_id), "some({id: 1})")
+  assert_eq(outcome_kind(invalid_id), "error")
+  assert_eq(display(outcome_reason(invalid_id)), "invalid field")
+})
+
+test("validate_optional handles missing and present fields", () -> {
+  missing = validate_optional("nickname", {name: "Ada"})
+  present = validate_optional("nickname", {nickname: "ace"})
+  checked = validate_optional("nickname", {nickname: "ace"}, (value) -> some(value))
+
+  assert_eq(outcome_kind(missing), "skipped")
+  assert_eq(display(optional_absence_reason(missing)), "missing_optional_field")
+  assert_eq(display(present), "some(ace, {field: nickname})")
+  assert_eq(display(checked), "some(ace)")
+})
+
+test("validate_record composes field validators", () -> {
+  valid = valid_person({id: 1, name: "Ada"})
+  invalid = valid_person({id: 0, name: "Bad"})
+  missing = valid_person({id: 2})
+
+  assert_eq(display(valid), "some({id: 1, name: Ada})")
+  assert_eq(outcome_kind(invalid), "error")
+  assert_eq(display(outcome_reason(invalid)), "record_validation_failed")
+  assert_eq(outcome_kind(missing), "error")
+  assert_eq(display(outcome_reason(missing)), "record_validation_failed")
+})
+
+test("validate_each preserves list order and outcome boundaries", () -> {
+  plain_results = validate_each(
+    [{id: 1, name: "Ada"}, {id: 0, name: "Bad"}, {id: 2, name: "Grace"}],
+    valid_person
+  )
+
+  upstream_missing = validate_each([none("skip")], must_not_run)
+  upstream_error = validate_each([err(quote(bad_record), {row: 7})], must_not_run)
+  upstream_some = validate_each([some({id: 3, name: "Lin"})], valid_person)
+
+  assert_eq(count(plain_results), 3)
+  assert_eq(display(validated_value_at(plain_results, 0)), "{id: 1, name: Ada}")
+  assert_eq(display(outcome_reason(outcome_at(plain_results, 1))), "record_validation_failed")
+  assert_eq(display(validated_value_at(plain_results, 2)), "{id: 2, name: Grace}")
+
+  assert_eq(count(upstream_missing), 1)
+  assert_eq(outcome_kind(outcome_at(upstream_missing, 0)), "skipped")
+  assert_eq(display(outcome_reason(outcome_at(upstream_missing, 0))), "skip")
+
+  assert_eq(count(upstream_error), 1)
+  assert_eq(outcome_kind(outcome_at(upstream_error, 0)), "error")
+  assert_eq(display(outcome_reason(outcome_at(upstream_error, 0))), "bad_record")
+
+  assert_eq(count(upstream_some), 1)
+  assert_eq(display(validated_value_at(upstream_some, 0)), "{id: 3, name: Lin}")
+})
+
+test("collect_validated aggregates clean records and diagnostics", () -> {
+  outcomes = [
+    some({id: 1, name: "Ada"}),
+    none("blank_line"),
+    err(quote(record_validation_failed), {row: 3}),
+    some({id: 2, name: "Grace"})
+  ]
+
+  result = collect_validated(outcomes)
+  diagnostics = result("diagnostics")
+
+  assert_eq(display(result("clean")), "[{id: 1, name: Ada}, {id: 2, name: Grace}]")
+  assert_eq(count(diagnostics), 2)
+  assert_eq(display(map_at(diagnostics, 0)("kind")), "skipped")
+  assert_eq(display(map_at(diagnostics, 0)("reason")), "blank_line")
+  assert_eq(display(map_at(diagnostics, 1)("kind")), "error")
+  assert_eq(display(map_at(diagnostics, 1)("reason")), "record_validation_failed")
+})

--- a/tests/unit/test_r3_validation_helpers_native_tests.py
+++ b/tests/unit/test_r3_validation_helpers_native_tests.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from genia.native_test_runner import run_native_tests
+
+
+def test_r3_validation_helpers_native_tests_pass(capsys):
+    fixture = Path("tests/native/r3_validation_helpers.genia")
+
+    exit_code = run_native_tests(str(fixture))
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "[PASS] validate_required and validate_field return current outcomes\n"
+        "[PASS] validate_optional handles missing and present fields\n"
+        "[PASS] validate_record composes field validators\n"
+        "[PASS] validate_each preserves list order and outcome boundaries\n"
+        "[PASS] collect_validated aggregates clean records and diagnostics\n"
+        "Summary: total=5 passed=5 failed=0 errors=0\n"
+    )
+    assert captured.err == ""


### PR DESCRIPTION
close #464
## Summary

Adds selected Genia-native test coverage for R3 validation-helper behavior.

This PR adds a focused native fixture for validation helpers used by the validated-pipeline surface, plus a Python wrapper that runs the fixture through the existing native test runner.

Covered behavior includes:

* `validate_required`
* `validate_field`
* `validate_optional`
* `validate_record`
* `validate_each` list order and Outcome-boundary preservation
* `collect_validated` aggregation

This is coverage only. The selected behavior already existed, so the implementation phase was a no-op.

## Files Changed

* `tests/native/r3_validation_helpers.genia`
* `tests/unit/test_r3_validation_helpers_native_tests.py`
* `GENIA_STATE.md`
* issue #464 handoff/audit files under `.genia/process/tmp/handoffs/...`

## Validation

Ran and passed:

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validation_helpers_native_tests.py -v
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r1_validated_pipeline_native_tests.py -v
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py -v
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py -v
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_validate_each.py tests/unit/test_validate_record.py tests/unit/test_validate_optional.py -v
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py -v
```

Results:

* `test_r3_validation_helpers_native_tests.py`: 1 passed
* `test_r1_validated_pipeline_native_tests.py`: 1 passed
* `test_native_test_runner.py`: 26 passed
* `test_native_test_cli.py`: 6 passed
* `test_native_test_kernel.py`: 6 passed
* validation helper unit tests: 51 passed
* semantic doc sync: 85 passed

## Notes

* No production/runtime behavior changed.
* No parser, lexer, evaluator, Core IR, CLI, validation-helper implementation, native test runner, or host adapter changes.
* `GENIA_STATE.md` now records the selected R3 validation-helper native fixture coverage.
* Audit verdict: PASS WITH ISSUES. The only issue was process-trail hygiene: `06-doc-sync.md` had been written but not committed because `.genia/process/tmp` is ignored. It was committed retroactively with the audit handoff for trail consistency.

Closes #464.
