### PR TITLE
Feature/issue 452 r4 lifecycle annotation binding model

### DIFF
--- a/.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/03-test.md
+++ b/.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/03-test.md
@@ -1,0 +1,116 @@
+# Genia Test Handoff — Issue #452
+
+CHANGE NAME: issue #452 r4-lifecycle-annotation-binding-model
+CHANGE SLUG: issue-452-r4-lifecycle-annotation-binding-model
+TYPE: feature
+ISSUE: 452
+BRANCH: feature/issue-452-r4-lifecycle-annotation-binding-model
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/`
+
+## Branch
+
+Starting branch: feature/issue-452-r4-lifecycle-annotation-binding-model
+Working branch: feature/issue-452-r4-lifecycle-annotation-binding-model
+Branch already existed or newly created: already existed
+
+## Files Changed
+
+- `tests/unit/test_lifecycle_binding.py`
+- `tests/unit/test_native_test_cli.py`
+- `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/03-test.md`
+
+## Tests Added
+
+Added `tests/unit/test_lifecycle_binding.py` with focused failing coverage for the approved lifecycle annotation binding helper contract:
+
+- `test_optional_binding_with_zero_candidates_succeeds_without_diagnostics`
+- `test_required_binding_with_zero_candidates_reports_deterministic_diagnostic`
+- `test_annotation_name_matching_selects_only_matching_annotations`
+- `test_exact_metadata_filters_include_matching_metadata`
+- `test_exact_metadata_filters_exclude_non_matching_metadata`
+- `test_callable_participant_kind_accepts_callable_values`
+- `test_callable_participant_kind_rejects_non_callable_values_with_diagnostic`
+- `test_source_order_ordering_is_deterministic`
+- `test_reverse_source_order_ordering_is_deterministic`
+- `test_stable_name_order_ordering_is_deterministic`
+- `test_duplicate_participant_selection_reports_diagnostic_and_keeps_at_most_one_participant`
+- `test_unsupported_ordering_reports_deterministic_error`
+
+Added nearby native-test regression coverage in `tests/unit/test_native_test_cli.py`:
+
+- `test_native_test_cli_ignores_non_test_metadata_annotations_for_discovery`
+- `test_test_annotation_does_not_execute_outside_native_test_mode`
+
+Existing nearby coverage already proves valid `@test` discovery still works.
+
+## Expected Failing Command
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py -v
+```
+
+## Failing Output Summary
+
+The focused lifecycle binding suite collected 12 tests and all 12 failed:
+
+```text
+tests/unit/test_lifecycle_binding.py FFFFFFFFFFFF
+ModuleNotFoundError: No module named 'genia.lifecycle_binding'
+12 failed in 0.32s
+```
+
+## Reason The Tests Fail
+
+The tests intentionally target the later implementation module from the approved design:
+
+```text
+src/genia/lifecycle_binding.py
+```
+
+That module does not exist yet. This is the expected TEST-phase failure boundary. No placeholder module was added because importing the missing target is enough to fail clearly before implementation.
+
+## Validation Run
+
+Focused red lifecycle binding command:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py -v
+```
+
+Result: expected failure, 12 failed with `ModuleNotFoundError: No module named 'genia.lifecycle_binding'`.
+
+Native-test regression command:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v
+```
+
+Result: 19 passed.
+
+Focused lint command:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff check tests/unit/test_lifecycle_binding.py tests/unit/test_native_test_cli.py
+```
+
+Result: All checks passed.
+
+Initial local `uv run ruff ...` failed because `ruff` was not installed in the project environment. `uvx ruff ...` required network access and then passed.
+
+## No Implementation Done
+
+No implementation was done in this phase.
+
+No parser, lexer, Core IR, evaluator, runtime lifecycle execution, CLI behavior, native test behavior, public builtins, prelude functions, lifecycle runner, setup/teardown behavior, module/server/actor/REPL lifecycle behavior, or docs outside this handoff were changed.
+
+## Recommended Implementation Target Files
+
+- `src/genia/lifecycle_binding.py`
+- `src/genia/test_cli.py`, only if later implementation routes native-test discovery through the helper while preserving current observable behavior
+
+## Risks Or Follow-ups
+
+- The new unit tests define the expected internal Python helper API names from the approved design: `LifecycleAnnotationBinding`, `AnnotationCandidate`, `AnnotationInfo`, `discover_lifecycle_participants`, result participants, and diagnostics.
+- Unsupported ordering is expected to raise `ValueError` with a deterministic path-style message.
+- Callable participant validation is currently specified using Python callability for the internal helper tests; later implementation should reconcile this with existing Genia runtime/native-test function-group callability without changing current native-test behavior.
+- The prompt asked to read `docs/process/03-test.md`, but that file is absent in this checkout. The available process files include `docs/process/04-test.md`.

--- a/.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/04-implementation.md
@@ -1,0 +1,84 @@
+# Genia Implementation Handoff — Issue #452
+
+CHANGE NAME: issue #452 r4-lifecycle-annotation-binding-model
+CHANGE SLUG: issue-452-r4-lifecycle-annotation-binding-model
+TYPE: feature
+ISSUE: 452
+BRANCH: feature/issue-452-r4-lifecycle-annotation-binding-model
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/`
+
+## Branch
+
+Starting branch: feature/issue-452-r4-lifecycle-annotation-binding-model
+Working branch: feature/issue-452-r4-lifecycle-annotation-binding-model
+Branch already existed or newly created: already existed
+
+## Failing-Test Commit
+
+48b564ec4c6e6516c626d46bff52c17c4e0aa3bc
+
+## Files Changed
+
+- `src/genia/lifecycle_binding.py`
+- `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/04-implementation.md`
+
+## Summary Of Implementation
+
+Added the internal Python reference-host lifecycle annotation binding helper module at `src/genia/lifecycle_binding.py`.
+
+The module implements the small dataclass/function API required by the approved tests:
+
+- `LifecycleAnnotationBinding`
+- `AnnotationInfo`
+- `AnnotationCandidate`
+- `LifecycleParticipant`
+- `LifecycleBindingDiagnostic`
+- `LifecycleBindingResult`
+- `discover_lifecycle_participants(...)`
+
+The implementation supports exact annotation-name matching, exact metadata filters, callable participant validation, deterministic `source_order`, `reverse_source_order`, and `stable_name_order`, duplicate participant diagnostics, required-binding diagnostics, and deterministic unsupported-ordering errors.
+
+The helper selects participants only. It does not execute participant values.
+
+## Validation Commands Run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py -v
+```
+
+Result: 12 passed.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v
+```
+
+Result: 19 passed.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_plan.py tests/doc/test_lifecycle_architecture_doc.py
+```
+
+Result: 39 passed.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff check src/genia/lifecycle_binding.py tests/unit/test_lifecycle_binding.py tests/unit/test_native_test_cli.py
+```
+
+Result: All checks passed.
+
+The first lint attempt without network approval failed while fetching `ruff`; the approved retry passed.
+
+## Behavior Not Changed
+
+No parser behavior changed.
+No lexer behavior changed.
+No Core IR or lowering behavior changed.
+No evaluator semantics changed.
+No runtime lifecycle execution was added.
+No CLI behavior changed.
+No native-test behavior changed.
+No docs, cheatsheets, SICP docs, browser/playground docs, shared specs, public builtins, prelude functions, setup/teardown behavior, lifecycle runner, module/server/actor/REPL lifecycle hooks, or new syntax were added.
+
+## Implementation Commit
+
+Recorded in the final implementation-phase report after commit creation.

