### PR TITLE
docs(roadmap): promote R5 after R4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,17 +40,16 @@ When sources conflict, resolve in this order:
 6. `docs/host-interop/*`
 7. `docs/architecture/*`
 8. implementation (`src/*`, `hosts/*`)
-9. `docs/process/run-change.md` 
+9. `docs/process/run-change.md`
 
 Rules:
 - Tests must reflect actual behavior
 - Implementation must match STATE + RULES
 - Docs must describe ONLY what is implemented
 - Cross-doc semantic guardrails live in `docs/contract/semantic_facts.json` and `tests/doc/test_semantic_doc_sync.py`
-“Contract” defines behavior only.
-It MUST NOT include tests.
+- “Contract” defines behavior only. It MUST NOT include tests.
+- Shared spec YAML files and pytest tests belong to the TEST phase.
 
-Shared spec YAML files and pytest tests belong to the TEST phase.
 ---
 
 # 🚫 NON-AUTHORITATIVE SOURCES
@@ -118,6 +117,7 @@ Banned certainty phrases in docs unless narrowly evidenced:
 * `no drift`
 
 ---
+
 ## Cross-Tool Instruction Sync
 
 Shared cross-tool LLM guidance lives in `docs/ai/LLM_CONTRACT.md`.
@@ -148,13 +148,13 @@ Before proposing or implementing new feature work, read:
 Before creating new issues/tickets, also read:
 - `docs/process/08-roadmap-ticketing.md`
 
-**Current active release: R4 — Lifecycle Generalization.**
-R3 (Native Test Expansion Wave 1) is complete. When asked for new Genia work with no release specified, classify work against R4 first. If it is not R4 lifecycle work, mark it as non-R4 and defer or park it unless the user explicitly asked for it. See `docs/strategy/release-roadmap.md` and `docs/ai/LLM_CONTRACT.md` for full R4 scope and agent guidance.
+**Current active release: R5 — Native Test Migration / Genia-Facing Coverage Wave 1.**
+R4 (Lifecycle Generalization) is complete. When asked for new Genia work with no release specified, classify work against R5 first. If it is not native-test migration or Genia-facing coverage work, mark it as non-R5 and defer, park, or classify it to R6 unless the user explicitly asked for it. See `docs/strategy/release-roadmap.md` and `docs/ai/LLM_CONTRACT.md` for full R5 scope and agent guidance.
 
 Prefer work that strengthens Genia's first killer workflow:
 **Outcome-aware validated data pipelines.**
 
