### PR TITLE
Feature/issue 465 r3 native tests validated pipeline examples

### DIFF
--- a/.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/03-failing-tests.md
+++ b/.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/03-failing-tests.md
@@ -1,0 +1,53 @@
+# Genia TEST / Failing Tests - Issue #465
+
+CHANGE NAME: issue #465 r3-native-tests-validated-pipeline-examples  
+CHANGE SLUG: issue-465-r3-native-tests-validated-pipeline-examples  
+TYPE: feature  
+ISSUE: 465  
+BRANCH: feature/issue-465-r3-native-tests-validated-pipeline-examples
+
+## Scope tested
+
+Added failing Python test coverage for the planned R3 native-test validated-pipeline example file:
+
+```text
+examples/r3_validated_pipeline_native_tests.genia
+```
+
+The focused test expects the future example to run through the existing native-test runner and report three passing native tests that prove:
+
+- upstream `some(...)`, `none(...)`, and `err(...)` Outcome boundaries stay observable;
+- `validate_each(...)` output feeds `collect_validated(...)` directly;
+- a small JSONL-style validated pipeline keeps clean records and diagnostics visible through the native-test report path.
+
+## Files changed
+
+- `tests/unit/test_r3_validated_pipeline_native_test_examples.py`
+- `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/03-failing-tests.md`
+
+## Commands run
+
+```bash
+uv run pytest -q tests/unit/test_r3_validated_pipeline_native_test_examples.py -v
+```
+
+## Failing output summary
+
+The focused test fails before implementation as intended:
+
+```text
+tests/unit/test_r3_validated_pipeline_native_test_examples.py F          [100%]
+E       assert 2 == 0
+FAILED tests/unit/test_r3_validated_pipeline_native_test_examples.py::test_r3_validated_pipeline_native_test_examples_pass
+1 failed
+```
+
+The failure is narrow: the test expects native-test execution of `examples/r3_validated_pipeline_native_tests.genia` to exit `0`, but current execution exits `2` before the example exists.
+
+## Failing-test commit SHA
+
+Final SHA is reported after the commit is created. The SHA cannot be embedded in this same committed file without changing the commit identity.
+
+## Implementation note
+
+No implementation changes were made. No `.genia` example file, runtime behavior, parser behavior, validation helper behavior, docs, or CLI/native-test runner behavior was changed in this TEST phase.

