### PR TITLE
Feature/issue 480 r3 non string test metadata boundary

### DIFF
--- a/.genia/process/tmp/handoffs/issue-480-r3-non-string-test-metadata-boundary/03-test.md
+++ b/.genia/process/tmp/handoffs/issue-480-r3-non-string-test-metadata-boundary/03-test.md
@@ -1,0 +1,94 @@
+# Test — Issue #480: R3 Non-String Test Metadata Boundary
+
+## Branch
+
+- Starting branch: `feature/issue-480-r3-non-string-test-metadata-boundary`
+- Working branch: `feature/issue-480-r3-non-string-test-metadata-boundary`
+- Branch status: already existed; no branch creation or switch was needed in this phase
+
+## Selected Metadata Boundary Policy
+
+Policy A: string-only metadata.
+
+- Native test metadata keys must be strings.
+- Native test metadata values must be strings.
+- Composite metadata values such as lists and maps are invalid.
+- Invalid native test metadata must surface as deterministic discovery errors.
+- When a test unit location is available, invalid metadata diagnostics should include it.
+
+This is the smallest boundary that matches the current Genia direction: existing annotation metadata for `@test`, `@doc`, `@since`, `@deprecated`, and `@category` is string-valued, and current native-test metadata already uses string fields such as `description` and `discovery_error`.
+
+## Files Changed
+
+- `tests/unit/test_native_test_kernel.py`
+- `.genia/process/tmp/handoffs/issue-480-r3-non-string-test-metadata-boundary/03-test.md`
+
+## Tests Added
+
+- `test_valid_string_test_metadata_remains_accepted`
+- `test_non_string_metadata_value_is_discovery_error_with_location`
+- `test_composite_metadata_values_are_discovery_errors`
+- `test_non_string_metadata_key_is_discovery_error`
+
+The existing duplicate-name/location-oriented CLI coverage remains unchanged and continues to pass:
+
+- `test_native_test_cli_reports_duplicate_valid_native_test_names`
+- `test_native_test_cli_preserves_malformed_annotation_reason_before_duplicate_name`
+
+## Commands Run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py tests/unit/test_native_test_cli.py -k 'metadata or native or duplicate'
+```
+
+Result: expected failure, `3 failed, 21 passed`.
+
+Failing tests:
+
+- `tests/unit/test_native_test_kernel.py::test_non_string_metadata_value_is_discovery_error_with_location`
+- `tests/unit/test_native_test_kernel.py::test_composite_metadata_values_are_discovery_errors`
+- `tests/unit/test_native_test_kernel.py::test_non_string_metadata_key_is_discovery_error`
+
+Failure summary: invalid metadata currently passes through as normal native tests instead of becoming discovery errors.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -k 'metadata or native'
+```
+
+Result: `14 passed`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py
+```
+
+Result: `14 passed`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py
+```
+
+Result: `26 passed`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py
+```
+
+Result: expected failure, `3 failed, 7 passed`.
+
+Failing tests:
+
+- `tests/unit/test_native_test_kernel.py::test_non_string_metadata_value_is_discovery_error_with_location`
+- `tests/unit/test_native_test_kernel.py::test_composite_metadata_values_are_discovery_errors`
+- `tests/unit/test_native_test_kernel.py::test_non_string_metadata_key_is_discovery_error`
+
+## Existing Unrelated Failures
+
+None observed in the focused native-test suites run during this phase.
+
+## Commit
+
+- Failing-test commit SHA: `PENDING`
+
+## Implementation Status
+
+Implementation has not been done in this phase.

--- a/.genia/process/tmp/handoffs/issue-480-r3-non-string-test-metadata-boundary/03-test.md
+++ b/.genia/process/tmp/handoffs/issue-480-r3-non-string-test-metadata-boundary/03-test.md
@@ -87,7 +87,7 @@ None observed in the focused native-test suites run during this phase.
 
 ## Commit
 
-- Failing-test commit SHA: `PENDING`
+- Failing-test commit SHA: `4df6fef6bca0b1333946ac8f4ebb9a35382ffe30`
 
 ## Implementation Status
 

--- a/.genia/process/tmp/handoffs/issue-480-r3-non-string-test-metadata-boundary/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-480-r3-non-string-test-metadata-boundary/04-implementation.md
@@ -1,0 +1,87 @@
+# Implementation — Issue #480: R3 Non-String Test Metadata Boundary
+
+## Branch
+
+- Starting branch: `feature/issue-480-r3-non-string-test-metadata-boundary`
+- Working branch: `feature/issue-480-r3-non-string-test-metadata-boundary`
+- Branch status: already existed; no branch creation or switch was needed in this phase
+
+## Failing-Test Commit Referenced
+
+- `4df6fef6bca0b1333946ac8f4ebb9a35382ffe30`
+
+## Selected Policy Confirmed
+
+Policy A: native test metadata keys and values must be strings.
+
+Invalid metadata is reported as a deterministic discovery error before the native test body is run.
+
+## Implementation Summary
+
+- Added one metadata validation boundary in `src/genia/test_kernel.py`.
+- `run_test_unit(...)` now checks native test metadata after test-unit name validation and before discovery-error/body validation.
+- Invalid metadata keys report:
+  - `invalid native test metadata key: expected string, received <type>`
+- Invalid metadata values report:
+  - `invalid native test metadata value for key '<key>': expected string, received <type>`
+- Existing `TestUnit.location` is appended when it is already available.
+- Diagnostics use Genia runtime type names rather than raw Python `repr`.
+- Existing valid string metadata, explicit discovery errors, duplicate-name discovery behavior, and native-test reporting remain unchanged.
+
+## Files Changed
+
+- `src/genia/test_kernel.py`
+- `.genia/process/tmp/handoffs/issue-480-r3-non-string-test-metadata-boundary/04-implementation.md`
+
+## Commands Run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py -k 'metadata'
+```
+
+Result: `4 passed, 6 deselected`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py tests/unit/test_native_test_cli.py -k 'metadata or native or duplicate'
+```
+
+Result: `24 passed`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py
+```
+
+Result: `10 passed`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py
+```
+
+Result: `14 passed`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py
+```
+
+Result: `26 passed`.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_interpreter_test_mode.py
+```
+
+Result: `20 passed`.
+
+```bash
+uv run ruff check src/genia/test_kernel.py tests/unit/test_native_test_kernel.py
+```
+
+Result: not run successfully; `ruff` is not installed in the project environment (`Failed to spawn: ruff`).
+
+## Implementation Commit SHA
+
+- Commit SHA: recorded in final phase report after commit creation.
+
+## Known Follow-Ups
+
+- Docs sync has not been done in this phase.
+- Audit has not been done in this phase.

--- a/GENIA_RULES.md
+++ b/GENIA_RULES.md
@@ -164,6 +164,7 @@ Required constraints:
   - has no effect on language evaluation behavior outside native test mode
   - annotated functions with one or more parameters are a discovery error, not an evaluation error
   - duplicate native-test names across `@test` annotated functions and explicit `test(name, body)` registrations are discovery errors in native test mode
+- native test metadata keys and values must be strings; non-string metadata keys or values in a `TestUnit` are discovery errors reported before test body execution; diagnostics use Genia runtime type names; existing `TestUnit.location` is appended to diagnostic text when available
 - multiple annotations merge from top to bottom
 - last annotation wins for duplicate metadata keys
 - rebinding without annotations preserves existing binding metadata

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2266,18 +2266,19 @@ LANGUAGE CONTRACT:
 - It aggregates suite results and maps suite results to kernel-level exit codes.
 - `TestResult` is distinct from Outcome (`some`/`none`/`err`); there is no automatic mapping between them.
 - Exit code `0` means all executed tests passed or the suite was empty; exit code `1` means at least one test failed or errored.
+- Native test metadata keys and values must be strings. Non-string metadata is reported as a deterministic discovery error before test body execution. Diagnostics use deterministic Genia runtime type names and include existing `TestUnit.location` when available.
 
 PYTHON REFERENCE HOST:
 - Implemented as `src/genia/test_kernel.py` in the Python reference host.
 - Provides: `NativeTestFailure`, `TestUnit`, `run_test_unit`, `run_test_suite`, `aggregate_results`, `suite_exit_code`.
-- `TestUnit` is a frozen dataclass with `name` (required non-empty string), `body` (required callable), and optional `location` and `metadata`.
-- `run_test_unit(test_unit)` executes the body, catches `NativeTestFailure` as a `fail` result, and catches other exceptions as `error` results.
+- `TestUnit` is a frozen dataclass with `name` (required non-empty string), `body` (required callable), and optional `location` and `metadata`. When `metadata` is present, all keys and values must be strings; non-string metadata is a discovery error.
+- `run_test_unit(test_unit)` validates metadata before executing the body, catches `NativeTestFailure` as a `fail` result, and catches other exceptions as `error` results. Non-string metadata keys are reported as discovery errors with reason `invalid native test metadata key: expected string, received <type>`; non-string metadata values are reported as discovery errors with reason `invalid native test metadata value for key '<key>': expected string, received <type>`. Diagnostics use Genia runtime type names; existing `TestUnit.location` is appended when available. Invalid metadata must not cause the test body to execute.
 - `run_test_suite(test_units)` runs each unit in given order and aggregates results via `aggregate_results`.
 - Normalized `TestResult` dictionaries contain stable keys: `kind`, `name`, `phase`, `reason`, `expected`, `actual`, `stdout`, `stderr`, `diagnostics`.
 - `stdout` and `stderr` are stable empty strings in this phase; capture is not implemented.
 - `TestSuiteResult` dictionaries contain: `total`, `passed`, `failed`, `errored`, `results`.
 - `results` preserves input order exactly.
-- Validated by `tests/unit/test_native_test_kernel.py` (6 tests, Python reference host only).
+- Validated by `tests/unit/test_native_test_kernel.py` (10 tests, Python reference host only).
 
 Not implemented in this phase:
 - `skip` result kind

--- a/docs/contract/semantic_facts.json
+++ b/docs/contract/semantic_facts.json
@@ -15,5 +15,6 @@
   "annotation_builtins": "`@doc`, `@meta`, `@since`, `@deprecated`, and `@category`",
   "canonical_format_field_path_separator": "Dot (`.`) is the canonical field-path separator for representation/format placeholders; slash (`/`) is not the format field-path separator and remains limited to existing slash operator/Core IR wording.",
   "canonical_named_access_separator": "Dot (`.`) is the canonical named-access separator; legacy slash named access has been removed and is not general field-path lookup.",
-  "native_test_annotation_discovery": "`@test \"description\"` annotates zero-argument functions for native test discovery; discovery runs after legacy `test(name, body)` registrations; duplicate native-test names across explicit and annotated tests are discovery errors."
+  "native_test_annotation_discovery": "`@test \"description\"` annotates zero-argument functions for native test discovery; discovery runs after legacy `test(name, body)` registrations; duplicate native-test names across explicit and annotated tests are discovery errors.",
+  "native_test_metadata_string_boundary": "Native test metadata keys and values must be strings. Non-string metadata keys or values are reported as deterministic discovery errors before test body execution. Diagnostics use Genia runtime type names and append existing TestUnit.location when available."
 }