-```
+```text
 messy records in → clear pipelines → validated shaped output / reports + useful diagnostics
 ```
 
@@ -187,21 +187,21 @@ Genia maintains a deliberately small and stable core surface.
 
 New features MUST pass all of the following criteria:
 
-1. Reinforce value templates  
+1. Reinforce value templates
    - The feature strengthens or composes with:
      - refinement
      - shapes (open/closed)
      - variants
      - contracts
 
-2. Reinforce canonical patterns  
+2. Reinforce canonical patterns
    - The feature aligns with and strengthens:
      - pattern matching
      - flow/pipeline model
      - value-first design
    - It must not introduce competing paradigms
 
-3. Reduce ambiguity  
+3. Reduce ambiguity
    - The feature makes programs easier to reason about
    - It must not introduce multiple equivalent ways to express the same concept
    - It must not blur existing semantics
@@ -216,282 +216,3 @@ A feature MUST NOT be added if it:
 - introduces a second way to express an existing pattern
 - adds syntax without increasing clarity
 - expands the surface area without strengthening the core model
-
---------------------------------
-INTENT
---------------------------------
-
-The goal is not to prevent growth.
-
-The goal is to ensure that every addition:
-- sharpens the language
-- reinforces existing mental models
-- makes Genia simpler, not broader
-
----
-
-## Cheatsheet Sync Rule (CRITICAL)
-
-`docs/cheatsheet/*` must remain a truthful quick-reference surface for implemented behavior only.
-
-When language/runtime/API-facing behavior or user-facing examples change, agents must also update relevant cheatsheet pages.
-
-At minimum, review and update as needed:
-
-* `docs/cheatsheet/core.md`
-* `docs/cheatsheet/unix-power-mode.md`
-
-Cheatsheets must not include:
-
-* unimplemented helpers/operators
-* speculative or planned features presented as available
-* call shapes that do not match the current runtime
-
-If cheatsheet content conflicts with source-of-truth docs, `GENIA_STATE.md` remains final authority and cheatsheets must be corrected.
-
-### Cheatsheet Example Validation Rule
-
-Every runnable example added or changed in a cheatsheet **must** include a `[case: <id>]` marker and a matching entry in the sidecar JSON file under `tests/data/`:
-
-| Cheatsheet | Sidecar JSON | Test module |
-|---|---|---|
-| `docs/cheatsheet/piepline-flow-vs-value.md` | `tests/data/pipeline_flow_vs_value_cases.json` | `tests/test_cheatsheet_pipeline_flow_vs_value.py` |
-| `docs/cheatsheet/core.md` | `tests/data/cheatsheet_core_cases.json` | `tests/test_cheatsheet_core.py` |
-| `docs/cheatsheet/quick-reference.md` | `tests/data/cheatsheet_quick_reference_cases.json` | `tests/test_cheatsheet_quick_reference.py` |
-| `docs/cheatsheet/unix-power-mode.md` | `tests/data/cheatsheet_unix_power_mode_cases.json` | `tests/test_cheatsheet_unix_power_mode.py` |
-| `docs/cheatsheet/unix-to-genia.md` | `tests/data/cheatsheet_unix_to_genia_cases.json` | `tests/test_cheatsheet_unix_to_genia.py` |
-
-Marker placement: add `<!-- [case: <id>] -->` on the line immediately before the opening ` ``` ` fence of the runnable snippet.
-
-JSON case entry shape:
-```json
-{
-  "id": "<id>",
-  "source": "<genia source>",
-  "expected_result": "<display string>",
-  "expected_stdout": "<optional stdout string>",
-  "stdin_data": ["optional", "lines"]
-}
-```
-
-Agents must run `pytest tests/test_cheatsheet_*.py` after editing any cheatsheet to catch drift.
-
----
-
-## SICP Validation Rule (CRITICAL)
-
-`docs/sicp/*` is an executable learning surface when present.
-
-Runnable Genia blocks in SICP chapters must follow the fence/expected-output contract in `docs/sicp/AGENTS.MD` and remain truthful to current implementation.
-
-When editing SICP chapters, agents must:
-
-* keep `docs/sicp/index.md` aligned with the published chapter set
-* run `pytest tests/test_sicp_code_blocks.py`
-
----
-
-## `@doc` Style Validation Rule
-
-When editing any of these files:
-
-* `docs/style/doc-style.md`
-* `docs/cheatsheet/core.md` (the `@doc Quick Reference` section)
-* `docs/cheatsheet/quick-reference.md` (the `@doc Quick Reference` section)
-* `docs/book/03-functions.md` (the `Documenting Functions` or `@doc Style Guide` sections)
-
-agents must run:
-
-```
-pytest tests/test_doc_style_sync.py
-```
-
-This validates that:
-
-* the style guide retains its required sections and examples
-* cheatsheet `@doc` sections stay consistent with the style guide
-* book `@doc` content matches the style guide's allowed headers and Markdown subset
-* the linter's constants match the style guide
-* prelude `@doc` strings (when present) pass the linter
-
----
-
-## Core Philosophy
-
-### 1. Preserve Simplicity
-
-Genia must remain:
-
-* Minimal
-* Expressive
-* Human-readable
-* Easy to implement
-
-Avoid:
-
-* Extra syntax
-* Cleverness over clarity
-* Hidden behavior
-
----
-
-### 2. Pattern Matching Is the Core
-
-Genia is a **pattern-matching-first language**.
-
-Agents must not continue into the next phase unless explicitly prompted.
-
-Commit prefixes must match the phase:
-
-- `preflight(scope): ... issue #123`
-- `contract(scope): ... issue #123`
-- `design(scope): ... issue #123`
-- `test(scope): ... issue #123`
-- `feat(scope): ... issue #123`
-- `fix(scope): ... issue #123`
-- `docs(scope): ... issue #123`
-- `audit(scope): ... issue #123`
-- `distillation(scope): ... issue #123`
-
-The `test` phase must commit failing tests before implementation.
-The `implementation` phase must reference the failing-test commit SHA.
-
-## Drift-Prevention Rules
-
-- Keep docs, tests, and implementation aligned
-- Update documentation when behavior or examples change
-- Update tests when behavior, wording, or protected semantic facts change
-- Host-only behavior must keep `LANGUAGE CONTRACT:` and `PYTHON REFERENCE HOST:` labels where applicable
-- Do not leave deleted-doc references in tests, tooling, or instruction files
-- No process artifact may live in docs/ after merge.
-
-## Required Workflow for Any Change
-
-1. update `GENIA_STATE.md`
-2. update any other affected core docs
-3. update implementation only for already-defined behavior
-4. update or add tests
-5. run the relevant audit/validation
-
----
-
-# 🚫 HARD CONSTRAINTS
-
-Agents MUST NOT:
-
-- invent behavior not defined in contract
-- update docs to describe unimplemented features
-- change semantics without updating STATE
-- mix design and implementation in a single step
-- perform repo-wide renames in a single pass
-- redefine language behavior inside host adapters
-
-Parking-lot documents are non-authoritative idea capture only. They must not be treated as implemented behavior or source-of-truth language semantics.
-
----
-
-# 🔁 RENAME SAFETY RULE
-
-Renames MUST be performed in phases:
-
-1. introduce alias
-2. migrate usage incrementally
-3. update tests
-4. remove old name later
-
-Never:
-- rename everything at once
-
----
-
-# 🌍 MULTI-HOST RULES
-
-Future hosts (Node, Java, Rust, Go, C++):
-
-- MUST follow the shared contract
-- MUST NOT redefine behavior
-- MUST pass spec tests
-- MUST treat Core IR as the portability boundary
-
-Python is the reference host.
-
----
-
-# 🧠 PROMPT DISCIPLINE
-
-Each prompt must perform ONE type of work:
-
-- Contract
-- Design
-- Implementation
-- Test
-- Docs
-- Audit
-- Distillation
-
-Never combine responsibilities.
-
----
-
-# 🧾 DOCUMENTATION TRUTH RULE
-
-Docs must:
-
-- describe ONLY implemented behavior
-- clearly label partial features
-- avoid implying future capabilities
-- match testable behavior
-
----
-
-# 🧪 TESTING RULE
-
-Tests must:
-
-- validate real behavior
-- cover edge cases
-- fail on regression
-
-No vague assertions.
-
----
-
-# 🧩 PHILOSOPHY
-
-Genia prioritizes:
-
-- minimalism
-- pattern-first design
-- explicit behavior
-- portability via Core IR
-- truth over convenience
-
----
-
-# 🔒 FINAL RULE
-
-If something is unclear, incomplete, or conflicting:
-
-STOP and resolve truth before proceeding.
-
-Never guess.
-
----
-
-# ✅ SUMMARY
-
-This repository is:
-
-- the source of truth
-- the implementation
-- the contract
-
-It is NOT:
-
-- a tutorial
-- a learning-content repository
-- a teaching resource
-
----
-
-# 🚀 END

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,17 @@ When sources conflict, resolve in this order:
 6. `docs/host-interop/*`
 7. `docs/architecture/*`
 8. implementation (`src/*`, `hosts/*`)
-9. `docs/process/run-change.md`
+9. `docs/process/run-change.md` 
 
 Rules:
 - Tests must reflect actual behavior
 - Implementation must match STATE + RULES
 - Docs must describe ONLY what is implemented
 - Cross-doc semantic guardrails live in `docs/contract/semantic_facts.json` and `tests/doc/test_semantic_doc_sync.py`
-- “Contract” defines behavior only. It MUST NOT include tests.
-- Shared spec YAML files and pytest tests belong to the TEST phase.
+“Contract” defines behavior only.
+It MUST NOT include tests.
 
+Shared spec YAML files and pytest tests belong to the TEST phase.
 ---
 
 # 🚫 NON-AUTHORITATIVE SOURCES
@@ -117,7 +118,6 @@ Banned certainty phrases in docs unless narrowly evidenced:
 * `no drift`
 
 ---
-
 ## Cross-Tool Instruction Sync
 
 Shared cross-tool LLM guidance lives in `docs/ai/LLM_CONTRACT.md`.
@@ -187,21 +187,21 @@ Genia maintains a deliberately small and stable core surface.
 
 New features MUST pass all of the following criteria:
 
-1. Reinforce value templates
+1. Reinforce value templates  
    - The feature strengthens or composes with:
      - refinement
      - shapes (open/closed)
      - variants
      - contracts
 
-2. Reinforce canonical patterns
+2. Reinforce canonical patterns  
    - The feature aligns with and strengthens:
      - pattern matching
      - flow/pipeline model
      - value-first design
    - It must not introduce competing paradigms
 
-3. Reduce ambiguity
+3. Reduce ambiguity  
    - The feature makes programs easier to reason about
    - It must not introduce multiple equivalent ways to express the same concept
    - It must not blur existing semantics
@@ -216,3 +216,282 @@ A feature MUST NOT be added if it:
 - introduces a second way to express an existing pattern
 - adds syntax without increasing clarity
 - expands the surface area without strengthening the core model
+
+--------------------------------
+INTENT
+--------------------------------
+
+The goal is not to prevent growth.
+
+The goal is to ensure that every addition:
+- sharpens the language
+- reinforces existing mental models
+- makes Genia simpler, not broader
+
+---
+
+## Cheatsheet Sync Rule (CRITICAL)
+
+`docs/cheatsheet/*` must remain a truthful quick-reference surface for implemented behavior only.
+
+When language/runtime/API-facing behavior or user-facing examples change, agents must also update relevant cheatsheet pages.
+
+At minimum, review and update as needed:
+
+* `docs/cheatsheet/core.md`
+* `docs/cheatsheet/unix-power-mode.md`
+
+Cheatsheets must not include:
+
+* unimplemented helpers/operators
+* speculative or planned features presented as available
+* call shapes that do not match the current runtime
+
+If cheatsheet content conflicts with source-of-truth docs, `GENIA_STATE.md` remains final authority and cheatsheets must be corrected.
+
+### Cheatsheet Example Validation Rule
+
+Every runnable example added or changed in a cheatsheet **must** include a `[case: <id>]` marker and a matching entry in the sidecar JSON file under `tests/data/`:
+
+| Cheatsheet | Sidecar JSON | Test module |
+|---|---|---|
+| `docs/cheatsheet/piepline-flow-vs-value.md` | `tests/data/pipeline_flow_vs_value_cases.json` | `tests/test_cheatsheet_pipeline_flow_vs_value.py` |
+| `docs/cheatsheet/core.md` | `tests/data/cheatsheet_core_cases.json` | `tests/test_cheatsheet_core.py` |
+| `docs/cheatsheet/quick-reference.md` | `tests/data/cheatsheet_quick_reference_cases.json` | `tests/test_cheatsheet_quick_reference.py` |
+| `docs/cheatsheet/unix-power-mode.md` | `tests/data/cheatsheet_unix_power_mode_cases.json` | `tests/test_cheatsheet_unix_power_mode.py` |
+| `docs/cheatsheet/unix-to-genia.md` | `tests/data/cheatsheet_unix_to_genia_cases.json` | `tests/test_cheatsheet_unix_to_genia.py` |
+
+Marker placement: add `<!-- [case: <id>] -->` on the line immediately before the opening ` ``` ` fence of the runnable snippet.
+
+JSON case entry shape:
+```json
+{
+  "id": "<id>",
+  "source": "<genia source>",
+  "expected_result": "<display string>",
+  "expected_stdout": "<optional stdout string>",
+  "stdin_data": ["optional", "lines"]
+}
+```
+
+Agents must run `pytest tests/test_cheatsheet_*.py` after editing any cheatsheet to catch drift.
+
+---
+
+## SICP Validation Rule (CRITICAL)
+
+`docs/sicp/*` is an executable learning surface when present.
+
+Runnable Genia blocks in SICP chapters must follow the fence/expected-output contract in `docs/sicp/AGENTS.MD` and remain truthful to current implementation.
+
+When editing SICP chapters, agents must:
+
+* keep `docs/sicp/index.md` aligned with the published chapter set
+* run `pytest tests/test_sicp_code_blocks.py`
+
+---
+
+## `@doc` Style Validation Rule
+
+When editing any of these files:
+
+* `docs/style/doc-style.md`
+* `docs/cheatsheet/core.md` (the `@doc Quick Reference` section)
+* `docs/cheatsheet/quick-reference.md` (the `@doc Quick Reference` section)
+* `docs/book/03-functions.md` (the `Documenting Functions` or `@doc Style Guide` sections)
+
+agents must run:
+
+```
+pytest tests/test_doc_style_sync.py
+```
+
+This validates that:
+
+* the style guide retains its required sections and examples
+* cheatsheet `@doc` sections stay consistent with the style guide
+* book `@doc` content matches the style guide's allowed headers and Markdown subset
+* the linter's constants match the style guide
+* prelude `@doc` strings (when present) pass the linter
+
+---
+
+## Core Philosophy
+
+### 1. Preserve Simplicity
+
+Genia must remain:
+
+* Minimal
+* Expressive
+* Human-readable
+* Easy to implement
+
+Avoid:
+
+* Extra syntax
+* Cleverness over clarity
+* Hidden behavior
+
+---
+
+### 2. Pattern Matching Is the Core
+
+Genia is a **pattern-matching-first language**.
+
+Agents must not continue into the next phase unless explicitly prompted.
+
+Commit prefixes must match the phase:
+
+- `preflight(scope): ... issue #123`
+- `contract(scope): ... issue #123`
+- `design(scope): ... issue #123`
+- `test(scope): ... issue #123`
+- `feat(scope): ... issue #123`
+- `fix(scope): ... issue #123`
+- `docs(scope): ... issue #123`
+- `audit(scope): ... issue #123`
+- `distillation(scope): ... issue #123`
+
+The `test` phase must commit failing tests before implementation.
+The `implementation` phase must reference the failing-test commit SHA.
+
+## Drift-Prevention Rules
+
+- Keep docs, tests, and implementation aligned
+- Update documentation when behavior or examples change
+- Update tests when behavior, wording, or protected semantic facts change
+- Host-only behavior must keep `LANGUAGE CONTRACT:` and `PYTHON REFERENCE HOST:` labels where applicable
+- Do not leave deleted-doc references in tests, tooling, or instruction files
+- No process artifact may live in docs/ after merge.
+
+## Required Workflow for Any Change
+
+1. update `GENIA_STATE.md`
+2. update any other affected core docs
+3. update implementation only for already-defined behavior
+4. update or add tests
+5. run the relevant audit/validation
+
+---
+
+# 🚫 HARD CONSTRAINTS
+
+Agents MUST NOT:
+
+- invent behavior not defined in contract
+- update docs to describe unimplemented features
+- change semantics without updating STATE
+- mix design and implementation in a single step
+- perform repo-wide renames in a single pass
+- redefine language behavior inside host adapters
+
+Parking-lot documents are non-authoritative idea capture only. They must not be treated as implemented behavior or source-of-truth language semantics.
+
+---
+
+# 🔁 RENAME SAFETY RULE
+
+Renames MUST be performed in phases:
+
+1. introduce alias
+2. migrate usage incrementally
+3. update tests
+4. remove old name later
+
+Never:
+- rename everything at once
+
+---
+
+# 🌍 MULTI-HOST RULES
+
+Future hosts (Node, Java, Rust, Go, C++):
+
+- MUST follow the shared contract
+- MUST NOT redefine behavior
+- MUST pass spec tests
+- MUST treat Core IR as the portability boundary
+
+Python is the reference host.
+
+---
+
+# 🧠 PROMPT DISCIPLINE
+
+Each prompt must perform ONE type of work:
+
+- Contract
+- Design
+- Implementation
+- Test
+- Docs
+- Audit
+- Distillation
+
+Never combine responsibilities.
+
+---
+
+# 🧾 DOCUMENTATION TRUTH RULE
+
+Docs must:
+
+- describe ONLY implemented behavior
+- clearly label partial features
+- avoid implying future capabilities
+- match testable behavior
+
+---
+
+# 🧪 TESTING RULE
+
+Tests must:
+
+- validate real behavior
+- cover edge cases
+- fail on regression
+
+No vague assertions.
+
+---
+
+# 🧩 PHILOSOPHY
+
+Genia prioritizes:
+
+- minimalism
+- pattern-first design
+- explicit behavior
+- portability via Core IR
+- truth over convenience
+
+---
+
+# 🔒 FINAL RULE
+
+If something is unclear, incomplete, or conflicting:
+
+STOP and resolve truth before proceeding.
+
+Never guess.
+
+---
+
+# ✅ SUMMARY
+
+This repository is:
+
+- the source of truth
+- the implementation
+- the contract
+
+It is NOT:
+
+- a tutorial
+- a learning-content repository
+- a teaching resource
+
+---
+
+# 🚀 END

--- a/docs/ai/LLM_CONTRACT.md
+++ b/docs/ai/LLM_CONTRACT.md
@@ -94,28 +94,29 @@ Agents must:
 
 The strategy and roadmap docs do not define implemented behavior. `GENIA_STATE.md` remains final authority.
 
-## Active Release: R4 — Lifecycle Generalization
+## Active Release: R5 — Native Test Migration / Genia-Facing Coverage Wave 1
 
-**Current active release is R4.**
+**Current active release is R5.**
 
-R3 (Native Test Expansion Wave 1) is complete. R4 (Lifecycle Generalization) is now the active release focus.
+R4 (Lifecycle Generalization) is complete. R5 is now the active release focus.
 
 When an LLM agent is asked for new Genia work and no release is specified:
 
-1. Classify the work against R4 first.
-2. If the work is R4 lifecycle work — lifecycle plan shape, phase shape, scope model, cleanup rules, failure rules, annotation binding model, deterministic source-order / reverse-source-order execution rules, or portable lifecycle docs — proceed through the normal phase pipeline.
-3. If the work is not R4, mark it as non-R4 and either defer/parking-lot it or proceed only if the user explicitly asked for it.
+1. Classify the work against R5 first.
+2. If the work is native-test migration or Genia-facing coverage — Outcome helpers, validation helpers, Flow/Seq visible behavior, implemented Sheet helper behavior, prelude-level utilities, examples intended to be Genia-facing, or test-boundary docs — proceed through the normal phase pipeline.
+3. If the work is not R5, mark it as non-R5 and either defer/parking-lot it or classify it to R6 unless the user explicitly asked for it.
 
-R4 is not a bucket for actors, servers, notebooks, UI, or plugins. Those may use lifecycle later, but they are not R4 implementation targets by default.
+R5 is not a bucket for new data-workflow helpers or broad feature work. Those may belong to R6 or the parking lot, but they are not R5 implementation targets by default.
 
-R4 exclusions (do not include unless explicitly requested):
-- server mode implementation
-- actor lifecycle implementation
-- arbitrary plugin system
-- YAML lifecycle runner
-- broad runtime rewrites
-- lifecycle behavior not exercised by tests
-- unrelated data-pipeline hardening (belongs to R6)
+R5 exclusions (do not include unless explicitly requested):
+- CSV helper implementation
+- new Sheet APIs such as row-access ergonomics, Sheet row Seq adapters, `collect_sheet`, or `render_csv` / `write_csv`
+- new diagnostic helper APIs
+- value-template implementation
+- actor, browser, server, notebook, or playground work
+- parser, lexer, Core IR, or host-adapter changes
+- broad pytest deletion
+- shared semantic spec authority changes
 
 ## Validation
 

--- a/docs/strategy/release-roadmap.md
+++ b/docs/strategy/release-roadmap.md
@@ -39,7 +39,7 @@ Theme:
 
 R1 proved the core pipeline model end-to-end:
 
-```
+```text
 messy records in → clear pipelines → Outcome-aware validation → clean records + diagnostics out
 ```
 
@@ -54,7 +54,7 @@ Delivered:
 - End-to-end validated data pipeline demo (`examples/validated_pipeline_demo.genia`)
 - Docs and tests tied to implemented behavior
 
-Excluded from R1 (see R2, R5, or parking lot):
+Excluded from R1 (see R2, R6, or parking lot):
 
 - general lifecycle system
 - native unit test framework
@@ -73,14 +73,9 @@ Theme:
 
 > Let Genia test Genia where Genia-level tests make sense.
 
-Primary outcomes:
-
-- Genia-native tests can cover pipeline, Outcome, validation, and Sheet-facing behavior.
-- Native tests complement pytest/specs; they do not replace all Python tests.
-- The Python reference host has a minimal native test kernel, CLI entry point, and assertion-helper surface.
-- A Genia-native fixture covers part of the validated data pipeline surface.
-
 R2 protects and exercises the R1 surface through native Genia tests.
+
+Delivered:
 
 - `genia test <file>` execution mode
 - legacy `genia --test <file>` mode
@@ -91,7 +86,7 @@ R2 protects and exercises the R1 surface through native Genia tests.
 - selected shared CLI native-test outcomes
 - one native validated-pipeline fixture
 
-Primary outcomes:
+Excluded:
 
 - arbitrary custom lifecycle definitions
 - annotation-driven native test discovery
@@ -127,34 +122,16 @@ Implemented annotation-driven test syntax (issue #458):
 test1() = assert_eq(1+1, 2)
 ```
 
-R2 introduced the `test(name, body)` call form. R3 adds `@test "description"` annotation-driven native test discovery (issue #458): `@test` annotated zero-argument functions are discovered after legacy `test(name, body)` registrations and run through the same native test kernel. The annotation carries the human-readable description; the function name is the test identifier.
+R2 introduced the `test(name, body)` call form. R3 added `@test "description"` annotation-driven native test discovery: `@test` annotated zero-argument functions are discovered after legacy `test(name, body)` registrations and run through the same native test kernel. The annotation carries the human-readable description; the function name is the test identifier.
 
-R3 delivered:
+Delivered:
 
-- `@test "description"` annotation-driven native test discovery (issue #458) — implemented and documented as current behavior
-- native test coverage for validation helpers (`validate_required`, `validate_field`, `validate_optional`, `validate_record`, `validate_each`) and `collect_validated`
-- native test coverage for Outcome constructors and rendering behavior (`some`, `none`, `err`, `display`, `debug_repr`)
+- `@test "description"` annotation-driven native test discovery (issue #458)
+- native test coverage for validation helpers and `collect_validated`
+- native test coverage for Outcome constructors and rendering behavior
 - native test coverage for JSONL helper behavior in validated pipeline examples
 - at least one pipeline example backed by a native test (`examples/r3_validated_pipeline_native_tests.genia`)
 - native tests kept focused on Genia-facing behavior; parser/IR/host internals were not touched
-
-Do not overclaim R3 completion beyond what the current repo actually shows.
-
-Primary outcomes:
-
-- `@test "description"` annotation-driven native test discovery is implemented (issue #458). ✓ done
-- Validation helpers are covered by native tests.
-- Outcome constructors and rendering behavior are tested at the Genia level.
-- JSONL helper behavior is exercised by native tests.
-- One or two pipeline examples demonstrate native tests on real workflow behavior.
-
-Includes:
-
-- `@test "description"` annotation + named-function discovery (issue #458) ✓ implemented
-- native tests for validation helpers
-- native tests for Outcome constructors and rendering
-- native tests for JSONL helper behavior
-- one or two end-to-end pipeline example tests
 
 Excludes:
 
@@ -165,18 +142,11 @@ Excludes:
 - pytest migration (see R5)
 - setup/teardown, fixtures, parameterization, broad discovery, or multi-host claims
 
-Exit criteria:
-
-- Native tests use the `@test "description" / name() = body` form for annotation-driven discovery. The annotation syntax is implemented and documented as current behavior (issue #458). ✓ done
-- Native tests cover validation helpers, Outcome constructors/rendering, and JSONL helper behavior.
-- At least one pipeline example is backed by a native test.
-- No parser, IR, or host internals are touched.
-
 ---
 
-## Release R4 — Lifecycle Generalization
+## Release R4 — Lifecycle Generalization ✓ COMPLETE
 
-**Status: Active release focus.**
+**Status: Complete.** R4 extracted the proven test lifecycle shape into a portable lifecycle contract while keeping observable lifecycle behavior narrow and test-backed.
 
 Theme:
 
@@ -188,7 +158,7 @@ Primary outcomes:
 - Annotation discovery is phase-driven and explicit.
 - Execution modes can eventually use lifecycle plans without making import/load behavior spooky.
 
-Includes:
+Delivered / included:
 
 - lifecycle plan shape
 - phase shape
@@ -198,7 +168,7 @@ Includes:
 - annotation binding model
 - deterministic source-order / reverse-source-order execution rules
 - portable docs for execution-mode lifecycle proposals
-- test lifecycle remains the first implemented consumer — the Python reference host native test path now consumes the inert lifecycle contract as descriptive plan/scope data (issue #454); Experimental, no lifecycle runner / phase execution / setup/teardown / observable native-test behavior change
+- test lifecycle remains the first implemented consumer — the Python reference host native test path consumes the inert lifecycle contract as descriptive plan/scope data (issue #454); Experimental, no lifecycle runner / phase execution / setup/teardown / observable native-test behavior change
 - annotations do not execute merely because they exist
 
 Excludes:
@@ -209,24 +179,19 @@ Excludes:
 - YAML lifecycle runner unless separately approved
 - broad runtime rewrites
 - lifecycle behavior not exercised by tests
-- unrelated R5 data hardening unless explicitly requested
+- unrelated data-pipeline hardening, now classified under R6 unless explicitly promoted
 
 Exit criteria:
 
 - Lifecycle is documented as a general model.
-- Test lifecycle remains the first implemented consumer. ✓ first consumer implemented as an inert descriptor link (issue #454); the Python reference host native test path describes/validates its lifecycle shape without executing lifecycle phases.
+- Test lifecycle remains the first implemented consumer as an inert descriptor link.
 - No annotations execute merely because they exist.
-
-Agent guidance for R4:
-
-- Current release focus is R4. When asked for new Genia work with no release specified, classify the work against R4 first.
-- If the work is R4 lifecycle work, proceed through the normal phase pipeline.
-- If the work is not R4, mark it as non-R4 and either defer/parking-lot it or proceed only if the user explicitly asked for it.
-- R4 is not a bucket for actors, servers, notebooks, UI, or plugins. Those may use lifecycle later, but they are not R4 implementation targets by default.
 
 ---
 
-## Release R5 — Native Test Expansion / Pytest Migration Wave 1
+## Release R5 — Native Test Migration / Genia-Facing Coverage Wave 1
+
+**Status: Active release focus.**
 
 Theme:
 
@@ -243,7 +208,7 @@ Move candidates:
 - Outcome helpers
 - validation helpers
 - Flow/Seq visible behavior
-- Sheet helper behavior
+- Sheet helper behavior that is already implemented
 - prelude-level utilities
 - examples intended to be Genia-facing
 
@@ -256,10 +221,38 @@ Keep in pytest:
 - spec runner implementation
 - Python-specific exceptions and plumbing
 
+Current R5 issue set:
+
+- **#509** — roadmap/R5 active-release alignment
+- **#510** — native-test vs pytest boundary contract
+- **#511** — audit pytest coverage for native-test migration candidates
+- **#512** — migrate Outcome helper behavior to native tests
+- **#513** — migrate validation helper behavior to native tests
+- **#514** — migrate visible Flow/Seq behavior to native tests
+- **#515** — migrate implemented Sheet helper behavior to native tests
+- **#516** — add native coverage for Genia-facing examples
+- **#517** — document native-test vs pytest guidance
+- **#518** — final R5 native migration truth review
+
+Existing R5-adjacent issues:
+
+- **#369** — optional shared spec cleanup for removed slash named-access compatibility
+- **#406** — tested validation quick-reference examples
+- **#486** — optional focused validated-pipeline reporting example, if still useful
+
 Exit criteria:
 
-- Native test suite proves useful without duplicating every pytest.
+- Native test suite proves useful Genia-facing behavior without duplicating every pytest.
 - Documentation explains what belongs in native tests vs pytest.
+- Parser, IR, host, CLI harness, spec-runner, and Python internals remain protected by pytest/shared specs.
+- No R6 data-hardening work is pulled into R5 unless explicitly promoted.
+
+Agent guidance for R5:
+
+- Current release focus is R5. When asked for new Genia work with no release specified, classify the work against R5 first.
+- If the work is native-test migration or Genia-facing coverage, proceed through the normal phase pipeline.
+- If the work is data-workflow hardening, classify it as R6 unless the user explicitly promotes it.
+- R5 is not a bucket for CSV helpers, new Sheet APIs, diagnostic helper APIs, actors, browser work, or broad value-template implementation.
 
 ---
 
@@ -269,13 +262,12 @@ Theme:
 
 > Make validated pipelines feel production-useful.
 
-This release picks up the data-workflow items deferred from R1. These items were deferred
-because R1 proved the core model; they are not required for that proof and belong to production-quality polish.
+This release picks up the data-workflow items deferred from R1. These items were deferred because R1 proved the core model; they are not required for that proof and belong to production-quality polish.
 
-Deferred R1 items now targeting R5:
+Deferred R1 items now targeting R6:
 
-- **#405** — post-R1 hardening (deferred from R1)
-- **#393** — R5 hardening
+- **#405** — post-R1 diagnostic-context hardening
+- **#393** — diagnostic helper APIs for field/index-aware validation diagnostics
 - **#394** — conditional / deferred until concrete need is proven
 - **#390** — CSV support (record ingestion from CSV files)
 - **#395** — Sheet landing zone improvements
@@ -291,25 +283,8 @@ Possible additional includes:
 - schema/shape inspection helpers
 - better command-line ergonomics
 - clearer examples for real-world records
-
 - possible file-search helper for CLI-native data workflow setup
-  - direct call shape: `find(root, opts)`
-  - options are represented as a plain validated options record
-  - initial file-search results should compose with Flow/Seq-style pipelines
-
 - Option Record Pattern for APIs with many optional settings
-  - default options value
-  - plain options record
-  - pure modifier functions
-  - final validation before execution
-
-- file-search options as the first concrete example:
-  - `default_find_options()`
-  - `with_pattern(...)`
-  - `with_max_depth(...)`
-  - `with_follow_symlinks(...)`
-  - `validate_find_options(...)`
-
 - diagnostics for unknown or invalid options
 
 Deferred candidates after the R1 demo proves the basic workflow:
@@ -333,14 +308,13 @@ These are valuable, but not part of the near roadmap unless explicitly promoted:
 
 - actor system
   - includes actor lifecycle, supervision, and actor-oriented runtime expansion
-  - keep out of R2/R3 unless a narrow use case explicitly requires it
+  - keep out of R5 unless a narrow use case explicitly requires it
 - browser playground runtime
   - useful as a future demo surface, not required for the first validated-data-pipeline release
 - ants / simulation teaching demos
   - useful teaching material after the data-pipeline wedge is demonstrable
 - full value-template system
-  - **#87 / #89 / #91** — broad value-template / contract roadmap issues; future / parking lot
-    unless explicitly promoted to a release
+  - **#87 / #89 / #91** — broad value-template / contract roadmap issues; future / parking lot unless explicitly promoted to a release
 - refinement / shape / contract / variant roadmap
 - validation DSL
   - do not create implementation tickets until helper-based validation proves insufficient
@@ -348,9 +322,8 @@ These are valuable, but not part of the near roadmap unless explicitly promoted:
 - server mode
 - notebook mode
 - parallel native test execution
-- **#399** — future design work; not R2 or near-term; belongs in parking lot until scope is defined
-- **#102** — broad scope; should be split into smaller targeted tickets or updated before use
-  as a release tracker; do not use as a release blocker in its current form
+- **#399** — future design work; not R5 or near-term; belongs in parking lot until scope is defined
+- **#102** — broad scope; should be split into smaller targeted tickets or updated before use as a release tracker; do not use as a release blocker in its current form
 
 ---
 
@@ -361,48 +334,22 @@ This section records the classification of R1-adjacent issues after R1 completio
 | Issue | Classification | Notes |
 |---|---|---|
 | #374 | **Closed / completed** | Delivered as part of R1. |
-| #405 | Post-R1 hardening → R5 | Keep open; schedule in R5. |
-| #393 | R5 hardening | Keep open; schedule in R5. |
+| #405 | R6 diagnostic-context hardening | Keep open; schedule in R6. |
+| #393 | R6 diagnostics hardening | Keep open; schedule in R6. |
 | #394 | Conditional / deferred | Keep open; promote when need is concrete. |
-| #390 | R5 — CSV support | Keep open; schedule in R5. |
-| #395 | R5 — Sheet landing zone | Keep open; schedule in R5. |
-| #396 | R5 — after #395 | Keep open; depends on Sheet landing zone. |
-| #363 / #364 | R5 — after Sheet landing zone | Keep open; schedule after #395. |
-| #399 | Future design | Not R2; park until scope is defined. |
+| #390 | R6 — CSV support | Keep open; schedule in R6. |
+| #395 | R6 — Sheet landing zone | Keep open; schedule in R6. |
+| #396 | R6 — after #395 | Keep open; depends on Sheet landing zone. |
+| #363 / #364 | R6 — after Sheet landing zone | Keep open; schedule after #395. |
+| #399 | Future design | Not R5; park until scope is defined. |
 | #87 / #89 / #91 | Parking lot | Future / parking lot unless explicitly promoted. |
 | #102 | Needs split or update | Do not use as a broad release blocker; split first. |
 
 If an issue listed above is already closed, do not reopen it.
 
+Possible future generated-helper idea:
+
 - record-derived `with_*` helper generation
   - possible future opt-in form: `@derive(quote(withers))`
   - generated helpers must be namespaced under the record/template
   - generated helpers must not create global `with_*` functions
-  - promote only after multiple APIs prove the manual Option Record Pattern is valuable
-
-- automatic global `with_*` helper generation
-  - rejected by default: risks namespace collisions, unclear origin, and excessive implicit API surface
-
----
-
-## Roadmap Rule for Agents
-
-**Current active release: R4 — Lifecycle Generalization.**
-
-Before proposing new tickets, agents must classify the work as:
-
-- current release (R4)
-- next release
-- infrastructure
-- follow-up
-- parking lot
-
-When asked for new Genia work with no release specified:
-
-1. Classify the work against R4 first.
-2. If the work is R4 lifecycle work (lifecycle plan shape, phase shape, scope model, cleanup/failure rules, annotation binding model, execution-order rules, portable lifecycle docs), proceed through the normal phase pipeline.
-3. If the work is not R4, mark it as non-R4 and either defer/parking-lot it or proceed only if the user explicitly asked for it.
-
-R4 is not a bucket for actors, servers, notebooks, UI, or plugins. Those may use lifecycle later, but they are not R4 implementation targets by default.
-
-If the work is parking-lot/future, do not create implementation tickets unless explicitly approved.


### PR DESCRIPTION
## Summary

Promotes R5 as the active release after R4 completion and cleans up stale R5/R6 roadmap wording.

Changes:
- marks R4 complete in `docs/strategy/release-roadmap.md`
- marks R5 active and defines it as Native Test Migration / Genia-Facing Coverage Wave 1
- lists the new R5 issues #509–#518
- moves deferred data-workflow hardening tickets to R6 classification
- updates `AGENTS.md` active-release guidance
- updates `docs/ai/LLM_CONTRACT.md` active-release guidance

Closes #509.

## Notes

This is docs/planning guidance only. It does not change implemented Genia behavior and should not require `GENIA_STATE.md` changes.

I used the GitHub connector rather than a local checkout, so I did not run local tests. Please run the relevant doc sync tests before merge.

## Suggested validation

```bash
uv run pytest -q tests/doc/test_semantic_doc_sync.py
```

Run any additional docs/contract tests normally used for LLM guidance changes.