--- a/.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/04-implementation.md
@@ -1,0 +1,68 @@
+# Genia IMPLEMENTATION - Issue #465
+
+CHANGE NAME: issue #465 r3-native-tests-validated-pipeline-examples
+CHANGE SLUG: issue-465-r3-native-tests-validated-pipeline-examples
+TYPE: feature
+ISSUE: 465
+BRANCH: feature/issue-465-r3-native-tests-validated-pipeline-examples
+
+## Phase
+
+IMPLEMENTATION ONLY
+
+## Failing-test commit SHA
+
+```text
+19c197a6a37394b14efbbc73299117841bdbaf55
+```
+
+## Branches
+
+- Starting branch: `feature/issue-465-r3-native-tests-validated-pipeline-examples`
+- Working branch: `feature/issue-465-r3-native-tests-validated-pipeline-examples`
+- Branch status: already existed
+
+## Files changed
+
+- `examples/r3_validated_pipeline_native_tests.genia`
+- `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/04-implementation.md`
+
+## Implementation summary
+
+Added `examples/r3_validated_pipeline_native_tests.genia`, a runnable native-test example file using existing `test(name, body)` syntax, current assertion helpers, and current validation/Outcome helpers only.
+
+The example contains three native tests matching the TEST-phase harness:
+
+- `validated pipeline preserves upstream Outcome boundaries`
+- `validate_each feeds collect_validated directly`
+- `validated JSONL pipeline keeps clean records and diagnostics observable`
+
+No parser, runtime, validation helper, assertion helper, native-test framework, CLI, docs, lifecycle, actor, browser, or playground behavior was changed.
+
+## Commands run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validated_pipeline_native_test_examples.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validation_helpers_native_tests.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r1_validated_pipeline_native_tests.py -v
+```
+
+## Validation results
+
+- `tests/unit/test_r3_validated_pipeline_native_test_examples.py`: 1 passed
+- `tests/unit/test_r3_validation_helpers_native_tests.py`: 1 passed
+- `tests/unit/test_native_test_runner.py`: 26 passed
+- `tests/unit/test_native_test_cli.py`: 6 passed
+- `tests/unit/test_native_test_kernel.py`: 6 passed
+- `tests/unit/test_r1_validated_pipeline_native_tests.py`: 1 passed
+
+## Implementation commit SHA
+
+Final SHA is reported after the commit is created. The SHA cannot be embedded in this same committed file without changing the commit identity.
+
+## Phase boundary
+
+Docs sync and audit were not performed in this phase. Stop after the implementation commit.

--- a/.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/05-doc-sync.md
+++ b/.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/05-doc-sync.md
@@ -1,0 +1,92 @@
+# Genia DOC SYNC — Issue #465
+
+CHANGE NAME: issue #465 r3-native-tests-validated-pipeline-examples
+CHANGE SLUG: issue-465-r3-native-tests-validated-pipeline-examples
+TYPE: feature
+ISSUE: 465
+BRANCH: feature/issue-465-r3-native-tests-validated-pipeline-examples
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/`
+
+---
+
+## Phase
+
+DOC SYNC ONLY
+
+---
+
+## Failing-test commit SHA
+
+```
+19c197a6a37394b14efbbc73299117841bdbaf55
+```
+
+## Implementation commit SHA
+
+```
+5b9b2ed0f387b115a4d00f2ed36f88d78c2475e1
+```
+
+---
+
+## Branches
+
+- Starting branch: `feature/issue-465-r3-native-tests-validated-pipeline-examples`
+- Working branch: `feature/issue-465-r3-native-tests-validated-pipeline-examples`
+- Branch status: already existed
+
+---
+
+## Files changed
+
+- `GENIA_STATE.md`
+- `README.md`
+- `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/05-doc-sync.md`
+
+---
+
+## Documentation updates made
+
+### GENIA_STATE.md
+
+1. **Native-test fixtures section (after existing R3 validation-helpers fixture paragraph)**: Added a new paragraph recording that `examples/r3_validated_pipeline_native_tests.genia` is a runnable native-test example for the R3 validated-pipeline surface, validated by `tests/unit/test_r3_validated_pipeline_native_test_examples.py`. The paragraph covers: Outcome-boundary preservation through `validate_each`, direct `validate_each(...) |> collect_validated(...)` composition, and JSONL-style pipeline observability. Maturity wording: selected native coverage only; does not imply complete validated-pipeline coverage or new language/runtime/CLI/lifecycle behavior.
+
+2. **Section 11 (Example demos shipped in-repo)**: Added a bullet entry for `examples/r3_validated_pipeline_native_tests.genia` after the `validated_pipeline_demo.genia` entry. The entry classifies it as an R3 native-test example, runnable through the native test runner, using existing `test(name, body)` syntax and existing validation/Outcome helpers. Explicitly labeled as selected coverage only, not complete validated-pipeline coverage; Experimental.
+
+### README.md
+
+Updated the examples listing line to include `r3_validated_pipeline_native_tests.genia` (described as a native-test example for the validated-pipeline surface) alongside the existing demo list.
+
+---
+
+## Explicit statement: implementation behavior not changed
+
+No implementation behavior was changed in this phase. No parser, runtime, validation helper, assertion helper, native-test framework, CLI, lifecycle, actor, browser, or playground behavior was modified. Only documentation was updated to reflect the example file added in the implementation commit.
+
+---
+
+## Commands run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validated_pipeline_native_test_examples.py -v
+```
+
+---
+
+## Validation results
+
+- `tests/doc/test_semantic_doc_sync.py`: **85 passed**
+- `tests/unit/test_r3_validated_pipeline_native_test_examples.py`: **1 passed**
+
+---
+
+## Docs-sync commit SHA
+
+Final SHA is reported after the commit is created. The SHA cannot be embedded in this same committed file without changing the commit identity.
+
+---
+
+## Note
+
+Audit and PR work were not performed in this phase. This handoff stops after the docs-sync commit as required.

--- a/.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/06-audit.md
+++ b/.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/06-audit.md
@@ -1,0 +1,192 @@
+# Genia AUDIT — Issue #465
+
+CHANGE NAME: issue #465 r3-native-tests-validated-pipeline-examples
+CHANGE SLUG: issue-465-r3-native-tests-validated-pipeline-examples
+TYPE: feature
+ISSUE: 465
+BRANCH: feature/issue-465-r3-native-tests-validated-pipeline-examples
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/`
+
+---
+
+## Phase
+
+AUDIT / TRUTH REVIEW
+
+---
+
+## Commit SHAs
+
+- Failing-test commit SHA: `19c197a6a37394b14efbbc73299117841bdbaf55`
+- Implementation commit SHA: `5b9b2ed0f387b115a4d00f2ed36f88d78c2475e1`
+- Docs-sync commit SHA: `35f577bec477ce91964a805558173bc7965b40c4`
+
+---
+
+## Branches
+
+- Starting branch: `feature/issue-465-r3-native-tests-validated-pipeline-examples`
+- Working branch: `feature/issue-465-r3-native-tests-validated-pipeline-examples`
+- Branch status: already existed; not main
+
+---
+
+## Files Reviewed
+
+- `AGENTS.md`
+- `GENIA_STATE.md`
+- `GENIA_RULES.md`
+- `GENIA_REPL_README.md`
+- `README.md`
+- `docs/process/06-audit.md`
+- `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/01-contract.md`
+- `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/02-design.md`
+- `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/03-failing-tests.md`
+- `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/04-implementation.md`
+- `.genia/process/tmp/handoffs/issue-465-r3-native-tests-validated-pipeline-examples/05-doc-sync.md`
+- `examples/r3_validated_pipeline_native_tests.genia`
+- `tests/unit/test_r3_validated_pipeline_native_test_examples.py`
+- `GENIA_STATE.md` lines 2320–2380 (native-test fixtures and example demos sections)
+- `README.md` line 35 (examples listing)
+
+---
+
+## Checks Performed
+
+### 1. Spec / Contract vs Implementation
+
+- Contract (01-contract.md) requires: at least one deterministic validated-pipeline example executable through the native test runner, using only implemented Genia syntax, native-test forms, assertion helpers, and validation helpers. **VERIFIED.**
+- Implementation provides exactly three native tests in `examples/r3_validated_pipeline_native_tests.genia` using `test(name, body)`, `assert_eq`, `validate_each`, `collect_validated`, `validate_record`, `validate_field`, `validate_required`, `parse_jsonl_record`. All are currently implemented helpers.
+- No parser, Core IR, Flow, Seq, Sheet, Outcome, lifecycle, actor, browser, or playground behavior was changed. **VERIFIED.**
+- No new assertion-helper families or validation DSL were introduced. **VERIFIED.**
+
+### 2. Design vs Implementation
+
+- Design (02-design.md) specifies: `examples/r3_validated_pipeline_native_tests.genia` + `tests/unit/test_r3_validated_pipeline_native_test_examples.py` + minimal docs updates. **VERIFIED.**
+- Chosen native-test form: `test(name, body)`. **VERIFIED** — consistent with design recommendation and current repo truth.
+- File choices match exactly. No architectural drift, extra abstraction, or extraneous files introduced. **VERIFIED.**
+- Docs updated in `GENIA_STATE.md` and `README.md` only, as designed. **VERIFIED.**
+
+### 3. TDD Order (failing test before implementation)
+
+- Failing-test commit `19c197a` contains ONLY:
+  - `tests/unit/test_r3_validated_pipeline_native_test_examples.py`
+  - `03-failing-tests.md` (handoff)
+- Implementation commit `5b9b2ed` contains ONLY:
+  - `examples/r3_validated_pipeline_native_tests.genia`
+  - `04-implementation.md` (handoff)
+- Failing-test commit predates implementation commit chronologically and by SHA order. **VERIFIED — TDD order preserved.**
+
+### 4. Test Validity
+
+- Python test `test_r3_validated_pipeline_native_test_examples_pass` asserts:
+  - `exit_code == 0`
+  - exact `stdout` with three `[PASS]` lines and summary
+  - `stderr == ""`
+- Before implementation: test fails with exit code 2 (file not found). **VERIFIED** per 03-failing-tests.md.
+- After implementation: test passes (1 passed). **VERIFIED** by running pytest.
+- The three Genia native tests contain meaningful, non-vague assertions:
+  - Exact `display(...)` string comparisons against expected rendered values
+  - `count(...)` checks for list/diagnostic lengths
+  - `outcome_kind(...)` structural checks for `some`/`none`/`err`
+  - `outcome_reason(...)` reason extraction with string comparison
+- Tests prove three PASS lines as intended. **VERIFIED.**
+- No false-confidence risks identified: `map_at` with out-of-bounds access returns `{}`, which would fail the subsequent key-access assertions in the right direction.
+
+### 5. Truthfulness Review
+
+- `GENIA_STATE.md` addition (line 2330) explicitly states: "This is selected native coverage only; it does not imply complete validated-pipeline coverage, advanced Flow behavior beyond what is already stated above, or new language/runtime/CLI/lifecycle behavior." **VERIFIED — no overbroad claims.**
+- `GENIA_STATE.md` example demos section (line 2371) states: "this is selected native coverage only, not complete validated-pipeline coverage; Experimental." **VERIFIED.**
+- `README.md` (line 35) says "a native-test example for the validated-pipeline surface" — accurately scoped. **VERIFIED.**
+- No "all examples", "complete coverage", "fully aligned", or "no drift" phrases found. **VERIFIED.**
+- No implication of future lifecycle, setup/teardown, actor, browser, playground, Sheet, or value-template behavior. **VERIFIED.**
+
+### 6. Cross-File Consistency
+
+- `GENIA_STATE.md` references correct file names and test file. **VERIFIED.**
+- `README.md` example listing updated consistently. **VERIFIED.**
+- Semantic doc sync tests pass (85 passed). **VERIFIED.**
+- No stale references or mismatch between README and GENIA_STATE found. **VERIFIED.**
+
+### 7. Philosophy / Complexity
+
+- Change is minimal: 1 example file + 1 Python test + 2 small doc additions. **VERIFIED.**
+- Strengthens Outcome-aware validated data pipeline direction directly. **VERIFIED.**
+- Example/test/doc coverage only — no new semantics introduced. **VERIFIED.**
+- No scope expansion: no parser, runtime, validation helper, assertion helper, CLI, lifecycle, actor, browser, or playground changes. **VERIFIED.**
+
+---
+
+## Validation Commands Run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validated_pipeline_native_test_examples.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r3_validation_helpers_native_tests.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_r1_validated_pipeline_native_tests.py -v
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py -v
+```
+
+---
+
+## Validation Results
+
+| Command | Result |
+|---|---|
+| `test_r3_validated_pipeline_native_test_examples.py` | 1 passed |
+| `test_r3_validation_helpers_native_tests.py` | 1 passed |
+| `test_native_test_runner.py` | 26 passed |
+| `test_native_test_cli.py` | 6 passed |
+| `test_native_test_kernel.py` | 6 passed |
+| `test_r1_validated_pipeline_native_tests.py` | 1 passed |
+| `test_semantic_doc_sync.py` | 85 passed |
+
+All commands returned 0 failures, 0 errors.
+
+---
+
+## Issues Found
+
+None.
+
+---
+
+## Recommended Fixes
+
+None. No issues were found.
+
+---
+
+## Follow-Up Issues Needed
+
+None identified from this audit. R4 lifecycle generalization remains out of scope for this change as required.
+
+---
+
+## Audit Verdict
+
+**PASS**
+
+The implementation matches the contract and design exactly. TDD order was preserved. The example is correctly scoped to existing `test(name, body)` syntax and existing validation/Outcome helpers. Docs are truthful and well-bounded. All validation tests pass. No scope expansion, no silent additions, no false claims, no overbroad language.
+
+---
+
+## Merge Readiness
+
+**READY TO MERGE.**
+
+The branch `feature/issue-465-r3-native-tests-validated-pipeline-examples` is ready for PR. Three commits are present on this branch ahead of main:
+
+1. `19c197a` — `test(native-tests): add failing validated pipeline examples issue #465`
+2. `5b9b2ed` — `feat(native-tests): add validated pipeline examples issue #465`
+3. `35f577b` — `docs(native-tests): sync validated pipeline examples issue #465`
+
+All tests pass. Docs are truthful. No unresolved issues.
+
+---
+
+## Audit Commit SHA
+
+Reported after commit is created. The SHA cannot be embedded in this same committed file without changing the commit identity.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2327,6 +2327,8 @@ A Genia-native fixture now covers selected Outcome constructor, representation, 
 
 A Genia-native fixture covers selected validation-helper behavior for the R3 validated-pipeline surface, including required/field/optional/record validation, `validate_each` Outcome-boundary behavior, and `collect_validated` aggregation. Validated by `tests/unit/test_r3_validation_helpers_native_tests.py` (1 test, Python reference host only); the fixture is `tests/native/r3_validation_helpers.genia`. This is selected native coverage only and does not change validation, Outcome, Flow, or native-test semantics.
 
