### PR TITLE
Feature/issue 495 r4 lifecycle binding genia callability

### DIFF
--- a/.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/03-test.md
+++ b/.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/03-test.md
@@ -1,0 +1,125 @@
+# Test — issue #495 r4-lifecycle-binding-genia-callability
+
+CHANGE NAME: issue #495 r4-lifecycle-binding-genia-callability
+CHANGE SLUG: issue-495-r4-lifecycle-binding-genia-callability
+
+Handoff directory:
+
+```text
+.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/
+```
+
+Output file:
+
+```text
+.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/03-test.md
+```
+
+---
+
+## 0. BRANCH
+
+Starting branch:
+
+```text
+feature/issue-495-r4-lifecycle-binding-genia-callability
+```
+
+Working branch:
+
+```text
+feature/issue-495-r4-lifecycle-binding-genia-callability
+```
+
+Branch check passed before edits. Work was not done on `main`.
+
+---
+
+## 1. FILES CHANGED
+
+```text
+tests/unit/test_lifecycle_binding.py
+.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/03-test.md
+```
+
+No production implementation files were changed.
+
+---
+
+## 2. TESTS ADDED
+
+Updated `tests/unit/test_lifecycle_binding.py` with focused callable participant coverage:
+
+* `test_callable_participant_kind_accepts_genia_function_group_semantics`
+  * Uses a `NonCallableMock` with `spec=GeniaFunctionGroup` so it is recognized as a Genia function-group representation while failing raw Python `callable(...)`.
+  * Proves `participant_kind="callable"` must use Genia callable-participant semantics rather than only Python host callability.
+* `test_callable_participant_kind_accepts_genia_function_values`
+  * Constructs a minimal `GeniaFunction` with `IrVar("none")` and an empty `Env`.
+  * Proves direct Genia function values remain accepted as lifecycle callable participants.
+
+Existing tests continue to cover:
+
+* plain Python callable candidates accepted for internal compatibility
+* ordinary non-callable candidates rejected with the existing diagnostic shape
+* callable participant validation does not execute candidate values
+* ordering, metadata filters, duplicate diagnostics, required binding diagnostics, and invalid ordering behavior
+
+---
+
+## 3. EXPECTED FAILING TEST COMMAND
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py -v
+```
+
+Observed result:
+
+```text
+17 collected
+1 failed, 16 passed
+```
+
+Observed failing test:
+
+```text
+tests/unit/test_lifecycle_binding.py::test_callable_participant_kind_accepts_genia_function_group_semantics
+```
+
+Observed failing output summary:
+
+```text
+assert _participant_names(result) == ["setup"]
+E AssertionError: assert [] == ['setup']
+```
+
+Interpretation:
+
+* The candidate is `isinstance(function_group, GeniaFunctionGroup)`.
+* The candidate is not accepted because current lifecycle binding checks only raw Python `callable(candidate.value)`.
+* This is the intended red signal for the implementation phase.
+
+---
+
+## 4. NEARBY VALIDATION
+
+Command:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py tests/unit/test_native_test_kernel.py -v
+```
+
+Observed result:
+
+```text
+29 passed
+```
+
+Native-test behavior was not disturbed by the test-phase edit.
+
+---
+
+## 5. IMPLEMENTATION HANDOFF
+
+No production implementation was changed in this TEST phase.
+
+The implementation phase must reference the failing-test commit SHA from this TEST-phase commit before changing `src/genia/lifecycle_binding.py`.