--- a/.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/05-doc-sync.md
+++ b/.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/05-doc-sync.md
@@ -1,0 +1,99 @@
+# Genia Doc Sync Handoff — Issue #452
+
+CHANGE NAME: issue #452 r4-lifecycle-annotation-binding-model
+CHANGE SLUG: issue-452-r4-lifecycle-annotation-binding-model
+TYPE: feature
+ISSUE: 452
+BRANCH: feature/issue-452-r4-lifecycle-annotation-binding-model
+HANDOFF DIR: `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/`
+
+## Branch
+
+Starting branch: feature/issue-452-r4-lifecycle-annotation-binding-model
+Working branch: feature/issue-452-r4-lifecycle-annotation-binding-model
+Branch already existed or newly created: already existed
+
+## Commits
+
+Failing-test commit: 48b564ec4c6e6516c626d46bff52c17c4e0aa3bc
+Implementation commit: 45413d99063a77d8d5b4383a0e260aa0bb098c4a
+Docs commit: recorded in final doc-sync report after commit creation
+
+## Docs And Files Inspected
+
+- `AGENTS.md`
+- `GENIA_STATE.md`
+- `GENIA_RULES.md`
+- `GENIA_REPL_README.md`
+- `README.md`
+- `docs/ai/LLM_CONTRACT.md`
+- `docs/architecture/lifecycle.md`
+- `docs/contract/semantic_facts.json`
+- `tests/doc/test_semantic_doc_sync.py`
+- `tests/doc/test_lifecycle_architecture_doc.py`
+- `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/00-preflight.md`
+- `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/01-contract.md`
+- `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/02-design.md`
+- `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/03-test.md`
+- `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/04-implementation.md`
+- lifecycle-related docs discovered by `rg`, including `docs/design/*`, `docs/strategy/*`, `docs/parking-lot/*`, and lifecycle doc tests
+
+`docs/book/` was also checked and does not exist in this checkout.
+
+## Files Changed
+
+- `GENIA_STATE.md`
+- `docs/architecture/lifecycle.md`
+- `.genia/process/tmp/handoffs/issue-452-r4-lifecycle-annotation-binding-model/05-doc-sync.md`
+
+## Rationale For Doc Changes
+
+`GENIA_STATE.md` now records the implemented and tested internal Python reference-host lifecycle annotation binding helper in a narrow section. The wording states that the helper selects annotation candidates by exact annotation/metadata matching, participant kind, deterministic ordering, duplicate diagnostics, required-binding diagnostics, and unsupported-ordering errors. It also states that binding results are discovery data only and do not execute participants.
+
+`docs/architecture/lifecycle.md` now aligns its lifecycle vocabulary/status section with `GENIA_STATE.md`: `stable_name_order` is included in the ordering vocabulary, and the current implementation status mentions the internal `src/genia/lifecycle_binding.py` helper while preserving that lifecycle execution remains unimplemented.
+
+No update was made to `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, `docs/contract/semantic_facts.json`, or `tests/doc/test_semantic_doc_sync.py` because the implemented helper is internal Python reference-host support, not a user-facing syntax, runtime, CLI, native-test, or protected semantic-facts change.
+
+## Behavior Explicitly Not Documented As Implemented
+
+- parser changes
+- lexer changes
+- Core IR changes
+- evaluator semantic changes
+- CLI behavior changes
+- native-test behavior changes
+- lifecycle runner behavior
+- lifecycle execution behavior
+- setup/teardown behavior
+- `@setup`
+- `@teardown`
+- module lifecycle hooks
+- server lifecycle hooks
+- actor lifecycle hooks
+- REPL lifecycle hooks
+- public Genia builtins
+- prelude functions
+- public user-facing lifecycle annotation APIs
+- import-time hook execution
+
+## Validation Commands Run
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py
+```
+
+Result: 85 passed.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_lifecycle_architecture_doc.py
+```
+
+Result: 7 passed.
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py tests/unit/test_native_test_cli.py
+```
+
+Result: 31 passed.
+
+No ruff run was needed in this phase because only Markdown/state docs and the handoff changed.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2425,6 +2425,33 @@ Explicit limitations:
 - No changes were made to parser, lexer, Core IR, evaluator, prelude, CLI, native test runner, runtime execution paths, or shared semantic specs.
 - This is Python reference-host internal utility code; no public Genia prelude API was added in this phase.
 