+A runnable native-test example file is now available for the R3 validated-pipeline surface. The example is `examples/r3_validated_pipeline_native_tests.genia`, validated by `tests/unit/test_r3_validated_pipeline_native_test_examples.py` (1 test, Python reference host only). It covers Outcome-boundary preservation through `validate_each` (upstream `some(...)`, `none(...)`, and `err(...)` items pass through without invoking the validator), direct `validate_each(...) |> collect_validated(...)` composition, and a JSONL-style pipeline demonstrating clean/diagnostic observability. The example uses existing `test(name, body)` native-test authoring, existing validation helpers, and existing Outcome semantics only. This is selected native coverage only; it does not imply complete validated-pipeline coverage, advanced Flow behavior beyond what is already stated above, or new language/runtime/CLI/lifecycle behavior.
+
 ## 9.2) Native test CLI (Python reference host, Experimental)
 
 Status: Experimental, Python reference host.
@@ -2366,6 +2368,7 @@ PYTHON REFERENCE HOST:
 - `examples/ants_actor.genia`: actor/coordinator version of the ants simulation — same colony rules, different execution structure
 - `examples/ants_web.genia`: browser visualization over the same ants simulation using the current blocking HTTP helper, JSON endpoints, and a Canvas renderer in plain browser JavaScript
 - `examples/validated_pipeline_demo.genia`: experimental first demo milestone for the Outcome-aware validated data pipeline direction — a file-mode demo covered by shared CLI spec `spec/cli/validated-data-pipeline-demo.yaml`; reads JSONL records from `examples/data/validated_pipeline_demo.jsonl`, validates each record using existing `parse_jsonl_record`, `validate_each`, `validate_record`, and `collect_validated` helpers, and emits clean records plus diagnostics; demonstrates the intended Outcome-aware validated data pipeline direction; does not add new helper/runtime semantics; Experimental