--- a/.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/04-implementation.md
@@ -1,0 +1,188 @@
+# Implementation — issue #495 r4-lifecycle-binding-genia-callability
+
+CHANGE NAME: issue #495 r4-lifecycle-binding-genia-callability
+CHANGE SLUG: issue-495-r4-lifecycle-binding-genia-callability
+
+Handoff directory:
+
+```text
+.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/
+```
+
+Output file:
+
+```text
+.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/04-implementation.md
+```
+
+---
+
+## 0. BRANCH
+
+Starting branch:
+
+```text
+feature/issue-495-r4-lifecycle-binding-genia-callability
+```
+
+Working branch:
+
+```text
+feature/issue-495-r4-lifecycle-binding-genia-callability
+```
+
+Branch check passed before edits. Work was not done on `main`.
+
+---
+
+## 1. FAILING-TEST ANCHOR
+
+Referenced failing-test commit:
+
+```text
+3d5429a
+```
+
+Anchor verification:
+
+```bash
+git show --stat --oneline 3d5429a
+```
+
+Observed summary:
+
+```text
+3d5429a test(lifecycle): capture Genia callable participants issue #495
+2 files changed, 170 insertions(+)
+```
+
+Focused pre-implementation check:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py -v
+```
+
+Observed starting result:
+
+```text
+1 failed, 16 passed
+```
+
+Observed failing test:
+
+```text
+tests/unit/test_lifecycle_binding.py::test_callable_participant_kind_accepts_genia_function_group_semantics
+```
+
+The failure was the intended Genia callable-participant red state: a `GeniaFunctionGroup`-shaped value that is not raw Python-callable was rejected by lifecycle binding.
+
+---
+
+## 2. FILES CHANGED
+
+```text
+src/genia/lifecycle_binding.py
+.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/04-implementation.md
+```
+
+No tests were modified in this implementation phase.
+
+---
+
+## 3. IMPLEMENTATION SUMMARY
+
+Implemented the smallest production change in `src/genia/lifecycle_binding.py`:
+
+* imported `GeniaFunction` and `GeniaFunctionGroup` from `genia.callable`
+* added internal helper `_is_lifecycle_callable_participant(value) -> bool`
+* delegated the existing `participant_kind == "callable"` branch to that helper
+
+The helper accepts:
+
+* `GeniaFunctionGroup`
+* `GeniaFunction`
+* plain Python callables for existing internal compatibility
+
+All non-`"callable"` participant kinds preserve the previous behavior.
+
+Callable validation does not execute candidate values. It only performs `isinstance(...)` checks and the existing Python `callable(...)` compatibility check.
+
+Native-test behavior was not changed. No native-test discovery integration was added.
+
+---
+
+## 4. DOCUMENTATION DECISION
+
+No source-of-truth docs were changed.
+
+Reason:
+
+* This is internal lifecycle binding hardening only.
+* No public lifecycle behavior was introduced.
+* No parser, lexer, Core IR, prelude, builtin, CLI, native-test, or user-visible lifecycle behavior changed.
+
+---
+
+## 5. VALIDATION
+
+Focused lifecycle binding validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py -v
+```
+
+Observed result:
+
+```text
+17 passed
+```
+
+Nearby native-test validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_cli.py tests/unit/test_native_test_kernel.py -v
+```
+
+Observed result:
+
+```text
+29 passed
+```
+
+Optional nearby lifecycle validation:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_plan.py tests/unit/test_lifecycle_binding.py -v
+```
+
+Observed result:
+
+```text
+52 passed
+```
+
+---
+
+## 6. IMPLEMENTATION COMMIT
+
+Implementation commit SHA:
+
+```text
+See `git show --oneline HEAD` after commit creation.
+```
+
+Note: the final commit SHA cannot be embedded literally inside the same committed file without changing that commit's SHA. The final implementation commit SHA is reported by `git show --oneline HEAD` after the commit is created.
+
+Commit message:
+
+```text
+fix(lifecycle): align callable participant validation issue #495
+```
+
+---
+
+## 7. REMAINING FOLLOW-UPS
+
+None for this implementation phase.
+
+Do not proceed to doc-sync, audit, PR, or cleanup from this phase.