--- a/src/genia/test_kernel.py
+++ b/src/genia/test_kernel.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Callable, ClassVar, Iterable
 
+from .values import _runtime_type_name
+
 
 class NativeTestFailure(Exception):
     def __init__(self, reason: str, expected: Any = None, actual: Any = None):
@@ -56,9 +58,44 @@ def _discovery_error(test_unit: Any, reason: str) -> dict[str, Any]:
     )
 
 
+def _metadata_location_suffix(test_unit: Any) -> str:
+    location = getattr(test_unit, "location", None)
+    return f" at {location}" if isinstance(location, str) and location else ""
+
+
+def _metadata_discovery_error(test_unit: Any) -> str | None:
+    metadata = getattr(test_unit, "metadata", None)
+    if metadata is None:
+        return None
+    if not isinstance(metadata, dict):
+        received = _runtime_type_name(metadata)
+        return (
+            "invalid native test metadata: "
+            f"expected map, received {received}{_metadata_location_suffix(test_unit)}"
+        )
+    for key, value in metadata.items():
+        if not isinstance(key, str):
+            received = _runtime_type_name(key)
+            return (
+                "invalid native test metadata key: "
+                f"expected string, received {received}{_metadata_location_suffix(test_unit)}"
+            )
+        if not isinstance(value, str):
+            received = _runtime_type_name(value)
+            return (
+                f"invalid native test metadata value for key '{key}': "
+                f"expected string, received {received}{_metadata_location_suffix(test_unit)}"
+            )
+    return None
+
+
 def run_test_unit(test_unit: TestUnit) -> dict[str, Any]:
     if not isinstance(getattr(test_unit, "name", None), str) or test_unit.name == "":
         return _discovery_error(test_unit, "test unit name must be a non-empty string")