+- `examples/r3_validated_pipeline_native_tests.genia`: R3 native-test example for the validated-pipeline surface — runnable through the native test runner (`genia test examples/r3_validated_pipeline_native_tests.genia`); covers Outcome-boundary preservation through `validate_each`, direct `validate_each(...) |> collect_validated(...)` composition, and a JSONL-style pipeline with clean/diagnostic observability; uses existing `test(name, body)` native-test syntax and existing validation/Outcome helpers; validated by `tests/unit/test_r3_validated_pipeline_native_test_examples.py`; this is selected native coverage only, not complete validated-pipeline coverage; Experimental
 
 `examples/ants.genia` intentionally uses only currently implemented features:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository currently provides:
   - bundled `.genia` prelude sources are loaded from package resources, so installed `genia` tools can use the same stdlib as repo execution
   - autoloaded function names can also be referenced as higher-order function values, not only called directly
 - debug-stdio adapter support for editor integration (**Python-host-only**)
-- runnable demos under `examples/` (including `tic-tac-toe.genia`, `ants.genia`, `ants_terminal.genia`, `ants_actor.genia`, `ants_web.genia`, `http_service.genia`, and `validated_pipeline_demo.genia`)
+- runnable demos under `examples/` (including `tic-tac-toe.genia`, `ants.genia`, `ants_terminal.genia`, `ants_actor.genia`, `ants_web.genia`, `http_service.genia`, `validated_pipeline_demo.genia`, and `r3_validated_pipeline_native_tests.genia` — a native-test example for the validated-pipeline surface)
 - proper tail-call optimization for calls in tail position
 - multi-host scaffolding docs/manifests under `docs/host-interop/`, `docs/architecture/`, `spec/`, `tools/spec_runner/`, and `hosts/`
 