+## 9.5) Lifecycle annotation binding helper (Python reference host, Experimental)
+
+Status: Experimental, Python reference host only. Implemented in issue #452.
+
+LANGUAGE CONTRACT:
+- Lifecycle annotation binding treats annotations as candidate markers for lifecycle phases; annotations do not execute themselves.
+- A lifecycle annotation binding selects candidates by annotation name, exact metadata filters, participant kind, and deterministic ordering.
+- Supported first-pass ordering labels are `source_order`, `reverse_source_order`, and `stable_name_order`.
+- Required bindings report a deterministic diagnostic when no participants match; optional bindings may produce an empty participant list without diagnostics.
+- Selecting the same declaration more than once for one binding produces a deterministic diagnostic and includes that declaration at most once.
+- Binding results are discovery data only. Selecting a participant does not invoke it, activate a phase, execute setup/teardown behavior, or change ordinary evaluation.
+
+PYTHON REFERENCE HOST:
+- Implemented as `src/genia/lifecycle_binding.py`.
+- Provides internal dataclasses and `discover_lifecycle_participants(...)` for phase-owned annotation binding discovery.
+- The helper supports annotation-name matching, exact metadata filtering, callable participant validation, deterministic ordering, duplicate diagnostics, required-binding diagnostics, unsupported-ordering errors, and binding results without executing participant values.
+- Validated by `tests/unit/test_lifecycle_binding.py` (12 tests), Python reference host only.
+
+Explicit limitations:
+- No lifecycle runner behavior is implemented.
+- No lifecycle phase execution is implemented.
+- No setup/teardown behavior is implemented.
+- No `@setup` or `@teardown` annotations are implemented.
+- No parser, lexer, Core IR, evaluator, CLI, native test behavior, prelude, public builtin, runtime execution path, or shared semantic spec behavior changed.
+- No public Genia lifecycle annotation binding API was added.
+- Native test discovery remains owned by the existing native test CLI/test-mode layer; it was not refactored to use this helper in this phase.
+
 ## 10) Explicitly not implemented (current)
 
 - general unrestricted host interop / FFI layer