--- a/.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/05-doc-sync.md
+++ b/.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/05-doc-sync.md
@@ -1,0 +1,222 @@
+# Doc Sync — issue #495 r4-lifecycle-binding-genia-callability
+
+CHANGE NAME: issue #495 r4-lifecycle-binding-genia-callability
+CHANGE SLUG: issue-495-r4-lifecycle-binding-genia-callability
+ISSUE: #495
+PHASE: DOC-SYNC
+
+Output file:
+
+```text
+.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/05-doc-sync.md
+```
+
+---
+
+## 0. BRANCH
+
+Starting branch:
+
+```text
+feature/issue-495-r4-lifecycle-binding-genia-callability
+```
+
+Working branch:
+
+```text
+feature/issue-495-r4-lifecycle-binding-genia-callability
+```
+
+Branch check passed (matches the required branch exactly). No work on `main`. No merge. No rebase.
+
+---
+
+## 1. ANCHORS
+
+Implementation commit verified: `89c6ede`
+
+```text
+89c6ede fix(lifecycle): align callable participant validation issue #495
+ .../04-implementation.md             | 188 +++++++++++++++++++++
+ src/genia/lifecycle_binding.py       |   7 +-
+ 2 files changed, 194 insertions(+), 1 deletion(-)
+```
+
+Failing-test commit referenced: `3d5429a`
+
+```text
+3d5429a test(lifecycle): capture Genia callable participants issue #495
+ .../03-test.md                         | 125 +++++++++++++++++++++
+ tests/unit/test_lifecycle_binding.py   |  45 ++++++++
+ 2 files changed, 170 insertions(+)
+```
+
+### Working-tree note
+
+`git status --short` before doc-sync work showed only one untracked entry:
+
+```text
+?? .claude/settings.local.json
+```
+
+This is a session/tooling local settings file (not git-ignored, not part of issue
+#495, no tracked source/doc modifications). No tracked working-tree changes existed
+prior to doc-sync. It was NOT staged or committed in this phase. Proceeded on this
+basis.
+
+---
+
+## 2. IMPLEMENTATION DIFF REVIEWED
+
+`git show -- src/genia/lifecycle_binding.py` (commit `89c6ede`):
+
+- Imported `GeniaFunction` and `GeniaFunctionGroup` from `genia.callable`.
+- The `participant_kind == "callable"` branch now delegates to a new internal
+  helper `_is_lifecycle_callable_participant(value)`.
+- The helper accepts `GeniaFunctionGroup`, `GeniaFunction`, or any plain Python
+  `callable(...)`.
+
+Nature of change: internal hardening of lifecycle-binding callable-participant
+recognition so `participant_kind="callable"` recognizes Genia runtime callable
+representations in addition to raw Python callables. Validation performs only
+`isinstance(...)` / `callable(...)` checks; it does not execute participant values.
+No parser, lexer, Core IR, evaluator, prelude, builtin, CLI, native-test, or
+user-visible lifecycle behavior changed.
+
+---
+
+## 3. FILES REVIEWED
+
+Repository rule / state docs:
+
+- `AGENTS.md`
+- `GENIA_STATE.md` (final authority) — esp. §9.5 lifecycle annotation binding helper
+- `GENIA_RULES.md`
+- `GENIA_REPL_README.md`
+- `README.md`
+
+Strategy / process docs:
+
+- `docs/strategy/killer-workflow.md`
+- `docs/strategy/release-roadmap.md`
+- `docs/architecture/lifecycle.md` (§ lifecycle annotation binding discovery)
+
+Handoff docs:
+
+- `00-preflight.md`, `01-contract.md`, `02-design.md`, `03-test.md`,
+  `04-implementation.md`
+
+Source/tests:
+
+- `src/genia/lifecycle_binding.py` (diff at `89c6ede`)
+- `tests/unit/test_lifecycle_binding.py`
+
+---
+
+## 4. DOCS SEARCHED
+
+```bash
+grep -RIn "lifecycle binding|callable participant|participant_kind|setup|teardown|@test|native test|native-test" \
+  GENIA_STATE.md GENIA_RULES.md GENIA_REPL_README.md README.md docs
+```
+
+Relevant authoritative statements located and checked:
+
+- `GENIA_STATE.md` §9.5 LANGUAGE CONTRACT (lines ~2432–2441) and PYTHON REFERENCE
+  HOST (lines ~2443–2448): describe binding selection "by annotation name, exact
+  metadata filters, participant kind, and deterministic ordering" and "callable
+  participant validation … without executing participant values."
+- `docs/architecture/lifecycle.md` (line ~156): describes `discover_lifecycle_participants(...)`
+  including "callable participant validation."
+- `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`: only `@test` /
+  native-test surfaces; no lifecycle-binding callable-participant statements.
+
+---
+
+## 5. DOCUMENTATION DECISION
+
+Public-behavior contract statements are NOT stale:
+
+- The §9.5 phrase "callable participant validation" and the architecture-doc
+  description remain accurate. Neither claims the mechanism is restricted to raw
+  Python callables, and #495 does not expose lifecycle binding as public language
+  behavior. No contract statement required change.
+- No `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`, or `docs/book/*`
+  statement was made stale. The change adds no setup/teardown, no `@setup`/`@teardown`,
+  no native-test integration, and no native-test CLI/user behavior change.
+
+One stale factual statement WAS found and corrected (smallest accurate update):
+
+- `GENIA_STATE.md` §9.5 stated `tests/unit/test_lifecycle_binding.py` had
+  `(15 tests)`. The failing-test commit `3d5429a` (part of #495) added two
+  tests (`test_callable_participant_kind_accepts_genia_function_group_semantics`,
+  `test_callable_participant_kind_accepts_genia_function_values`), bringing the
+  file to 17 tests. Verified: parent of `3d5429a` = 15 `def test_`, `3d5429a` = 17.
+  Updated `(15 tests)` → `(17 tests)`. This follows the repo convention of keeping
+  exact validation counts accurate (cf. §9.2 "(17 tests)", "(20 tests)") and does
+  not expand R4 scope, document internal helper behavior as public, or add
+  speculative docs.
+
+No other doc changes made.
+
+---
+
+## 6. FILES CHANGED
+
+```text
+GENIA_STATE.md                                                     (15 -> 17 test count, §9.5)
+.genia/process/tmp/handoffs/.../05-doc-sync.md                     (this handoff)
+```
+
+---
+
+## 7. VALIDATION
+
+Environment note: the documented `uv run pytest` invocation could not run here —
+the repo `.venv` is linked to a missing `python@3.12` interpreter and `uv`'s
+attempt to download a standalone CPython was blocked by network restrictions.
+Validation was instead run in an equivalent clean venv (system CPython 3.10.12,
+which satisfies `requires-python >=3.8`) with `pytest` + `PyYAML` and the package
+installed editable (`pip install -e .`). Same test files, same source.
+
+Focused implementation validation:
+
+```bash
+python -m pytest -q tests/unit/test_lifecycle_binding.py
+# -> 17 passed
+```
+
+Nearby validation:
+
+```bash
+python -m pytest -q tests/unit/test_native_test_cli.py tests/unit/test_native_test_kernel.py
+# -> 29 passed
+```
+
+Doc validation (a doc file changed, so doc tests were run):
+
+```bash
+python -m pytest -q tests/doc/test_semantic_doc_sync.py
+# -> 85 passed
+```
+
+All validation passed.
+
+---
+
+## 8. DOC-SYNC COMMIT
+
+Commit message:
+
+```text
+docs(lifecycle): sync callable participant docs issue #495
+```
+
+Commit SHA: reported by `git show --oneline HEAD` after commit creation (the SHA
+cannot be embedded inside the file it commits without changing that SHA).
+
+---
+
+## 9. REMAINING FOLLOW-UPS
+
+None. Stopped after the doc-sync commit. Did not proceed to audit, PR, or cleanup.

--- a/.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/06-audit.md
+++ b/.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/06-audit.md
@@ -1,0 +1,238 @@
+# Audit — issue #495 r4-lifecycle-binding-genia-callability
+
+CHANGE NAME: issue #495 r4-lifecycle-binding-genia-callability
+ISSUE: #495
+PHASE: AUDIT (assume wrong until proven correct)
+
+Output file:
+
+```text
+.genia/process/tmp/handoffs/issue-495-r4-lifecycle-binding-genia-callability/06-audit.md
+```
+
+---
+
+## 0. BRANCH
+
+Starting branch: `feature/issue-495-r4-lifecycle-binding-genia-callability`
+Working branch:  `feature/issue-495-r4-lifecycle-binding-genia-callability`
+
+Branch matches exactly. No work on `main`. No merge. No rebase.
+
+`git status --short` shows only the untracked tooling file `?? .claude/settings.local.json`
+(ignored per instructions, not committed). No unrelated tracked changes.
+
+`git diff --name-only main..HEAD`:
+
+```text
+.genia/process/tmp/handoffs/.../03-test.md
+.genia/process/tmp/handoffs/.../04-implementation.md
+.genia/process/tmp/handoffs/.../05-doc-sync.md
+GENIA_STATE.md
+src/genia/lifecycle_binding.py
+tests/unit/test_lifecycle_binding.py
+```
+
+All tracked changes are in-scope for #495.
+
+---
+
+## 1. COMMITS REVIEWED
+
+```text
+3d5429a test(lifecycle): capture Genia callable participants issue #495
+89c6ede fix(lifecycle): align callable participant validation issue #495
+2fe22bd docs(lifecycle): sync callable participant docs issue #495
+```
+
+Note (informational, not a defect): the audit prompt referred to `2fe22bd` as
+"docs(lifecycle): record doc sync decision issue #495". The actual message is
+"docs(lifecycle): sync callable participant docs issue #495". This is correct: the
+doc-sync prompt specified the "sync callable participant docs" message precisely when
+a source-of-truth doc changes, and a source doc (GENIA_STATE.md) did change.
+
+---
+
+## 2. FILES REVIEWED
+
+- `src/genia/lifecycle_binding.py` (diff + lines 160–197)
+- `tests/unit/test_lifecycle_binding.py` (new tests in `3d5429a`)
+- `src/genia/callable.py` (`GeniaFunctionGroup`, `GeniaFunction`, their `__call__`)
+- `src/genia/test_kernel.py` (unchanged — not in diff)
+- `GENIA_STATE.md` §9.5, `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md`,
+  `docs/architecture/lifecycle.md`
+- Handoffs `00`–`05`
+
+---
+
+## 3. SUMMARY VERDICT
+
+**PASS** — ready to merge: **YES**
+
+The change is a minimal, correct, internal hardening of lifecycle-binding
+callable-participant recognition. Tests pin the intended contract and catch
+regression to host-only `callable()` semantics. Docs remain accurate; the only doc
+change is a correct test-count update.
+
+---
+
+## 4. CONTRACT ↔ IMPLEMENTATION FINDINGS
+
+The decision point is `_participant_kind_matches` → `_is_lifecycle_callable_participant`:
+
+```python
+def _is_lifecycle_callable_participant(value: Any) -> bool:
+    return isinstance(value, (GeniaFunctionGroup, GeniaFunction)) or callable(value)
+```
+
+- ✅ `participant_kind="callable"` no longer relies only on raw Python `callable()`;
+  it first checks the Genia runtime callable types by `isinstance`.
+- ✅ Accepts `GeniaFunctionGroup` (isinstance branch).
+- ✅ Accepts `GeniaFunction` (isinstance branch).
+- ✅ Plain Python callables remain accepted (`or callable(value)`).
+- ✅ Ordinary non-callable values remain rejected (e.g. `int 1` → both checks False).
+  The rejection diagnostic at `lifecycle_binding.py:102`
+  (`for @<name> expected callable, ...`) is unchanged.
+- ✅ Validation does not execute candidates — only `isinstance(...)` / `callable(...)`
+  introspection; no call is made.
+- ✅ Filtering (`_annotation_matches`), ordering (`_validate_ordering`/`_order_key`),
+  duplicate diagnostics, and required-binding diagnostics are untouched by the diff.
+- ✅ No native-test discovery integration added; `discover_lifecycle_participants`
+  is not wired into the native-test path.
+- ✅ No lifecycle runner / phase execution / setup / teardown added.
+- ✅ No parser, lexer, Core IR, prelude, or public builtin change (diff touches only
+  `lifecycle_binding.py` + tests + GENIA_STATE.md).
+- ✅ Native-test CLI/kernel behavior unchanged (`test_kernel.py` not in diff;
+  native-test test suites pass — see §7).
+
+Observation: both `GeniaFunctionGroup` and `GeniaFunction` define `__call__`
+(callable.py:235, 276), so real instances are already Python-callable. The change is
+therefore type-intent hardening: the binding now decides on the Genia callable *type*
+rather than the host `__call__` protocol, so a Genia callable representation that does
+not expose `__call__` is still accepted. This is exactly what the design intended.
+
+---
+
+## 5. DESIGN ↔ IMPLEMENTATION FINDINGS
+
+- ✅ Matches `04-implementation.md`: single import added, one internal helper added,
+  the `"callable"` branch delegates to it; "smallest production change".
+- ✅ Scope discipline held — no scope creep into runner/lifecycle/native-test surfaces
+  as committed in `01-contract.md` / `02-design.md`.
+
+---
+
+## 6. TESTS ↔ CONTRACT FINDINGS
+
+New tests (`3d5429a`):
+
+- `test_callable_participant_kind_accepts_genia_function_group_semantics`: uses
+  `NonCallableMock(spec=GeniaFunctionGroup)` and asserts `not callable(function_group)`
+  AND `isinstance(..., GeniaFunctionGroup)`, then that the participant is bound with no
+  diagnostics. This is the meaningful regression guard: it pins acceptance via type,
+  not via `callable()`.
+- `test_callable_participant_kind_accepts_genia_function_values`: builds a real
+  `GeniaFunction` and asserts it binds with no diagnostics.
+
+Red/green verification (run in the clean 3.10 venv; see §7 for environment):
+
+- Current implementation: both tests PASS.
+- Simulated pre-implementation (decision point forced back to raw `callable()`):
+  the group-semantics test **FAILS** (assertion), the function test still passes
+  (real `GeniaFunction` has `__call__`). This reproduces `04-implementation.md`'s
+  observed pre-impl state ("1 failed, 16 passed") and proves the suite catches
+  regression to host-only `callable()` semantics.
+
+- ✅ Tests assert concrete behavior (participant names, value identity, empty
+  diagnostics) — not implementation trivia.
+- ✅ Existing lifecycle binding tests still cover ordering, filters, duplicate
+  diagnostics, required bindings, and the non-callable rejection diagnostic (17 tests
+  total, all pass).
+
+---
+
+## 7. VALIDATION ENVIRONMENT + COMMANDS/RESULTS
+
+Environment acceptability decision: **ACCEPTABLE.**
+
+`05-doc-sync.md` documented that `uv run pytest` could not execute because the repo
+`.venv` points to a missing `python@3.12` and uv's standalone-interpreter download is
+network-blocked. Confirmed again here — `uv run pytest` fails at cache/interpreter
+initialization. Per `pyproject.toml`, `requires-python = ">=3.8"` and the only runtime
+dependency is `PyYAML`, so running on system CPython 3.10.12 with `pytest` + `PyYAML`
+and an editable install is a faithful equivalent. No version-specific behavior is
+exercised by these tests. This is acceptable for audit; no fix required.
+
+uv attempt (still blocked):
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_lifecycle_binding.py
+# -> error: Failed to initialize cache / interpreter download blocked
+```
+
+Clean venv used (system CPython 3.10.12):
+
+```bash
+python3 -m venv /tmp/genvenv
+/tmp/genvenv/bin/pip install pytest pyyaml
+/tmp/genvenv/bin/pip install -e .
+```
+
+Results:
+
+```bash
+/tmp/genvenv/bin/python -m pytest -q tests/unit/test_lifecycle_binding.py
+# -> 17 passed
+
+/tmp/genvenv/bin/python -m pytest -q tests/unit/test_native_test_cli.py tests/unit/test_native_test_kernel.py
+# -> 29 passed
+
+/tmp/genvenv/bin/python -m pytest -q tests/doc/test_semantic_doc_sync.py
+# -> 85 passed
+```
+
+Red/green check script (monkeypatching the decision point to raw `callable()`):
+
+```text
+CURRENT IMPL (89c6ede):              group-semantics PASS, function-values PASS
+SIMULATED PRE-IMPL (raw callable()): group-semantics FAIL,  function-values PASS
+```
+
+---
+
+## 8. DOCS ↔ BEHAVIOR FINDINGS
+
+- ✅ `GENIA_STATE.md` §9.5 test count for `test_lifecycle_binding.py` correctly
+  updated 15 → 17 (verified: parent of `3d5429a` = 15 `def test_`, HEAD = 17). The
+  `2fe22bd` diff is exactly that one line.
+- ✅ No doc implies public/user-facing lifecycle binding behavior (§9.5 keeps
+  "Python reference host, Experimental", "No public Genia lifecycle annotation binding
+  API was added").
+- ✅ No doc implies setup/teardown is implemented (explicit limitations intact).
+- ✅ No doc implies native-test discovery is integrated with lifecycle binding
+  (§9.5: "Native test discovery remains owned by the existing native test CLI/test-mode
+  layer; it was not refactored to use this helper").
+- ✅ `GENIA_RULES.md`, `GENIA_REPL_README.md`, `README.md` unchanged and accurate
+  (no lifecycle-binding callable-participant claims).
+- ✅ `docs/architecture/lifecycle.md` describes "callable participant validation"
+  without restricting it to Python callables — remains accurate; not stale.
+
+---
+
+## 9. ISSUES FOUND
+
+None of severity ≥ low affecting correctness, scope, or docs.
+
+Informational only:
+- Commit message of `2fe22bd` differs from the string in the audit prompt; the actual
+  message is the doc-sync-prescribed one for a source-doc change. No action.
+
+No code or doc fixes required.
+
+---
+
+## 10. FINAL VERDICT
+
+PASS WITH NO ISSUES. Ready to merge: **YES**.
+
+Stopping after the audit commit. Not proceeding to PR, cleanup, distillation, or merge.

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2445,7 +2445,7 @@ PYTHON REFERENCE HOST:
 - Provides internal dataclasses and `discover_lifecycle_participants(...)` for phase-owned annotation binding discovery.
 - The helper supports annotation-name matching, exact metadata filtering, callable participant validation, deterministic ordering, duplicate diagnostics, required-binding diagnostics, and binding results without executing participant values.
 - `LifecycleAnnotationBinding.ordering` defaults to `source_order` when omitted. Ordering values are validated through a centralized `_validate_ordering(...)` check that rejects non-string values and unsupported labels with deterministic `binding.ordering` diagnostics; the ordering value is preserved in the normalized binding result data.
-- Validated by `tests/unit/test_lifecycle_binding.py` (15 tests), Python reference host only.
+- Validated by `tests/unit/test_lifecycle_binding.py` (17 tests), Python reference host only.
 
 Explicit limitations:
 - No lifecycle runner behavior is implemented.

--- a/src/genia/lifecycle_binding.py
+++ b/src/genia/lifecycle_binding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from .callable import GeniaFunction, GeniaFunctionGroup
 from .values import _runtime_type_name
 
 
@@ -173,8 +174,12 @@ def _participant_kind_matches(
     candidate: AnnotationCandidate,
 ) -> bool:
     if binding.participant_kind == "callable":
-        return callable(candidate.value)
+        return _is_lifecycle_callable_participant(candidate.value)
     return True
+
+
+def _is_lifecycle_callable_participant(value: Any) -> bool:
+    return isinstance(value, (GeniaFunctionGroup, GeniaFunction)) or callable(value)
 
 
 def _validate_ordering(ordering: Any) -> str:

--- a/tests/unit/test_lifecycle_binding.py
+++ b/tests/unit/test_lifecycle_binding.py
@@ -1,4 +1,5 @@
 import importlib
+from unittest.mock import NonCallableMock
 
 import pytest
 
@@ -65,6 +66,20 @@ def _participant_names(result):
 
 def _diagnostic_reasons(result):
     return [diagnostic.reason for diagnostic in result.diagnostics]
+
+
+def _genia_function(name="setup"):
+    callable_mod = importlib.import_module("genia.callable")
+    environment_mod = importlib.import_module("genia.environment")
+    ir_mod = importlib.import_module("genia.ir")
+    return callable_mod.GeniaFunction(
+        name=name,
+        params=[],
+        rest_param=None,
+        docstring=None,
+        body=ir_mod.IrVar("none"),
+        closure=environment_mod.Env(),
+    )
 
 
 def test_optional_binding_with_zero_candidates_succeeds_without_diagnostics():
@@ -150,6 +165,36 @@ def test_callable_participant_kind_accepts_callable_values():
 
     assert _participant_names(result) == ["setup"]
     assert result.participants[0].value is setup
+    assert result.diagnostics == []
+
+
+def test_callable_participant_kind_accepts_genia_function_group_semantics():
+    callable_mod = importlib.import_module("genia.callable")
+    function_group = NonCallableMock(spec=callable_mod.GeniaFunctionGroup)
+    function_group.name = "setup"
+
+    result = _discover(
+        _binding(participant_kind="callable"),
+        [_candidate("setup", function_group, [_annotation("setup")])],
+    )
+
+    assert isinstance(function_group, callable_mod.GeniaFunctionGroup)
+    assert not callable(function_group)
+    assert _participant_names(result) == ["setup"]
+    assert result.participants[0].value is function_group
+    assert result.diagnostics == []
+
+
+def test_callable_participant_kind_accepts_genia_function_values():
+    function = _genia_function()
+
+    result = _discover(
+        _binding(participant_kind="callable"),
+        [_candidate("setup", function, [_annotation("setup")])],
+    )
+
+    assert _participant_names(result) == ["setup"]
+    assert result.participants[0].value is function
     assert result.diagnostics == []
 
 


### PR DESCRIPTION
## Summary

Close #495 

Implements issue #495 by aligning internal lifecycle annotation binding callable participant validation with Genia callable representations.

`participant_kind="callable"` now uses an explicit internal lifecycle callable-participant predicate instead of relying only on raw Python `callable()` semantics. The predicate accepts:

* `GeniaFunction`
* `GeniaFunctionGroup`
* plain Python callables for existing internal compatibility

This remains internal lifecycle-binding hardening only. It does not add lifecycle execution, setup/teardown, native-test discovery integration, parser/IR behavior, public builtins, or user-facing lifecycle behavior.

## Changes

* Added explicit internal callable-participant validation in `src/genia/lifecycle_binding.py`.
* Added regression tests proving Genia callable participant intent, including the important `NonCallableMock(spec=GeniaFunctionGroup)` guard against falling back to raw `callable()`.
* Updated `GENIA_STATE.md` test count for `tests/unit/test_lifecycle_binding.py` from 15 to 17.
* Added handoff records for test, implementation, doc-sync, and audit phases.

## Validation

Because `uv run pytest` was blocked in this environment by a missing python@3.12 and network-blocked interpreter download, validation was run in a clean Python 3.10 venv. The project requires Python `>=3.8`, and the alternate validation environment is documented in the handoffs.

Passing validation:

```bash
tests/unit/test_lifecycle_binding.py
# 17 passed
```

```bash
tests/unit/test_native_test_cli.py tests/unit/test_native_test_kernel.py
# 29 passed
```

```bash
tests/doc/test_semantic_doc_sync.py
# 85 passed
```

Audit verdict:

```text
PASS — ready to merge: YES
```

## Commit anchors

```text
Failing tests:  3d5429a
Implementation: 89c6ede
Doc sync:       2fe22bd
Audit:          36cfe90
```