--- a/examples/r3_validated_pipeline_native_tests.genia
+++ b/examples/r3_validated_pipeline_native_tests.genia
@@ -1,0 +1,105 @@
+valid_person(record) =
+  validate_record(record, {
+    id: (r) -> validate_field("id", (x) -> x > 0, "positive id", r),
+    name: (r) -> validate_required("name", r)
+  })
+
+classify_number(n) =
+  0 -> none("zero") |
+  _ ? n > 0 -> some(n) |
+  _ -> err(quote(negative_number), {value: n})
+
+outcome_kind(result) =
+  some(_) -> "some" |
+  none(_) -> "skipped" |
+  err(_) -> "error"
+
+outcome_reason(result) =
+  none(reason) -> reason |
+  err(reason) -> reason
+
+validated_value(result) =
+  some(value) -> value |
+  _ -> {}
+
+outcome_at(items, index) =
+  unwrap_or(none, items |> nth(index))
+
+validated_value_at(items, index) =
+  validated_value(outcome_at(items, index))
+
+map_at(items, index) =
+  unwrap_or({}, items |> nth(index))
+
+must_not_run(_value) =
+  assert_eq("validator should not run", "validator ran")
+
+test("validated pipeline preserves upstream Outcome boundaries", () -> {
+  results = validate_each([
+    some({id: 1, name: "Ada"}),
+    none("blank_line"),
+    err(quote(invalid_jsonl_record), {line: 3})
+  ], valid_person)
+
+  assert_eq(count(results), 3)
+  assert_eq(display(validated_value_at(results, 0)), "{id: 1, name: Ada}")
+  assert_eq(outcome_kind(outcome_at(results, 1)), "skipped")
+  assert_eq(display(outcome_reason(outcome_at(results, 1))), "blank_line")
+  assert_eq(outcome_kind(outcome_at(results, 2)), "error")
+  assert_eq(display(outcome_reason(outcome_at(results, 2))), "invalid_jsonl_record")
+
+  skipped = validate_each([none("skip")], must_not_run)
+  failed = validate_each([err(quote(bad_record), {row: 7})], must_not_run)
+
+  assert_eq(outcome_kind(outcome_at(skipped, 0)), "skipped")
+  assert_eq(display(outcome_reason(outcome_at(skipped, 0))), "skip")
+  assert_eq(outcome_kind(outcome_at(failed, 0)), "error")
+  assert_eq(display(outcome_reason(outcome_at(failed, 0))), "bad_record")
+})
+
+test("validate_each feeds collect_validated directly", () -> {
+  result =
+    validate_each([2, 0, -1, 3], classify_number)
+      |> collect_validated
+
+  diagnostics = result("diagnostics")
+  skipped = map_at(diagnostics, 0)
+  invalid = map_at(diagnostics, 1)
+
+  assert_eq(display(result("clean")), "[2, 3]")
+  assert_eq(count(diagnostics), 2)
+  assert_eq(display(skipped("kind")), "skipped")
+  assert_eq(display(skipped("reason")), "zero")
+  assert_eq(display(invalid("kind")), "error")
+  assert_eq(display(invalid("reason")), "negative_number")
+})
+
+test("validated JSONL pipeline keeps clean records and diagnostics observable", () -> {
+  lines = [
+    "{\"id\":1,\"name\":\"Ada\"}",
+    "",
+    "{\"id\":0,\"name\":\"Bad\"}",
+    "{\"id\":",
+    "{\"id\":2,\"name\":\"Grace\"}"
+  ]
+
+  result =
+    lines
+      |> map(parse_jsonl_record)
+      |> ((records) -> validate_each(records, valid_person))
+      |> collect_validated
+
+  diagnostics = result("diagnostics")
+  skipped = map_at(diagnostics, 0)
+  invalid = map_at(diagnostics, 1)
+  malformed = map_at(diagnostics, 2)
+
+  assert_eq(display(result("clean")), "[{id: 1, name: Ada}, {id: 2, name: Grace}]")
+  assert_eq(count(diagnostics), 3)
+  assert_eq(display(skipped("kind")), "skipped")
+  assert_eq(display(skipped("reason")), "blank_line")
+  assert_eq(display(invalid("kind")), "error")
+  assert_eq(display(invalid("reason")), "record_validation_failed")
+  assert_eq(display(malformed("kind")), "error")
+  assert_eq(display(malformed("reason")), "invalid_jsonl_record")
+})