+
+    invalid_metadata = _metadata_discovery_error(test_unit)
+    if invalid_metadata is not None:
+        return _discovery_error(test_unit, invalid_metadata)
 
     discovery_error = getattr(test_unit, "discovery_error", None)
     if discovery_error is None and isinstance(getattr(test_unit, "metadata", None), dict):

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -54,11 +54,12 @@ def test_semantic_facts_file_stays_small_and_complete() -> None:
         "naming_rule",
         "annotation_builtins",
         "native_test_annotation_discovery",
+        "native_test_metadata_string_boundary",
         CANONICAL_FIELD_PATH_SEPARATOR_FACT,
         CANONICAL_NAMED_ACCESS_SEPARATOR_FACT,
     }
     assert set(FACTS) == expected_keys
-    assert len(FACTS) <= 18, "semantic facts surface should stay intentionally small"
+    assert len(FACTS) <= 19, "semantic facts surface should stay intentionally small"
 
 
 def test_authoritative_docs_capture_pipeline_option_contract() -> None:

--- a/tests/unit/test_native_test_kernel.py
+++ b/tests/unit/test_native_test_kernel.py
@@ -6,6 +6,7 @@ from genia.test_kernel import (
     run_test_unit,
     suite_exit_code,
 )
+from genia.values import GeniaMap
 
 
 def test_passing_test_unit_result_aggregation_and_exit_code():
