### PR TITLE
transtion R3 to R4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,9 @@ Before proposing or implementing new feature work, read:
 Before creating new issues/tickets, also read:
 - `docs/process/08-roadmap-ticketing.md`
 
+**Current active release: R4 — Lifecycle Generalization.**
+R3 (Native Test Expansion Wave 1) is complete. When asked for new Genia work with no release specified, classify work against R4 first. If it is not R4 lifecycle work, mark it as non-R4 and defer or park it unless the user explicitly asked for it. See `docs/strategy/release-roadmap.md` and `docs/ai/LLM_CONTRACT.md` for full R4 scope and agent guidance.
+
 Prefer work that strengthens Genia's first killer workflow:
 **Outcome-aware validated data pipelines.**
 

--- a/docs/ai/LLM_CONTRACT.md
+++ b/docs/ai/LLM_CONTRACT.md
@@ -94,6 +94,29 @@ Agents must:
 
 The strategy and roadmap docs do not define implemented behavior. `GENIA_STATE.md` remains final authority.
 
+## Active Release: R4 — Lifecycle Generalization
+
+**Current active release is R4.**
+
+R3 (Native Test Expansion Wave 1) is complete. R4 (Lifecycle Generalization) is now the active release focus.
+
+When an LLM agent is asked for new Genia work and no release is specified:
+
+1. Classify the work against R4 first.
+2. If the work is R4 lifecycle work — lifecycle plan shape, phase shape, scope model, cleanup rules, failure rules, annotation binding model, deterministic source-order / reverse-source-order execution rules, or portable lifecycle docs — proceed through the normal phase pipeline.
+3. If the work is not R4, mark it as non-R4 and either defer/parking-lot it or proceed only if the user explicitly asked for it.
+
+R4 is not a bucket for actors, servers, notebooks, UI, or plugins. Those may use lifecycle later, but they are not R4 implementation targets by default.
+
+R4 exclusions (do not include unless explicitly requested):
+- server mode implementation
+- actor lifecycle implementation
+- arbitrary plugin system
+- YAML lifecycle runner
+- broad runtime rewrites
+- lifecycle behavior not exercised by tests
+- unrelated data-pipeline hardening (belongs to R6)
+
 ## Validation
 
 Repository tooling may validate tool-specific instruction files against this contract.

--- a/docs/strategy/killer-workflow.md
+++ b/docs/strategy/killer-workflow.md
@@ -79,9 +79,16 @@ messy records in → clear pipelines → Outcome-aware validation → clean reco
 R1 is complete.
 
 **R2** protects and exercises the R1 surface through native Genia tests.
-R2 is the active release focus. It is not more CSV/Sheet/diagnostic hardening — that belongs to R5.
+R2 is complete.
 
-**R5** hardens the data workflow with CSV, Sheets, report output, and richer diagnostics.
+**R3** expanded native Genia test coverage over Genia-facing behavior.
+R3 delivered `@test "description"` annotation-driven native test discovery, native test coverage for validation helpers, Outcome constructors/rendering, JSONL helpers, and pipeline examples.
+R3 is complete.
+
+**R4** extracts the proven test lifecycle shape into a portable lifecycle contract.
+R4 is the active release focus. It is not more data-pipeline hardening (that belongs to R6) and not actors, servers, or plugins (those are parking lot).
+
+**R6** hardens the data workflow with CSV, Sheets, report output, and richer diagnostics.
 
 ## Using This Document
 

--- a/docs/strategy/release-roadmap.md
+++ b/docs/strategy/release-roadmap.md
@@ -112,7 +112,9 @@ Exit criteria:
 
 ---
 
-## Release R3 — Native Test Expansion Wave 1
+## Release R3 — Native Test Expansion Wave 1 ✓ COMPLETE
+
+**Status: Complete.** R3 expanded native Genia test coverage over Genia-facing behavior.
 
 Theme:
 