--- a/tests/unit/test_r3_validated_pipeline_native_test_examples.py
+++ b/tests/unit/test_r3_validated_pipeline_native_test_examples.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from genia.native_test_runner import run_native_tests
+
+
+def test_r3_validated_pipeline_native_test_examples_pass(capsys):
+    fixture = Path("examples/r3_validated_pipeline_native_tests.genia")
+
+    exit_code = run_native_tests(str(fixture))
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == (
+        "[PASS] validated pipeline preserves upstream Outcome boundaries\n"
+        "[PASS] validate_each feeds collect_validated directly\n"
+        "[PASS] validated JSONL pipeline keeps clean records and diagnostics observable\n"
+        "Summary: total=3 passed=3 failed=0 errors=0\n"
+    )
+    assert captured.err == ""


### PR DESCRIPTION
Title: Add R3 native-test examples for validated pipelines
close #465 
## Summary

Adds runnable R3 native-test example coverage for the validated-pipeline surface.

This PR adds:

* `examples/r3_validated_pipeline_native_tests.genia`
* `tests/unit/test_r3_validated_pipeline_native_test_examples.py`
* truth-aligned docs updates in `GENIA_STATE.md` and `README.md`
* phase handoffs for failing tests, implementation, doc sync, and audit

The new example includes three native tests covering:

* Outcome-boundary preservation through `validate_each`
* direct `validate_each(...) |> collect_validated(...)` composition
* JSONL-style clean/diagnostic observability

The example uses existing `test(name, body)` native-test syntax, existing assertion helpers, and existing validation/Outcome helpers only.

## Scope

This is selected native-test example coverage only.

No parser, runtime, validation helper, assertion helper, CLI, lifecycle, actor, browser, playground, Flow, or Seq behavior changed.

## Validation

* `tests/unit/test_r3_validated_pipeline_native_test_examples.py`: 1 passed
* `tests/unit/test_r3_validation_helpers_native_tests.py`: 1 passed
* `tests/unit/test_native_test_runner.py`: 26 passed
* `tests/unit/test_native_test_cli.py`: 6 passed
* `tests/unit/test_native_test_kernel.py`: 6 passed
* `tests/unit/test_r1_validated_pipeline_native_tests.py`: 1 passed
* `tests/doc/test_semantic_doc_sync.py`: 85 passed

## Commits

* `19c197a` — failing test
* `5b9b2ed` — implementation
* `35f577b` — doc sync
* `630e72d` — audit

## Follow-ups

None required from audit.