@@ -107,6 +108,117 @@ def test_malformed_named_test_unit_with_non_callable_body_is_discovery_error():
         "diagnostics": {},
     }
     assert isinstance(result["diagnostics"], dict)
+
+
+def test_valid_string_test_metadata_remains_accepted():
+    result = run_test_unit(
+        TestUnit("passes", lambda: None, metadata={"description": "string metadata"})
+    )
+
+    assert result == {
+        "kind": "pass",
+        "name": "passes",
+        "phase": "evaluation",
+        "reason": None,
+        "expected": None,
+        "actual": None,
+        "stdout": "",
+        "stderr": "",
+        "diagnostics": {},
+    }
+
+
+def test_non_string_metadata_value_is_discovery_error_with_location():
+    result = run_test_unit(
+        TestUnit(
+            "bad_metadata",
+            lambda: None,
+            location="metadata_boundary.genia:2",
+            metadata={"description": 123},
+        )
+    )
+
+    assert result == {
+        "kind": "error",
+        "name": "bad_metadata",
+        "phase": "discovery",
+        "reason": (
+            "invalid native test metadata value for key 'description': "
+            "expected string, received int at metadata_boundary.genia:2"
+        ),
+        "expected": None,
+        "actual": None,
+        "stdout": "",
+        "stderr": "",
+        "diagnostics": {},
+    }
+
+
+def test_composite_metadata_values_are_discovery_errors():
+    suite = run_test_suite(
+        [
+            TestUnit("list_metadata", lambda: None, metadata={"description": ["bad"]}),
+            TestUnit(
+                "map_metadata",
+                lambda: None,
+                metadata={"description": GeniaMap().put("bad", "value")},
+            ),
+        ]
+    )
+
+    assert suite == {
+        "total": 2,
+        "passed": 0,
+        "failed": 0,
+        "errored": 2,
+        "results": [
+            {
+                "kind": "error",
+                "name": "list_metadata",
+                "phase": "discovery",
+                "reason": (
+                    "invalid native test metadata value for key 'description': "
+                    "expected string, received list"
+                ),
+                "expected": None,
+                "actual": None,
+                "stdout": "",
+                "stderr": "",
+                "diagnostics": {},
+            },
+            {
+                "kind": "error",
+                "name": "map_metadata",
+                "phase": "discovery",
+                "reason": (
+                    "invalid native test metadata value for key 'description': "
+                    "expected string, received map"
+                ),
+                "expected": None,
+                "actual": None,
+                "stdout": "",
+                "stderr": "",
+                "diagnostics": {},
+            },
+        ],
+    }
+    assert suite_exit_code(suite) == 1
+
+
+def test_non_string_metadata_key_is_discovery_error():
+    result = run_test_unit(TestUnit("bad_key", lambda: None, metadata={1: "value"}))
+
+    assert result == {
+        "kind": "error",
+        "name": "bad_key",
+        "phase": "discovery",
+        "reason": "invalid native test metadata key: expected string, received int",
+        "expected": None,
+        "actual": None,
+        "stdout": "",
+        "stderr": "",
+        "diagnostics": {},
+    }
 
 
 def test_aggregation_preserves_order_and_counts_mixed_results():


### PR DESCRIPTION
close #480 

## Summary

Fixes issue #480 by enforcing a deterministic string-only boundary for native test metadata.

Native test metadata now requires:

* metadata keys to be strings
* metadata values to be strings

Invalid metadata is reported as a discovery error before the test body executes. Diagnostics use deterministic Genia runtime type names and include existing `TestUnit.location` when available.

## Changes

* Added metadata validation in `src/genia/test_kernel.py`
* Added failing-then-passing kernel tests for invalid metadata boundaries
* Documented the native test metadata contract in:

  * `GENIA_STATE.md`
  * `GENIA_RULES.md`
  * `docs/contract/semantic_facts.json`
* Updated semantic facts doc-sync allowlist

## Validation

Passed:

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py
# 10 passed
```

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py
# 14 passed
```

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_runner.py
# 26 passed
```

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_interpreter_test_mode.py
# 20 passed
```

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py
# 85 passed
```

Audit validation total:

```text
155 passed, 0 failures
```

## Commits

* Failing tests: `4df6fef`
* Implementation: `0a19b06`
* Docs sync: `f8547a5`

## Audit

Audit verdict: **PASS**

Merge readiness: **YES**

Audit noted two optional coverage polish items, neither blocking:

* add explicit tests for `bool`, `float`, and `None` metadata values
* add a non-string metadata key test with location