@@ -126,6 +128,17 @@ test1() = assert_eq(1+1, 2)
 ```
 
 R2 introduced the `test(name, body)` call form. R3 adds `@test "description"` annotation-driven native test discovery (issue #458): `@test` annotated zero-argument functions are discovered after legacy `test(name, body)` registrations and run through the same native test kernel. The annotation carries the human-readable description; the function name is the test identifier.
+
+R3 delivered:
+
+- `@test "description"` annotation-driven native test discovery (issue #458) — implemented and documented as current behavior
+- native test coverage for validation helpers (`validate_required`, `validate_field`, `validate_optional`, `validate_record`, `validate_each`) and `collect_validated`
+- native test coverage for Outcome constructors and rendering behavior (`some`, `none`, `err`, `display`, `debug_repr`)
+- native test coverage for JSONL helper behavior in validated pipeline examples
+- at least one pipeline example backed by a native test (`examples/r3_validated_pipeline_native_tests.genia`)
+- native tests kept focused on Genia-facing behavior; parser/IR/host internals were not touched
+
+Do not overclaim R3 completion beyond what the current repo actually shows.
 
 Primary outcomes:
 
@@ -163,6 +176,8 @@ Exit criteria:
 
 ## Release R4 — Lifecycle Generalization
 
+**Status: Active release focus.**
+
 Theme:
 
 > Extract the proven test lifecycle shape into a portable lifecycle contract.
@@ -181,8 +196,10 @@ Includes:
 - cleanup rules
 - failure rules
 - annotation binding model
-- source-order / reverse-source-order execution rules
+- deterministic source-order / reverse-source-order execution rules
 - portable docs for execution-mode lifecycle proposals
+- test lifecycle remains the first implemented consumer
+- annotations do not execute merely because they exist
 
 Excludes:
 
@@ -190,13 +207,22 @@ Excludes:
 - actor lifecycle implementation
 - arbitrary plugin system
 - YAML lifecycle runner unless separately approved
+- broad runtime rewrites
 - lifecycle behavior not exercised by tests
+- unrelated R5 data hardening unless explicitly requested
 
 Exit criteria:
 
 - Lifecycle is documented as a general model.
 - Test lifecycle remains the first implemented consumer.
 - No annotations execute merely because they exist.
+
+Agent guidance for R4:
+
+- Current release focus is R4. When asked for new Genia work with no release specified, classify the work against R4 first.
+- If the work is R4 lifecycle work, proceed through the normal phase pipeline.
+- If the work is not R4, mark it as non-R4 and either defer/parking-lot it or proceed only if the user explicitly asked for it.
+- R4 is not a bucket for actors, servers, notebooks, UI, or plugins. Those may use lifecycle later, but they are not R4 implementation targets by default.
 
 ---
 
@@ -361,12 +387,22 @@ If an issue listed above is already closed, do not reopen it.
 
 ## Roadmap Rule for Agents
 
+**Current active release: R4 — Lifecycle Generalization.**
+
 Before proposing new tickets, agents must classify the work as:
 
-- current release
+- current release (R4)
 - next release
 - infrastructure
 - follow-up
 - parking lot
+
+When asked for new Genia work with no release specified:
+
+1. Classify the work against R4 first.
+2. If the work is R4 lifecycle work (lifecycle plan shape, phase shape, scope model, cleanup/failure rules, annotation binding model, execution-order rules, portable lifecycle docs), proceed through the normal phase pipeline.
+3. If the work is not R4, mark it as non-R4 and either defer/parking-lot it or proceed only if the user explicitly asked for it.
+
+R4 is not a bucket for actors, servers, notebooks, UI, or plugins. Those may use lifecycle later, but they are not R4 implementation targets by default.
 
 If the work is parking-lot/future, do not create implementation tickets unless explicitly approved.


### PR DESCRIPTION
Summary
Transition planning and LLM guidance from R3 to R4.

R3 (Native Test Expansion Wave 1) is complete. This PR updates the repo's planning docs and LLM instruction surfaces so agents understand R4 (Lifecycle Generalization) is now the active release focus.

What changed:

docs/strategy/release-roadmap.md — R3 heading marked ✓ COMPLETE; R3 delivered-summary added (annotation discovery, validation/Outcome/JSONL native tests, pipeline examples); R4 marked as active focus; R4 Includes expanded with "deterministic" source-order rule, test lifecycle as first consumer, annotations-don't-execute; R4 Excludes expanded with broad-runtime-rewrites and R5 data hardening; R4 agent guidance block added; Roadmap Rule for Agents updated with R4 as current release and 3-step classification rule

docs/strategy/killer-workflow.md — Release Positioning updated: R2 and R3 marked complete, R4 set as active focus with explicit scope and exclusion reminder, R6 corrected for data workflow hardening

docs/ai/LLM_CONTRACT.md — New "Active Release: R4" section with full agent classification guidance: 3-step rule (classify against R4 first → proceed if R4 lifecycle work → defer/park otherwise), no-bucket reminder for actors/servers/plugins, R4 exclusion list

AGENTS.md — One-paragraph note in Product Priority declaring R4 active, R3 complete, with pointer to roadmap and LLM_CONTRACT for full scope

What was not changed: GENIA_STATE.md, GENIA_RULES.md, GENIA_REPL_README.md, README.md, parser, evaluator, tests, prelude, examples. No behavior was documented as implemented. No lifecycle was implemented.

Test plan
 pytest tests/doc/test_semantic_doc_sync.py — 85 passed
 pytest tests/doc/ — 107 passed
 Confirm R3 section precedes R4 section in roadmap (test_r3_native_test_roadmap_stays_separate_from_r4_lifecycle_generalization passes)