--- a/docs/architecture/lifecycle.md
+++ b/docs/architecture/lifecycle.md
@@ -74,11 +74,13 @@ Out of scope:
 
 `inert annotation rule` means annotations are metadata unless a future lifecycle phase explicitly consumes them through a lifecycle binding.
 
-`OrderingRule` means deterministic participant order within a phase. Initial ordering vocabulary includes `source_order` and `reverse_source_order`.
+`OrderingRule` means deterministic participant order within a phase. Initial ordering vocabulary includes `source_order`, `reverse_source_order`, and `stable_name_order`.
 
 `source_order` means candidates are processed in deterministic source order.
 
 `reverse_source_order` means candidates are processed in the reverse of deterministic source order.
+
+`stable_name_order` means candidates are processed by declaration name with deterministic source-position tie-breakers.
 
 `ExecutionMode` means the way Genia source is invoked and run, such as file, command, pipe, REPL, or native test mode. `execution mode lifecycle` is vocabulary for a possible future lifecycle associated with an execution mode; it is not a runtime execution-mode refactor in this issue.
 
@@ -114,6 +116,7 @@ The initial vocabulary terms are:
 
 - `source_order`
 - `reverse_source_order`
+- `stable_name_order`
 
 Illustrative/proposed, not current runtime behavior:
 
