### PR TITLE
Feature/issue 493 tooling ruff uv run

### DIFF
--- a/.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/04-implementation.md
@@ -1,0 +1,288 @@
+# === GENIA IMPLEMENTATION ===
+
+CHANGE NAME: issue #493 tooling-ruff-uv-run
+CHANGE SLUG: issue-493-tooling-ruff-uv-run
+ISSUE: #493
+BRANCH: feature/issue-493-tooling-ruff-uv-run
+
+## Branch
+
+Starting branch: feature/issue-493-tooling-ruff-uv-run
+Working branch: feature/issue-493-tooling-ruff-uv-run
+Branch status: Branch already existed; no branch creation was needed. The pre-existing untracked `ryan-holiday-book-club-list.md` file remained unstaged and untouched.
+
+## Scope
+
+What this phase changed: Added ruff to the existing project dev dependency group and changed CI linting from unmanaged `uvx ruff check .` to project-local `uv run ruff check .` after the existing `uv sync --dev` step.
+
+What this phase did not change: No Genia language syntax, parser behavior, evaluator behavior, Core IR, prelude behavior, Flow behavior, Outcome behavior, Sheets behavior, module/import behavior, native test behavior, shared spec behavior, ruff rules, broad lint cleanup, or broad formatting changed.
+
+## Inputs read
+
+- AGENTS.md
+- GENIA_STATE.md
+- GENIA_RULES.md
+- GENIA_REPL_README.md
+- README.md
+- 00-preflight.md
+- 01-contract.md
+- 02-design.md
+- 03-test.md
+- pyproject.toml
+- CI workflow file inspected/changed:
+  - .github/workflows/ci.yml
+
+## Failing evidence addressed
+
+Exact failing evidence from `03-test.md`:
+
+```text
+error: Failed to spawn: `ruff`
+  Caused by: No such file or directory (os error 2)
+```
+
+This phase addressed that by making `ruff` a project-managed dev dependency and validating that `uv run ruff check .` now resolves and runs ruff successfully.
+
+## Implementation summary
+
+Dependency changes: Added `"ruff>=0.8.0"` to the existing `[dependency-groups] dev = [...]` list in `pyproject.toml`.
+
+Lockfile changes: Ran `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv lock`. The repo has a local `uv.lock`, but `.gitignore` intentionally ignores it. The command resolved successfully with network access and reported `Added ruff v0.15.18`; no tracked lockfile diff exists because `uv.lock` is not tracked in `HEAD`.
+
+CI changes: Changed `.github/workflows/ci.yml` lint step from `uvx ruff check .` to `uv run ruff check .`. The workflow already runs `uv sync --dev` immediately before linting, so no additional sync step was needed.
+
+Docs/process changes, if any: None outside this implementation handoff.
+
+## Files changed
+
+Expected production/tooling files:
+
+- pyproject.toml
+- .github/workflows/ci.yml
+
+Expected handoff file:
+
+- .genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/04-implementation.md
+
+Local ignored file touched by tooling but not committed:
+
+- uv.lock
+
+Unrelated pre-existing untracked file not touched:
+
+- ryan-holiday-book-club-list.md
+
+## Commands run
+
+```bash
+git branch --show-current
+```
+
+Observed result:
+
+```text
+feature/issue-493-tooling-ruff-uv-run
+```
+
+```bash
+git status --short
+```
+
+Observed initial result:
+
+```text
+?? ryan-holiday-book-club-list.md
+```
+
+```bash
+grep -n "ruff" pyproject.toml || true
+```
+
+Observed pre-edit result:
+
+```text
+47:[tool.ruff]
+```
+
+```bash
+ls -l uv.lock
+```
+
+Observed result:
+
+```text
+-rw-r--r--@ 1 m0smith  staff  300895 Apr 28 12:40 uv.lock
+```
+
+```bash
+sed -n '1,90p' pyproject.toml
+```
+
+Observed pre-edit result: dev dependencies contained `mkdocs`, `mkdocs-material`, `pytest`, `pytest-cov`, and `pytest-xdist`; no `ruff` entry was present.
+
+```bash
+sed -n '45,65p' .github/workflows/ci.yml
+```
+
+Observed pre-edit result:
+
+```text
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Lint (ruff)
+        run: uvx ruff check .
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv lock
+```
+
+Observed sandbox result:
+
+```text
+error: Request failed after 3 retries in 3.6s
+  Caused by: Failed to fetch: `https://pypi.org/simple/pyyaml/`
+  Caused by: error sending request for url (https://pypi.org/simple/pyyaml/)
+  Caused by: client error (Connect)
+  Caused by: dns error
+  Caused by: failed to lookup address information: nodename nor servname provided, or not known
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv lock
+```
+
+Observed result with network access:
+
+```text
+Resolved 70 packages in 2.66s
+Added ruff v0.15.18
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run ruff check .
+```
+
+Observed sandbox result:
+
+```text
+× Failed to build `genia @ file:///Users/m0smith/projects/genia-2026`
+├─▶ Failed to resolve requirements from `build-system.requires`
+├─▶ No solution found when resolving: `hatchling`
+├─▶ Request failed after 3 retries in 9.0s
+├─▶ Failed to fetch: `https://pypi.org/simple/hatchling/`
+├─▶ error sending request for url (https://pypi.org/simple/hatchling/)
+├─▶ client error (Connect)
+├─▶ dns error
+╰─▶ failed to lookup address information: nodename nor servname provided, or
+    not known
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run ruff check .
+```
+
+Observed result with network access:
+
+```text
+All checks passed!
+```
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q
+```
+
+Observed result:
+
+```text
+8 failed, 2605 passed in 414.86s (0:06:54)
+```
+
+The 8 failures were all local socket-bind failures:
+
+```text
+PermissionError: [Errno 1] Operation not permitted
+```
+
+Affected tests:
+
+- tests/demo/test_ants_web_demo.py::test_ants_web_http_routes_serve_assets_and_state_updates
+- tests/unit/test_http_web.py::test_serve_http_plain_text_response
+- tests/unit/test_http_web.py::test_serve_http_json_response_and_request_body_parsing
+- tests/unit/test_http_web.py::test_serve_http_request_map_includes_client_and_raw_text_body
+- tests/unit/test_http_web.py::test_serve_http_json_body_parse_failure_stays_in_request_body_as_absence
+- tests/unit/test_http_web.py::test_serve_http_route_request_returns_not_found_response
+- tests/unit/test_http_web.py::test_serve_http_invalid_handler_result_returns_500
+- tests/unit/test_http_web.py::test_http_service_example_runs_health_endpoint
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_http_web.py tests/demo/test_ants_web_demo.py::test_ants_web_http_routes_serve_assets_and_state_updates
+```
+
+Observed result with local socket binding allowed:
+
+```text
+8 passed in 1.46s
+```
+
+```bash
+git diff --name-only
+```
+
+Observed result before handoff:
+
+```text
+.github/workflows/ci.yml
+pyproject.toml
+```
+
+```bash
+git status --short
+```
+
+Observed result before handoff:
+
+```text
+ M .github/workflows/ci.yml
+ M pyproject.toml
+?? ryan-holiday-book-club-list.md
+```
+
+```bash
+git check-ignore -v uv.lock .genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/04-implementation.md
+```
+
+Observed result:
+
+```text
+.gitignore:7:uv.lock	uv.lock
+.gitignore:83:.genia/process/tmp/	.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/04-implementation.md
+```
+
+## Validation
+
+Ruff validation: Passed with `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run ruff check .` after network access allowed uv to build/sync the local environment and install the project-managed ruff dependency.
+
+Pytest validation: Full `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q` produced `2605 passed` and 8 socket-bind failures under the sandbox. The exact failing HTTP/socket subset passed with local socket binding allowed: `8 passed in 1.46s`.
+
+Any limitations: Initial `uv lock` and `uv run ruff check .` attempts hit sandbox DNS/network limits. The full pytest run hit sandbox local socket binding limits for HTTP tests; the focused socket subset passed outside that limitation.
+
+## Runtime/language impact
+
+Confirm:
+
+- no parser changes
+- no evaluator changes
+- no Core IR changes
+- no runtime behavior changes
+- no Genia semantic docs changed
+
+## Follow-ups
+
+None.
+
+## Final verdict
+
+Ready for Docs Sync?
+YES

--- a/.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/06-doc-sync.md
+++ b/.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/06-doc-sync.md
@@ -1,0 +1,107 @@
+# === GENIA DOC SYNC ===
+
+CHANGE NAME: issue #493 tooling-ruff-uv-run
+CHANGE SLUG: issue-493-tooling-ruff-uv-run
+ISSUE: #493
+TYPE: feature
+BRANCH: feature/issue-493-tooling-ruff-uv-run
+
+Doc Sync output file:
+`.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/06-doc-sync.md`
+
+Starting branch: feature/issue-493-tooling-ruff-uv-run
+Working branch: feature/issue-493-tooling-ruff-uv-run
+Branch already existed or newly created: already existed
+
+---
+
+## 0. SUMMARY
+
+Docs Sync was expected to be a near no-op but was NOT. A repo-wide search for
+`ruff`/`uvx` references found two durable host docs that the Implementation
+phase did not catch (the implementation only touched `.github/workflows/ci.yml`).
+Both used the ephemeral `uvx ruff check .` form, which the Contract/Design
+phases require to be the project-managed `uv run ruff check .` form.
+
+Both were corrected in this phase.
+
+---
+
+## 1. FULL REFERENCE SWEEP
+
+Search command (excluding handoffs, `.venv`, site-packages):
+
+```bash
+grep -RIn "ruff\|uvx" . --include="*.md" --include="*.yml" --include="*.yaml" \
+  --include="*.toml" --include="*.cfg" --include="*.ini" \
+  | grep -v ".genia/process/tmp/handoffs" | grep -v "/.venv/" | grep -v "site-packages"
+```
+
+All ruff/uvx references in tracked, durable files:
+
+| File | Reference | State after this phase |
+|------|-----------|------------------------|
+| `pyproject.toml:18` | `"ruff>=0.8.0"` (dev dep) | correct — added in Implementation |
+| `pyproject.toml:48` | `[tool.ruff]` config | unchanged baseline — correct |
+| `.github/workflows/ci.yml:58` | `uv run ruff check .` | correct — fixed in Implementation |
+| `hosts/python/README.md:38` | `uvx ruff check .` → `uv run ruff check .` | **fixed in Doc Sync** |
+| `hosts/python/AGENTS.md:20` | `uvx ruff check .` → `uv run ruff check .` | **fixed in Doc Sync** |
+
+No `ruff`/lint references exist in top-level `README.md`, top-level `AGENTS.md`,
+`docs/process/*`, or `docs/ai/LLM_CONTRACT.md`.
+
+---
+
+## 2. CHANGES MADE IN THIS PHASE
+
+`hosts/python/README.md` — under "Known commands":
+
+```diff
+- - lint: `uvx ruff check .`
++ - lint: `uv run ruff check .`
+```
+
+`hosts/python/AGENTS.md` — under "Known local commands":
+
+```diff
+- - lint: `uvx ruff check .`
++ - lint: `uv run ruff check .`
+```
+
+Both are single-line command corrections inside existing command-reference
+lists. No prose, policy, tutorial, or philosophy content was added. No language
+or runtime docs were touched.
+
+---
+
+## 3. CONTRACT COMPLIANCE
+
+- Command spelling now consistent: every documented ruff invocation in the repo
+  uses `uv run ruff check .`. No bare `ruff` or `uvx ruff` remains as a
+  documented workflow.
+- No overclaiming wording introduced (ruff is not described as validating Genia
+  semantics, replacing pytest/specs, or guaranteeing correctness).
+- No durable language/runtime docs changed (`GENIA_STATE.md`, `GENIA_RULES.md`,
+  `GENIA_REPL_README.md`, `docs/book/*`, `docs/architecture/*`, `spec/*`
+  untouched).
+- Existing `[tool.ruff]` config preserved.
+
+---
+
+## 4. NOTES / FOLLOW-UPS
+
+- The Implementation handoff (`04-implementation.md`) claimed
+  `ryan-holiday-book-club-list.md` was "left untouched and unstaged." That file
+  no longer exists in the working tree (not committed, not ignored). Out of
+  issue scope, but the implementation report is now inaccurate on that point.
+- Implementation missed the two `hosts/python/` references because its search
+  scope was narrower than the full repo. Recommend the Audit phase re-run the
+  full sweep above to confirm no stragglers.
+- No other follow-ups.
+
+---
+
+## 5. VERDICT
+
+Docs Sync complete. Two durable host-doc references corrected to the
+project-managed `uv run ruff check .` form. Ready for Audit phase.

--- a/.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/07-audit.md
+++ b/.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/07-audit.md
@@ -1,0 +1,129 @@
+# === GENIA AUDIT ===
+
+CHANGE NAME: issue #493 tooling-ruff-uv-run
+CHANGE SLUG: issue-493-tooling-ruff-uv-run
+ISSUE: #493
+TYPE: feature
+BRANCH: feature/issue-493-tooling-ruff-uv-run
+
+Audit output file:
+`.genia/process/tmp/handoffs/issue-493-tooling-ruff-uv-run/07-audit.md`
+
+Starting branch: feature/issue-493-tooling-ruff-uv-run
+Working branch: feature/issue-493-tooling-ruff-uv-run
+Branch already existed or newly created: already existed
+
+---
+
+## 0. VERDICT
+
+**PASS WITH ISSUES** (issues are non-blocking and out of issue scope).
+
+The change satisfies the tooling contract: ruff is project-managed via the dev
+dependency group, and every documented ruff invocation uses `uv run ruff check .`.
+No language/runtime behavior changed. The "issues" are process/bookkeeping notes,
+not contract violations.
+
+---
+
+## 1. SCOPE OF AUDIT
+
+Audited the full branch diff against `main`
+(merge-base `74fd388`) across commits:
+
+- `fe4759e chore(tooling): run ruff through uv issue #493` (Implementation)
+- `69f0ac4 docs(tooling): use uv run ruff in host docs issue #493` (Doc Sync)
+
+Full changed file set (6 files):
+
+```
+.genia/.../04-implementation.md      (handoff)
+.genia/.../06-doc-sync.md            (handoff)
+.github/workflows/ci.yml
+hosts/python/AGENTS.md
+hosts/python/README.md
+pyproject.toml
+```
+
+No files under `src/`, `spec/`, `tests/`, `docs/book/`, `docs/architecture/`,
+`GENIA_STATE.md`, `GENIA_RULES.md`, or `GENIA_REPL_README.md` were touched.
+
+---
+
+## 2. CONTRACT CHECKS
+
+| Audit criterion | Result |
+|-----------------|--------|
+| `pyproject.toml` dependency state correct | PASS — `"ruff>=0.8.0"` added to existing `dev` group; lower-bound style matches sibling deps; no duplicate |
+| `[tool.ruff]` config preserved | PASS — config (`line-length = 100`, `target-version = "py312"`) not in diff |
+| Documented ruff command works | PASS (reported) — Implementation ran `uv run ruff check .` → passed |
+| Docs/scripts use `uv run ruff` where appropriate | PASS — ci.yml + both host docs converted from `uvx ruff` |
+| No bare/`uvx` ruff workflow remains | PASS — repo sweep shows only `uv run ruff check .` (3 occurrences); zero `uvx ruff` or bare `ruff check` left |
+| No language/runtime semantics changed | PASS — no runtime/spec/test/language-doc files in diff |
+| No unrelated formatting sweep | PASS — diff is 4 one-line edits + 1 dep line + 2 handoffs |
+| Test validation run and recorded | PASS — see §3 |
+| Broader lint/format/CI work parked | PASS — Implementation reported no follow-ups; Design parked format/CI-gate/cleanup/pre-commit as separate future issues |
+
+No overclaiming wording introduced anywhere (ruff is not described as validating
+Genia semantics, replacing pytest/specs, or guaranteeing correctness).
+
+---
+
+## 3. VALIDATION EVIDENCE
+
+Reported by the Implementation phase (run in a network-enabled environment):
+
+- `uv lock` succeeded; `Added ruff v0.15.18` (resolves the `>=0.8.0` constraint).
+- `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run ruff check .` — passed.
+- `uv run pytest -q` — `2605 passed`, with 8 sandbox socket-bind failures.
+- The 8 socket-dependent tests re-run with socket binding allowed — `8 passed in 1.46s`.
+
+Audit note on re-execution: this audit environment cannot independently re-run
+`uv run ...` because uv cannot provision the CPython 3.12 build-standalone
+(network egress to GitHub is blocked) and the local `.venv` points at a missing
+interpreter. Validation therefore relies on the Implementation phase's reported
+results, which are internally consistent and match the expected outcome. A clean
+re-run will occur in CI, where the `uv sync --dev` + `uv run ruff check .` steps
+now exercise the project-managed ruff.
+
+---
+
+## 4. NON-BLOCKING ISSUES
+
+1. **Handoff files are committed.** `04-implementation.md` and `06-doc-sync.md`
+   are tracked despite this change's handoff `README.md` saying handoffs "must
+   not be committed." This matches established repo precedent (handoffs for
+   issues #450/#451/#452 are tracked in HEAD via force-add) and the Distillation
+   phase is the designated step to decide keep/extract/delete. Flagged for
+   Distillation, not a contract failure.
+
+2. **Stale `04-implementation.md` claim.** It states
+   `ryan-holiday-book-club-list.md` was "left untouched and unstaged"; that file
+   no longer exists in the working tree. Out of issue scope and does not affect
+   the deliverable.
+
+3. **`uv.lock` not committed.** It is gitignored (`.gitignore:7`) and untracked,
+   so the added ruff dependency is not pinned in a committed lockfile. This is
+   consistent with the repo's existing convention (lock regenerated via
+   `uv lock` / `uv sync --dev` in CI), so it is acceptable here, but maintainers
+   should confirm the unpinned-lock convention is intended.
+
+---
+
+## 5. BLOCKING ISSUES
+
+None.
+
+- `uv run ruff check .` runs (ruff available via project env). ✔
+- No docs instruct an unmanaged bare `ruff`. ✔
+- No language/runtime behavior changed. ✔
+- No lint/format policy broadened. ✔
+- No tests fail due to this change. ✔
+
+---
+
+## 6. RECOMMENDATION
+
+Proceed to Distillation. Distillation should decide the disposition of the
+handoff files (`00`–`07`) per repo process and correct or drop the inaccurate
+`ryan-holiday` note in `04-implementation.md` if those files are retained.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv sync --dev
 
       - name: Lint (ruff)
-        run: uvx ruff check .
+        run: uv run ruff check .
 
       - name: Run tests
         run: uv run pytest -q -vv --maxfail=1 -m "not slow" -n auto

--- a/hosts/python/AGENTS.md
+++ b/hosts/python/AGENTS.md
@@ -17,7 +17,7 @@ Additional host-local rules:
 Known local commands:
 
 - setup: `uv sync --dev`
-- lint: `uvx ruff check .`
+- lint: `uv run ruff check .`
 - tests: `uv run pytest -q -vv --maxfail=1`
 - coverage: `uv run pytest --cov=genia --cov-report=term-missing`
 - run REPL: `python3 -m genia.interpreter`

--- a/hosts/python/README.md
+++ b/hosts/python/README.md
@@ -35,6 +35,6 @@ Known commands:
 - setup: `uv sync --dev`
 - run REPL: `python3 -m genia.interpreter`
 - run CLI entrypoint: `genia -c "1 + 2"`
-- lint: `uvx ruff check .`
+- lint: `uv run ruff check .`
 - tests: `uv run pytest -q -vv --maxfail=1`
 - tests with coverage: `uv run pytest --cov=genia --cov-report=term-missing`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
   "pytest>=8.0",
   "pytest-cov>=5.0",
   "pytest-xdist>=3.6.1",
+  "ruff>=0.8.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
Close #493 
This change makes Ruff run through Genia’s project-managed `uv` environment instead of relying on an unmanaged/global Ruff install.

Issue: #493

Changes:

* Added `ruff>=0.8.0` to the existing dev dependency group in `pyproject.toml`.
* Updated CI linting from `uvx ruff check .` to project-local `uv run ruff check .`.
* Updated Python host docs to document the project-managed Ruff command.
* Preserved the tooling-only scope: no Genia language/runtime behavior changed.

## Validation

Ran:

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run ruff check .
```

Result: passed.

Ran full pytest:

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q
```

Result: `2605 passed`, plus 8 sandbox socket-bind failures.

Reran the exact HTTP/socket subset with socket binding allowed:

```bash
# exact subset command from handoff
```

Result: `8 passed in 1.46s`.

## Notes for Review

* `uv.lock` exists locally but is gitignored and not tracked in `HEAD`, so the Ruff dependency is not pinned in a committed lockfile.
* The handoff pipeline completed through distillation. Distillation found nothing further to extract into canonical docs.
* One stale handoff note remains in `04-implementation.md`: it says `ryan-holiday-book-club-list.md` was left untouched, but that untracked file is now gone. This does not affect the production/tooling diff.

## Scope Guardrails

This PR does not change:

* Genia parser behavior
* evaluator behavior
* Core IR
* runtime semantics
* Flow/Outcome/Sheet behavior
* native test behavior
* shared spec behavior
