### PR TITLE
Feature/issue 490 r4 scope validator edge tests

### DIFF
--- a/.genia/process/tmp/handoffs/issue-490-r4-scope-validator-edge-tests/03-test.md
+++ b/.genia/process/tmp/handoffs/issue-490-r4-scope-validator-edge-tests/03-test.md
@@ -1,0 +1,165 @@
+# === GENIA TEST PHASE ===
+
+CHANGE NAME: issue #490 r4-scope-validator-edge-tests
+CHANGE SLUG: issue-490-r4-scope-validator-edge-tests
+ISSUE: #490
+TYPE: feature
+BRANCH: feature/issue-490-r4-scope-validator-edge-tests
+HANDOFF DIR: .genia/process/tmp/handoffs/issue-490-r4-scope-validator-edge-tests
+OUTPUT: .genia/process/tmp/handoffs/issue-490-r4-scope-validator-edge-tests/03-test.md
+
+GENIA_STATE.md is final authority.
+
+STOP: TEST phase only. Implementation has not begun.
+
+---
+
+## 0. BRANCH INFORMATION
+
+Starting branch:
+
+```text
+feature/issue-490-r4-scope-validator-edge-tests
+```
+
+Working branch:
+
+```text
+feature/issue-490-r4-scope-validator-edge-tests
+```
+
+Branch status:
+
+- Branch already existed.
+- Worktree was clean before TEST edits.
+- No work was performed on `main`.
+
+Process note:
+
+- The prompt named `docs/process/03-test.md`, but this branch has `docs/process/04-test.md`.
+- The repo's test-phase template names `03-failing-tests.md`; the user prompt explicitly requested this file, `03-test.md`.
+- The approved preflight/contract/design handoffs target lifecycle scope-tree validation in `tests/unit/test_lifecycle_scope.py`, not lifecycle-plan validation in `tests/unit/test_lifecycle_plan.py`. The plan test file was run only as nearby regression coverage.
+
+---
+
+## 1. SCOPE SUMMARY
+
+Added focused edge/regression coverage for the existing R4 lifecycle scope-tree validator.
+
+Covered approved issue #490 edge cases:
+
+- invalid root `description` type
+- invalid root `metadata` type
+- `parent = some(non-symbol)`
+- explicit unsupported `source` and `flow` scope names
+- non-root scope using `none` parent
+
+No production behavior was changed.
+
+---
+
+## 2. TESTS ADDED
+
+Updated:
+
+```text
+tests/unit/test_lifecycle_scope.py
+```
+
+Added/expanded tests:
+
+- `test_rejects_non_string_root_description`
+- `test_rejects_non_map_root_metadata`
+- `test_rejects_some_non_symbol_parent`
+- `test_rejects_unsupported_scope_names_with_supported_scope_hint` now includes `source` and `flow`
+- `test_rejects_non_root_scope_with_none_parent`
+
+The tests use existing helpers and assert deterministic path-specific diagnostics.
+
+---
+
+## 3. VALIDATION COMMANDS AND OUTPUT SUMMARY
+
+Initial sandbox attempt:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_scope.py -v
+```
+
+Result:
+
+```text
+Failed before test execution while resolving hatchling from PyPI due sandbox/network DNS failure.
+```
+
+Focused validation after dependency resolution:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_scope.py -v
+```
+
+Result:
+
+```text
+20 passed in 0.14s
+```
+
+Nearby lifecycle regression validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_plan.py tests/unit/test_lifecycle_scope.py -v
+```
+
+Result:
+
+```text
+52 passed in 0.23s
+```
+
+---
+
+## 4. FAILING EVIDENCE
+
+No implementation-gap failure remains.
+
+The new edge tests pass against current `src/genia/lifecycle_scope.py`, confirming the approved behavior was already implemented and only missing focused coverage.
+
+Transient test-authoring correction:
+
+- First real pytest run reported 2 failures in `test_rejects_some_non_symbol_parent`.
+- The validator produced the expected messages, but the test regex did not escape `some(string)` / `some(int)` parentheses.
+- The test assertion was corrected before committing.
+
+Final failing tests:
+
+```text
+None.
+```
+
+Expected phase interpretation:
+
+- This is acceptable under `02-design.md`, which states the TEST phase is expected to produce tests that already pass if the validator already implements all five behaviors.
+- Implementation phase should be a no-op unless the process requires a separate no-op handoff.
+
+---
+
+## 5. FILES CHANGED
+
+```text
+tests/unit/test_lifecycle_scope.py
+.genia/process/tmp/handoffs/issue-490-r4-scope-validator-edge-tests/03-test.md
+```
+
+No production code changed.
+No source-of-truth docs changed.
+No parser, Core IR, prelude, CLI, native-test runner, runtime, or host adapter code changed.
+
+---
+
+## 6. STOP MARKER
+
+STOP.
+
+TEST phase is complete.
+Implementation has not begun.
+Do not continue into implementation without an explicit implementation-phase prompt.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2412,7 +2412,7 @@ PYTHON REFERENCE HOST:
 - Input order of scope records is preserved by normalization; no implicit reordering occurs.
 - Callable values stored in optional `metadata` fields are not invoked during validation or normalization.
 - Implemented in `src/genia/lifecycle_scope.py`.
-- Validated by `tests/unit/test_lifecycle_scope.py` (9 tests), Python reference host only.
+- Validated by `tests/unit/test_lifecycle_scope.py` (13 tests), Python reference host only.
 
 Explicit limitations:
 - No lifecycle runner behavior is implemented.

--- a/tests/unit/test_lifecycle_scope.py
+++ b/tests/unit/test_lifecycle_scope.py
@@ -148,6 +148,36 @@ def test_rejects_invalid_root_shape_with_path_diagnostics():
         _assert_invalid(scope_tree, expected_message)
 
 
+@pytest.mark.parametrize(
+    ("bad_description", "type_name"),
+    [
+        (symbol("oops"), "symbol"),
+        ([], "list"),
+        (_record(), "map"),
+    ],
+)
+def test_rejects_non_string_root_description(bad_description, type_name):
+    _assert_invalid(
+        _canonical_scope_tree(description=bad_description),
+        rf"invalid lifecycle scope tree at scope_tree\.description: expected string, got {type_name}",
+    )
+
+
+@pytest.mark.parametrize(
+    ("bad_metadata", "type_name"),
+    [
+        ([], "list"),
+        (symbol("oops"), "symbol"),
+        ("owner", "string"),
+    ],
+)
+def test_rejects_non_map_root_metadata(bad_metadata, type_name):
+    _assert_invalid(
+        _canonical_scope_tree(metadata=bad_metadata),
+        rf"invalid lifecycle scope tree at scope_tree\.metadata: expected map, got {type_name}",
+    )
+
+
 def test_rejects_invalid_scope_record_shape_with_path_diagnostics():
     cases = [
         (
@@ -187,8 +217,39 @@ def test_rejects_invalid_scope_record_shape_with_path_diagnostics():
         _assert_invalid(_scope_tree([scope_record]), expected_message)
 
 
+@pytest.mark.parametrize(
+    ("bad_parent", "type_name_regex"),
+    [
+        (GeniaOptionSome("execution"), r"some\(string\)"),
+        (GeniaOptionSome(123), r"some\(int\)"),
+    ],
+)
+def test_rejects_some_non_symbol_parent(bad_parent, type_name_regex):
+    scope = _record(
+        name=symbol("execution"),
+        parent=bad_parent,
+        children=[symbol("suite")],
+    )
+
+    _assert_invalid(
+        _scope_tree([scope]),
+        rf"invalid lifecycle scope tree at scope_tree\.scopes\[0\]\.parent: "
+        rf"expected none or some\(identifier\), got {type_name_regex}",
+    )
+
+
 def test_rejects_unsupported_scope_names_with_supported_scope_hint():
-    unsupported_names = ["server", "actor", "plugin", "request", "resource", "browser", "notebook"]
+    unsupported_names = [
+        "server",
+        "actor",
+        "plugin",
+        "request",
+        "resource",
+        "browser",
+        "notebook",
+        "source",
+        "flow",
+    ]
     for unsupported_name in unsupported_names:
         tree = _scope_tree(
             [
@@ -271,3 +332,32 @@ def test_rejects_noncanonical_scope_hierarchy():
     ]
     for scope_tree, expected_message in cases:
         _assert_invalid(scope_tree, expected_message)
+
+
+@pytest.mark.parametrize(
+    ("scope_name", "index", "expected_parent", "children"),
+    [
+        ("suite", 1, "execution", ["module"]),
+        ("module", 2, "suite", ["test"]),
+        ("test", 3, "module", []),
+    ],
+)
+def test_rejects_non_root_scope_with_none_parent(
+    scope_name,
+    index,
+    expected_parent,
+    children,
+):
+    scopes = [
+        _scope("execution", OPTION_NONE, ["suite"]),
+        _scope("suite", GeniaOptionSome(symbol("execution")), ["module"]),
+        _scope("module", GeniaOptionSome(symbol("suite")), ["test"]),
+        _scope("test", GeniaOptionSome(symbol("module")), []),
+    ]
+    scopes[index] = _scope(scope_name, OPTION_NONE, children)
+
+    _assert_invalid(
+        _scope_tree(scopes),
+        rf"invalid lifecycle scope tree at scope_tree\.scopes\[{scope_name}\]\.parent: "
+        rf"expected parent {expected_parent}, got none",
+    )


### PR DESCRIPTION
## Summary

Adds focused R4 lifecycle scope-tree validator edge coverage for issue #490.

This hardens the existing `src/genia/lifecycle_scope.py` data-shape validator without changing production behavior. The new tests cover:

* invalid root `description` type
* invalid root `metadata` type
* `parent = some(non-symbol)`
* unsupported `source` and `flow` scope names
* non-root scope using `none` parent

The implementation phase was verified as a no-op because the validator already enforced the approved behavior. A minimal doc-sync commit updates the `GENIA_STATE.md` lifecycle scope-tree test count from 9 to 13.

## Validation

* `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_scope.py -v`

  * `20 passed`
* `UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_plan.py tests/unit/test_lifecycle_scope.py -v`

  * `52 passed`
* Doc suite

  * `128 passed`

## Notes

No production code changed.

No lifecycle runner, annotation execution, new syntax, parser/Core IR changes, Flow/CLI/REPL behavior, or host-adapter behavior was added.
Close #490 