@@ -150,6 +153,8 @@ Lifecycle plan data-shape validation and normalization is implemented in the Pyt
 
 Lifecycle scope tree data-shape validation and normalization is implemented in the Python reference host as a focused internal utility (`src/genia/lifecycle_scope.py`, issue #450). `validate_lifecycle_scope_tree(value)` and `normalize_lifecycle_scope_tree(value)` validate that an ordinary map value conforms to the first-pass R4 lifecycle scope tree data shape: required `scopes` list, required `name`/`parent`/`children` fields per scope, the canonical `execution -> suite -> module -> test` hierarchy, duplicate-scope-name rejection, and unsupported-scope-name rejection. Optional `description` and `metadata` fields are preserved as inert data without execution. This is Python reference-host internal validation only; does not execute lifecycle behavior, does not add annotation discovery or setup/teardown behavior, does not add cleanup execution, and does not change parser, Core IR, prelude, CLI, native test runner, or runtime execution paths. See `GENIA_STATE.md` section 9.4 for the full language contract.
 
+Lifecycle annotation binding discovery is implemented in the Python reference host as a focused internal utility (`src/genia/lifecycle_binding.py`, issue #452). `discover_lifecycle_participants(...)` selects annotation candidates for a phase using exact annotation-name matching, exact metadata filters, callable participant validation, deterministic ordering, duplicate diagnostics, required-binding diagnostics, and unsupported-ordering errors. This helper returns binding result data only and does not execute participants. This is Python reference-host internal support only; no public Genia prelude API, lifecycle runner, setup/teardown behavior, `@setup` or `@teardown` annotations, parser change, Core IR change, CLI change, native test behavior change, or runtime execution path change was added. See `GENIA_STATE.md` section 9.5 for the full language contract.
+
 Generalized lifecycle plan execution is not implemented runtime behavior.
 
 Lifecycle runners are not implemented runtime behavior.
@@ -158,7 +163,7 @@ Phase graph execution is not implemented runtime behavior.
 
 Setup/teardown lifecycle hooks are not implemented runtime behavior.
 
-Generalized annotation bindings are not implemented runtime behavior.
+Generalized annotation binding execution is not implemented runtime behavior.
 
 Python is currently the reference host, as described by `GENIA_STATE.md`, but lifecycle vocabulary is not Python-only behavior.
 

--- a/src/genia/lifecycle_binding.py
+++ b/src/genia/lifecycle_binding.py
@@ -1,0 +1,208 @@
+"""Internal lifecycle annotation binding helpers for the Python reference host."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .values import _runtime_type_name
+
+
+@dataclass(frozen=True)
+class LifecycleAnnotationBinding:
+    phase: str
+    annotation_name: str
+    filters: Mapping[str, Any]
+    ordering: str
+    required: bool
+    participant_kind: str
+    failure_policy: str
+
+
+@dataclass(frozen=True)
+class AnnotationInfo:
+    name: str
+    metadata: Mapping[str, Any]
+    source_location: Any = None
+
+
+@dataclass(frozen=True)
+class AnnotationCandidate:
+    name: str
+    value: Any
+    annotations: list[AnnotationInfo]
+    source_location: Any = None
+    source_identity: str = ""
+    source_index: int = 0
+
+
+@dataclass(frozen=True)
+class LifecycleParticipant:
+    declaration_name: str
+    value: Any
+    annotation: AnnotationInfo
+    phase: str
+    binding: LifecycleAnnotationBinding
+    order_key: tuple[Any, ...]
+    source_location: Any = None
+
+
+@dataclass(frozen=True)
+class LifecycleBindingDiagnostic:
+    phase: str
+    annotation_name: str
+    declaration_name: str | None
+    source_location: Any
+    reason: str
+
+
+@dataclass(frozen=True)
+class LifecycleBindingResult:
+    phase: str
+    binding: LifecycleAnnotationBinding
+    participants: list[LifecycleParticipant]
+    diagnostics: list[LifecycleBindingDiagnostic]
+
+
+_SUPPORTED_ORDERINGS = {
+    "source_order",
+    "reverse_source_order",
+    "stable_name_order",
+}
+
+
+def discover_lifecycle_participants(
+    binding: LifecycleAnnotationBinding,
+    candidates: list[AnnotationCandidate],
+) -> LifecycleBindingResult:
+    if binding.ordering not in _SUPPORTED_ORDERINGS:
+        raise ValueError(
+            "invalid lifecycle annotation binding at binding.ordering: "
+            f"unsupported ordering {binding.ordering}"
+        )
+
+    participants: list[LifecycleParticipant] = []
+    diagnostics: list[LifecycleBindingDiagnostic] = []
+    seen_declarations: set[str] = set()
+
+    for candidate in candidates:
+        matching_annotations = [
+            annotation
+            for annotation in candidate.annotations
+            if _annotation_matches(binding, annotation)
+        ]
+        if not matching_annotations:
+            continue
+
+        if not _participant_kind_matches(binding, candidate):
+            diagnostics.append(
+                _diagnostic(
+                    binding,
+                    candidate,
+                    (
+                        f"lifecycle participant {candidate.name} "
+                        f"for @{binding.annotation_name} expected callable, "
+                        f"got {_runtime_type_name(candidate.value)}"
+                    ),
+                )
+            )
+            continue
+
+        for annotation in matching_annotations:
+            if candidate.name in seen_declarations:
+                diagnostics.append(
+                    _diagnostic(
+                        binding,
+                        candidate,
+                        (
+                            "duplicate lifecycle participant selected "
+                            f"for @{binding.annotation_name}: {candidate.name}"
+                        ),
+                    )
+                )
+                continue
+            seen_declarations.add(candidate.name)
+            participants.append(
+                LifecycleParticipant(
+                    declaration_name=candidate.name,
+                    value=candidate.value,
+                    annotation=annotation,
+                    phase=binding.phase,
+                    binding=binding,
+                    order_key=_order_key(binding, candidate),
+                    source_location=candidate.source_location,
+                )
+            )
+
+    participants = sorted(participants, key=lambda participant: participant.order_key)
+    if binding.required and not participants:
+        diagnostics.append(
+            LifecycleBindingDiagnostic(
+                phase=binding.phase,
+                annotation_name=binding.annotation_name,
+                declaration_name=None,
+                source_location=None,
+                reason=(
+                    "required lifecycle annotation binding found no candidates "
+                    f"for @{binding.annotation_name}"
+                ),
+            )
+        )
+
+    return LifecycleBindingResult(
+        phase=binding.phase,
+        binding=binding,
+        participants=participants,
+        diagnostics=diagnostics,
+    )
+
+
+def _annotation_matches(
+    binding: LifecycleAnnotationBinding,
+    annotation: AnnotationInfo,
+) -> bool:
+    if annotation.name != binding.annotation_name:
+        return False
+    for key, expected in binding.filters.items():
+        if key not in annotation.metadata:
+            return False
+        if annotation.metadata[key] != expected:
+            return False
+    return True
+
+
+def _participant_kind_matches(
+    binding: LifecycleAnnotationBinding,
+    candidate: AnnotationCandidate,
+) -> bool:
+    if binding.participant_kind == "callable":
+        return callable(candidate.value)
+    return True
+
+
+def _order_key(
+    binding: LifecycleAnnotationBinding,
+    candidate: AnnotationCandidate,
+) -> tuple[Any, ...]:
+    source_identity = candidate.source_identity
+    source_index = candidate.source_index
+    name = candidate.name
+    if binding.ordering == "source_order":
+        return (source_identity, source_index, name)
+    if binding.ordering == "reverse_source_order":
+        return (source_identity, -source_index, name)
+    return (name, source_identity, source_index)
+
+
+def _diagnostic(
+    binding: LifecycleAnnotationBinding,
+    candidate: AnnotationCandidate,
+    reason: str,
+) -> LifecycleBindingDiagnostic:
+    return LifecycleBindingDiagnostic(
+        phase=binding.phase,
+        annotation_name=binding.annotation_name,
+        declaration_name=candidate.name,
+        source_location=candidate.source_location,
+        reason=reason,
+    )

--- a/tests/unit/test_lifecycle_binding.py
+++ b/tests/unit/test_lifecycle_binding.py
@@ -1,0 +1,202 @@
+import importlib
+
+import pytest
+
+
+def _binding_module():
+    return importlib.import_module("genia.lifecycle_binding")
+
+
+def _annotation(name, metadata=None, *, line=1):
+    lifecycle_binding = _binding_module()
+    return lifecycle_binding.AnnotationInfo(
+        name=name,
+        metadata={} if metadata is None else metadata,
+        source_location={"file": "suite.genia", "line": line, "source": f"@{name}"},
+    )
+
+
+def _candidate(
+    name,
+    value,
+    annotations,
+    *,
+    source_identity="suite.genia",
+    source_index=1,
+):
+    lifecycle_binding = _binding_module()
+    return lifecycle_binding.AnnotationCandidate(
+        name=name,
+        value=value,
+        annotations=annotations,
+        source_location={"file": source_identity, "line": source_index},
+        source_identity=source_identity,
+        source_index=source_index,
+    )
+
+
+def _binding(
+    *,
+    annotation_name="setup",
+    filters=None,
+    ordering="source_order",
+    required=False,
+    participant_kind="callable",
+):
+    lifecycle_binding = _binding_module()
+    return lifecycle_binding.LifecycleAnnotationBinding(
+        phase="test_before",
+        annotation_name=annotation_name,
+        filters={} if filters is None else filters,
+        ordering=ordering,
+        required=required,
+        participant_kind=participant_kind,
+        failure_policy="diagnostic",
+    )
+
+
+def _discover(binding, candidates):
+    return _binding_module().discover_lifecycle_participants(binding, candidates)
+
+
+def _participant_names(result):
+    return [participant.declaration_name for participant in result.participants]
+
+
+def _diagnostic_reasons(result):
+    return [diagnostic.reason for diagnostic in result.diagnostics]
+
+
+def test_optional_binding_with_zero_candidates_succeeds_without_diagnostics():
+    result = _discover(_binding(required=False), [])
+
+    assert result.phase == "test_before"
+    assert result.participants == []
+    assert result.diagnostics == []
+
+
+def test_required_binding_with_zero_candidates_reports_deterministic_diagnostic():
+    result = _discover(_binding(required=True), [])
+
+    assert result.participants == []
+    assert _diagnostic_reasons(result) == [
+        "required lifecycle annotation binding found no candidates for @setup"
+    ]
+
+
+def test_annotation_name_matching_selects_only_matching_annotations():
+    selected = _candidate("selected", lambda: None, [_annotation("setup")], source_index=1)
+    ignored = _candidate("ignored", lambda: None, [_annotation("test")], source_index=2)
+
+    result = _discover(_binding(annotation_name="setup"), [ignored, selected])
+
+    assert _participant_names(result) == ["selected"]
+    assert result.diagnostics == []
+
+
+def test_exact_metadata_filters_include_matching_metadata():
+    candidate = _candidate(
+        "setup_test",
+        lambda: None,
+        [_annotation("setup", {"scope": "test", "role": "db"})],
+    )
+
+    result = _discover(_binding(filters={"scope": "test"}), [candidate])
+
+    assert _participant_names(result) == ["setup_test"]
+    assert result.diagnostics == []
+
+
+def test_exact_metadata_filters_exclude_non_matching_metadata():
+    candidate = _candidate(
+        "setup_module",
+        lambda: None,
+        [_annotation("setup", {"scope": "module"})],
+    )
+
+    result = _discover(_binding(filters={"scope": "test"}), [candidate])
+
+    assert result.participants == []
+    assert result.diagnostics == []
+
+
+def test_callable_participant_kind_accepts_callable_values():
+    def setup():
+        raise AssertionError("binding discovery must not execute participants")
+
+    result = _discover(_binding(participant_kind="callable"), [_candidate("setup", setup, [_annotation("setup")])])
+
+    assert _participant_names(result) == ["setup"]
+    assert result.participants[0].value is setup
+    assert result.diagnostics == []
+
+
+def test_callable_participant_kind_rejects_non_callable_values_with_diagnostic():
+    result = _discover(_binding(participant_kind="callable"), [_candidate("not_callable", 1, [_annotation("setup")])])
+
+    assert result.participants == []
+    assert _diagnostic_reasons(result) == [
+        "lifecycle participant not_callable for @setup expected callable, got int"
+    ]
+
+
+def test_source_order_ordering_is_deterministic():
+    candidates = [
+        _candidate("third", lambda: None, [_annotation("setup")], source_index=3),
+        _candidate("first", lambda: None, [_annotation("setup")], source_index=1),
+        _candidate("second", lambda: None, [_annotation("setup")], source_index=2),
+    ]
+
+    result = _discover(_binding(ordering="source_order"), candidates)
+
+    assert _participant_names(result) == ["first", "second", "third"]
+
+
+def test_reverse_source_order_ordering_is_deterministic():
+    candidates = [
+        _candidate("first", lambda: None, [_annotation("setup")], source_index=1),
+        _candidate("third", lambda: None, [_annotation("setup")], source_index=3),
+        _candidate("second", lambda: None, [_annotation("setup")], source_index=2),
+    ]
+
+    result = _discover(_binding(ordering="reverse_source_order"), candidates)
+
+    assert _participant_names(result) == ["third", "second", "first"]
+
+
+def test_stable_name_order_ordering_is_deterministic():
+    candidates = [
+        _candidate("bravo", lambda: None, [_annotation("setup")], source_index=1),
+        _candidate("alpha", lambda: None, [_annotation("setup")], source_index=2),
+        _candidate("charlie", lambda: None, [_annotation("setup")], source_index=3),
+    ]
+
+    result = _discover(_binding(ordering="stable_name_order"), candidates)
+
+    assert _participant_names(result) == ["alpha", "bravo", "charlie"]
+
+
+def test_duplicate_participant_selection_reports_diagnostic_and_keeps_at_most_one_participant():
+    candidate = _candidate(
+        "setup_once",
+        lambda: None,
+        [
+            _annotation("setup", {"scope": "test"}, line=1),
+            _annotation("setup", {"scope": "test"}, line=2),
+        ],
+    )
+
+    result = _discover(_binding(filters={"scope": "test"}), [candidate])
+
+    assert _participant_names(result) == ["setup_once"]
+    assert _diagnostic_reasons(result) == [
+        "duplicate lifecycle participant selected for @setup: setup_once"
+    ]
+
+
+def test_unsupported_ordering_reports_deterministic_error():
+    with pytest.raises(
+        ValueError,
+        match="invalid lifecycle annotation binding at binding.ordering: unsupported ordering random_order",
+    ):
+        _discover(_binding(ordering="random_order"), [])

--- a/tests/unit/test_native_test_cli.py
+++ b/tests/unit/test_native_test_cli.py
@@ -297,6 +297,49 @@ def test_native_test_cli_rejects_setup_annotation_instead_of_running_lifecycle_h
     assert "PASS ordinary" not in captured.out
 
 
+def test_native_test_cli_ignores_non_test_metadata_annotations_for_discovery(
+    tmp_path,
+    capsys,
+):
+    exit_code, captured = _run_native_test_source(
+        tmp_path,
+        capsys,
+        '@doc "helper docs only"\n'
+        "helper() = missing_name\n"
+        "\n"
+        '@test "ordinary test"\n'
+        "ordinary() = assert_true(true)\n",
+    )
+
+    assert exit_code == 0
+    assert captured.out == (
+        "total=1 passed=1 failed=0 errored=0\n"
+        "PASS ordinary\n"
+        "total=1 passed=1 failed=0 errored=0\n"
+    )
+    assert "helper" not in captured.out
+    assert captured.err == ""
+
+
+def test_test_annotation_does_not_execute_outside_native_test_mode(tmp_path, capsys):
+    from genia.builtins import make_global_env
+    from genia.interpreter import run_source
+
+    env = make_global_env(cli_args=[])
+
+    run_source(
+        '@test "ordinary test"\n'
+        'ordinary() = print("should not run")\n',
+        env,
+        filename=str(tmp_path / "ordinary.genia"),
+    )
+    captured = capsys.readouterr()
+
+    assert captured.out == ""
+    assert captured.err == ""
+    assert not hasattr(env, "_native_test_units")
+
+
 def test_formats_passing_suite_with_summary_before_and_after_results():
     report = _format_report(
         {


### PR DESCRIPTION
## Summary

Implements the R4 lifecycle annotation binding model as an internal Python reference-host helper.

This adds `src/genia/lifecycle_binding.py`, a small tested helper for discovering lifecycle participants from annotation metadata without executing them. The helper supports:

* exact annotation-name matching
* exact metadata filtering
* callable participant validation
* deterministic ordering:

  * `source_order`
  * `reverse_source_order`
  * `stable_name_order`
* required-binding diagnostics
* duplicate participant diagnostics
* unsupported-ordering errors
* binding results that select participants but never invoke them

Core lifecycle rule preserved:

```text
Annotations mark candidates.
Lifecycle phases decide what to run.
Annotations do not execute themselves.
```

## What changed

### Tests

Added focused contract tests for lifecycle annotation binding:

* optional binding with zero candidates
* required binding with zero candidates
* annotation name matching
* metadata filter include/exclude behavior
* callable participant acceptance/rejection
* deterministic ordering modes
* duplicate participant handling
* unsupported ordering behavior
* no participant execution during discovery

Added native-test regressions to confirm:

* non-`@test` metadata annotations are not discovered as native tests
* `@test` remains inert outside native test mode

### Implementation

Added:

* `src/genia/lifecycle_binding.py`

The implementation is intentionally internal and not wired into public runtime behavior. Native-test discovery was not refactored through this helper in this issue.

### Docs

Updated:

* `GENIA_STATE.md`
* `docs/architecture/lifecycle.md`

Docs now describe the helper as internal Python reference-host support only. They explicitly avoid claiming any public lifecycle execution behavior.

## What did not change

This PR does **not** add or change:

* parser behavior
* lexer behavior
* Core IR
* evaluator semantics
* CLI behavior
* native-test behavior
* lifecycle runner behavior
* lifecycle execution
* `@setup`
* `@teardown`
* module lifecycle hooks
* server lifecycle hooks
* actor lifecycle hooks
* REPL lifecycle hooks
* public Genia builtins
* prelude APIs
* import-time hook execution

No public user-facing lifecycle annotation API is introduced.

## Validation

Test phase:

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py -v
# expected red before implementation: 12 failed due to missing genia.lifecycle_binding
```

Implementation/doc validation:

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py -v
# 12 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py -v
# 19 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_plan.py tests/doc/test_lifecycle_architecture_doc.py
# 39 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py
# 85 passed

UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx ruff check src/genia/lifecycle_binding.py tests/unit/test_lifecycle_binding.py tests/unit/test_native_test_cli.py
# passed
```

Audit validation also passed:

```text
lifecycle_binding + native_test = 31 passed
lifecycle doc + semantic doc-sync + lifecycle_plan = 124 passed
ruff = all checks passed
```

Audit was run with system Python 3.10 and `PYTHONPATH=src` because the sandbox `.venv` was macOS-built and `uv` could not fetch a Python interpreter there. The audit reports this as equivalent to the prescribed focused `uv run` validations for this environment.

## Commits

```text
48b564e test(lifecycle): define annotation binding model issue #452
45413d9 feat(lifecycle): add annotation binding helper issue #452
1b2b0a1 docs(lifecycle): sync annotation binding helper issue #452
```

Audit produced no tracked commit because no patch was required and `06-audit.md` is ignored under `.genia/process/tmp/`.

## Audit

Final audit verdict: **PASS**

Audit found:

* 0 blockers
* 0 major issues
* 0 minor issues

Informational notes only:

* `reverse_source_order` reverses within source identity, which is deterministic and contract-compliant.
* participant-kind validation currently uses Python `callable()`; reconcile with Genia function-group callability only if/when native-test integration lands.
* `GENIA_STATE.md` says “Experimental” while handoffs used “Partial”; both are honest about non-public/non-executing status.

## Follow-ups

No blocking follow-ups.

Possible future work, not part of this PR:

* integrate this helper into native-test discovery only if it remains behavior-preserving
* define actual lifecycle runner behavior in a separate R4 issue
* define `@setup` / `@teardown` only in a later contract/test/implementation sequence
* clarify multi-source `reverse_source_order` semantics if future lifecycle phases need cross-source teardown ordering
 
closes #452 