### PR TITLE
Contract/issue 510 r5 native test boundary

### DIFF
--- a/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/00-preflight.md
+++ b/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/00-preflight.md
@@ -1,0 +1,436 @@
+# === GENIA PRE-FLIGHT ===
+
+CHANGE NAME:
+issue #510 r5-native-test-boundary
+
+CHANGE SLUG:
+issue-510-r5-native-test-boundary
+
+Issue: #510  
+Type: contract  
+Release classification: R5 — Native Test Expansion / Pytest Migration Wave 1  
+Branch: `contract/issue-510-r5-native-test-boundary`  
+Handoff directory: `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/`
+
+HARD STOP: Pre-flight only. Do not write contract, design, tests, implementation, docs sync, audit, or distillation.
+
+---
+
+## 0. BRANCH
+
+Branch required: YES  
+Branch type: contract  
+Branch slug: `issue-510-r5-native-test-boundary`  
+Expected branch: `contract/issue-510-r5-native-test-boundary`  
+Base branch: `main`
+
+Local verification required:
+
+- Starting branch: TODO verify locally with `git branch --show-current`
+- Working branch: `contract/issue-510-r5-native-test-boundary`
+- Branch state: user report says branch was created from `main` and checked out
+- Git status summary: TODO verify locally with `git status --short`
+
+Rules:
+
+- Do not work on `main`.
+- Do not switch branches in this phase unless explicitly required by the process.
+- Do not merge or rebase.
+- Do not continue beyond pre-flight unless explicitly prompted.
+
+---
+
+## 1. SCOPE LOCK
+
+Includes:
+
+- Define the pre-flight scope for a future **contract** change named `issue #510 r5-native-test-boundary`.
+- Classify this as explicit R5 work, even though the current active release is R4, because the user supplied an R5 issue/slug.
+- Identify the boundary between:
+  - Genia-native tests for Genia-facing behavior, and
+  - Python pytest/shared semantic-spec tests for parser, IR, host/runtime, CLI harness, spec runner, and Python-specific internals.
+- Identify authoritative files that must constrain the future contract.
+- Identify likely docs and tests affected by a future native-test boundary contract.
+- Preserve the R5 goal: move appropriate Genia-facing tests into Genia-native tests while keeping Python tests for Python host internals.
+- Produce only `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/00-preflight.md`.
+
+Excludes:
+
+- No contract writing beyond pre-flight findings.
+- No implementation.
+- No test migration.
+- No new native-test behavior.
+- No parser, IR, lowering, host adapter, CLI harness, spec runner, or runtime changes.
+- No setup/teardown, fixture, parameterization, property-test, snapshot-test, parallel-test, or broad discovery feature work.
+- No broad pytest migration.
+- No multi-host native-test claims.
+- No lifecycle-generalization work except where existing R4 native-test lifecycle facts constrain the boundary.
+- No docs sync beyond writing this handoff artifact.
+- No commit unless the local process explicitly requires pre-flight commits.
+
+Release note:
+
+- The current active release is R4 — Lifecycle Generalization.
+- This change is R5 and therefore non-R4, but it is explicitly requested by the user.
+- Proceeding through pre-flight is appropriate; later phases should continue only when explicitly prompted.
+
+---
+
+## 2. SOURCE OF TRUTH
+
+Authoritative:
+
+1. `GENIA_STATE.md` — final authority for implemented behavior
+2. `GENIA_RULES.md`
+3. `GENIA_REPL_README.md`
+4. `README.md`
+5. `spec/*`
+6. `docs/host-interop/*`
+7. `docs/architecture/*`
+8. implementation under `src/*` and `hosts/*`
+9. `docs/process/run-change.md` and related process docs
+
+Additional relevant:
+
+- `AGENTS.md`
+- `docs/ai/LLM_CONTRACT.md`
+- `docs/strategy/killer-workflow.md`
+- `docs/strategy/release-roadmap.md`
+- `docs/process/00-preflight.md`
+- native-test implementation/tests, likely including:
+  - `src/genia/test_kernel.py`
+  - `src/genia/test_cli.py`
+  - `tests/unit/test_native_test_kernel.py`
+  - `tests/unit/test_native_test_cli.py`
+  - native-test examples under `examples/`
+  - shared CLI spec cases for selected native `--test` / `genia test` outcomes
+
+Notes:
+
+- `GENIA_STATE.md` wins if sources conflict.
+- Strategy/roadmap docs are planning guides, not language contracts.
+- Docs must describe only implemented, test-verified behavior.
+- Contract phase must define behavior only; tests belong to the TEST phase.
+- Python is currently the only implemented host and reference host.
+
+---
+
+## 3. FEATURE MATURITY
+
+Stage:
+
+- [x] Experimental
+- [ ] Partial
+- [ ] Stable
+
+Doc wording:
+
+- Native-test behavior should remain described as **Experimental** unless `GENIA_STATE.md` proves a narrower mature status.
+- Python remains the reference host.
+- Native tests complement pytest/specs; they do not replace all Python tests.
+- The native-test boundary contract should avoid implying complete native-test coverage, full pytest migration, multi-host execution, lifecycle setup/teardown, fixtures, parameterization, snapshots, property testing, or parallel execution.
+
+Current behavior to verify in authoritative docs and implementation:
+
+- R2 introduced the minimal native test kernel and CLI entry point.
+- R3 added `@test "description"` annotation-driven native test discovery for zero-argument functions, using the same native test kernel as legacy `test(name, body)` registrations.
+- Shared CLI spec coverage includes selected native test-runner outcomes, but shared coverage is partial.
+- R4 treats test lifecycle as the first implemented lifecycle consumer only as inert/descriptive plan/scope data, with no lifecycle runner, no setup/teardown execution, and no observable native-test behavior change.
+
+---
+
+## 3a. Portability Analysis
+
+Portable contract candidates:
+
+- Native tests are appropriate for Genia-facing behavior that can be expressed and verified in Genia source.
+- Python pytest remains responsible for Python host internals, parser internals, IR normalization, host adapter behavior, CLI harness internals, spec runner implementation, and Python-specific exceptions/plumbing.
+- Shared semantic specs remain authoritative for portable observable CLI/eval/flow/error/parse/IR behavior where covered.
+- Native-test results exposed through CLI should stay deterministic and observable through stdout/stderr/exit-code where already covered.
+
+Python reference host today:
+
+- Python is the only implemented host.
+- Native test execution is implemented in the Python reference host.
+- Shared conformance currently runs against the Python reference host.
+
+Host-specific concerns:
+
+- The boundary contract must not require non-Python hosts to exist.
+- The contract must not move host-adapter or parser/IR internals into Genia-native tests.
+- If future hosts implement native tests, they must follow shared contract/spec behavior rather than redefining native-test semantics.
+
+Portability risk:
+
+- Risk: Medium.
+- Reason: native tests are Genia-facing, but the current implementation is Python-hosted. Boundary wording must be explicit about portable behavior versus Python reference-host implementation.
+
+---
+
+## 4. CONTRACT vs IMPLEMENTATION
+
+Portable contract:
+
+- Native Genia tests should cover Genia-facing behavior: prelude helpers, Outcome helpers, validation helpers, Flow/Seq visible behavior, Sheet helper behavior, examples intended to be user-facing, and other behavior that can be written naturally in Genia.
+- Native tests should validate behavior from the Genia user's perspective, not Python implementation details.
+- Pytest/shared specs remain responsible for implementation and conformance surfaces that are not Genia-level source behavior.
+- The native-test boundary should preserve deterministic naming, discovery, execution, result reporting, and diagnostics already documented as implemented.
+- The boundary should explicitly state that native tests complement pytest/specs.
+
+Python implementation today:
+
+- Native test kernel and CLI are implemented in Python.
+- Legacy `test(name, body)` and `@test "description"` named-function discovery are expected current behavior per R2/R3 roadmap/state alignment, subject to local verification.
+- Shared CLI specs include selected native test-runner passing, runtime-erroring, and discovery-error outcomes.
+- Python pytest remains necessary for host/runtime/parser/spec-runner internals.
+
+Not implemented / out of contract for this issue:
+
+- Full pytest migration.
+- Multi-host native-test execution.
+- Setup/teardown execution.
+- General fixture system.
+- Parameterized tests.
+- Snapshot tests.
+- Property tests.
+- Parallel native-test execution.
+- Arbitrary custom lifecycle execution.
+- Native tests for parser/IR/host adapter internals.
+- Native tests as replacement for shared semantic specs.
+
+---
+
+## 5. TEST STRATEGY
+
+Core invariants:
+
+- The contract distinguishes Genia-facing native-test candidates from pytest-only implementation/internal tests.
+- The contract does not imply native tests replace pytest or shared specs.
+- The contract does not describe unimplemented native-test features.
+- The contract aligns with current `GENIA_STATE.md` native-test and shared-spec facts.
+- The contract preserves R5 scope and does not accidentally pull in R4 lifecycle implementation.
+
+Expected behavior:
+
+- Future contract/docs should guide maintainers toward moving appropriate Genia-facing tests into native tests.
+- Future contract/docs should keep parser, IR, host adapter, CLI harness, spec runner, and Python-specific exception/plumbing tests in pytest/shared specs.
+- Native-test documentation should be explicit about Python reference-host status and experimental maturity.
+
+Failure cases:
+
+- Docs claim native tests are stable or complete without evidence.
+- Docs imply native tests replace pytest.
+- Docs imply setup/teardown, fixtures, parameterization, snapshots, property tests, parallelism, or multi-host support.
+- Tests are migrated into native tests even though they assert Python internals.
+- Shared specs are bypassed for portable observable behavior.
+- R5 boundary work changes observable test behavior without test/design/implementation phases.
+
+Test approach for later phases:
+
+- CONTRACT phase: no tests.
+- DESIGN phase: identify exact doc/test guardrails.
+- TEST phase, if contract wording becomes protected semantic text:
+  - update/add doc tests or semantic doc sync tests.
+  - consider `docs/contract/semantic_facts.json` only if a protected semantic fact is introduced or changed.
+- IMPLEMENTATION phase only if future tests expose missing behavior; this issue should likely be docs/contract-only unless the issue body says otherwise.
+- Run targeted doc tests and native-test-related unit tests in later phases as appropriate.
+
+---
+
+## 6. EXAMPLES
+
+Minimal:
+
+- Native-test candidate:
+  - A Genia source test for an Outcome helper, validation helper, Flow/Seq visible behavior, Sheet helper, or user-facing prelude utility.
+- Pytest candidate:
+  - A Python test for parser AST shape, IR normalization, host adapter plumbing, CLI harness internals, or spec runner implementation.
+
+Real:
+
+- Native Genia test:
+  - A validated-pipeline example test that asserts user-facing Genia behavior.
+- Pytest/shared spec:
+  - A shared CLI spec that asserts `stdout`, `stderr`, and `exit_code` for selected native test-runner outcomes.
+  - A pytest that asserts Python exception or adapter normalization behavior.
+
+Do not add runnable examples in this phase.
+
+---
+
+## 7. COMPLEXITY CHECK
+
+- [ ] Adding complexity
+- [x] Revealing structure
+
+Justification:
+
+- This change should not add a new testing mechanism.
+- It should reveal and document the correct boundary between existing native-test capability and existing pytest/spec responsibility.
+- The boundary reduces future migration ambiguity and prevents LLMs from moving the wrong tests into native Genia tests.
+
+Complexity risks:
+
+- Over-defining a migration matrix too early.
+- Turning a boundary contract into a broad pytest migration plan.
+- Pulling lifecycle execution features into R5 prematurely.
+- Blurring shared semantic specs versus native tests.
+
+Mitigation:
+
+- Keep contract wording narrow, maturity-labeled, and implementation-aligned.
+- Use explicit “belongs in native tests” / “stays in pytest/shared specs” categories.
+- Do not claim new behavior.
+
+---
+
+## 8. CROSS-FILE IMPACT
+
+Files likely to change in later phases:
+
+- `GENIA_STATE.md`
+- `docs/strategy/release-roadmap.md` only if R5 positioning needs clarification
+- README or testing docs only if public native-test guidance is currently incomplete or misleading
+- relevant docs/book or docs/architecture testing/native-test sections, if present
+- `docs/contract/semantic_facts.json` only if protected semantic facts are added/changed
+- `tests/doc/test_semantic_doc_sync.py` only if semantic sync guardrails need updates
+- native-test unit tests only if future phases change behavior
+
+Files unlikely to change:
+
+- parser/lexer/lowering/Core IR
+- host adapters
+- spec runner implementation
+- flow runtime
+- CLI harness internals
+- prelude implementation
+
+Risk of drift:
+
+- [ ] Low
+- [x] Medium
+- [ ] High
+
+Reason:
+
+- This is mostly contract/docs boundary work, but it touches a historically drift-prone area: what native Genia tests cover versus what remains in pytest/shared specs.
+
+---
+
+## 9. DOC DISTILLATION CHECK
+
+Creates process artifacts?
+
+- [x] YES → run Doc Distillation later if artifacts are tracked or process requires cleanup
+- [ ] NO
+
+Adds docs/design or docs/architecture files?
+
+- [ ] YES → classify KEEP / EXTRACT / DELETE
+- [x] NO in pre-flight
+
+Doc drift risk:
+
+- [ ] Low
+- [x] Medium
+- [ ] High
+
+Notes:
+
+- Handoff files under `.genia/process/tmp/handoffs/...` are process artifacts.
+- Later phases should ensure no temporary handoff artifacts are accidentally tracked unless the process explicitly requires it.
+- Contract/docs wording must remain aligned with `GENIA_STATE.md` and roadmap status.
+
+---
+
+## 10. PHILOSOPHY CHECK
+
+- preserves minimalism? YES
+- avoids hidden behavior? YES
+- keeps semantics out of host? YES, if the future contract labels Python reference-host details separately from portable native-test guidance
+- aligns with pattern-matching-first? YES / N/A — this boundary protects Genia-facing tests without adding syntax or competing paradigms
+
+Notes:
+
+- This change should reduce ambiguity rather than add surface area.
+- It should keep native tests focused on user-visible Genia behavior.
+- It should prevent broad testing-framework creep.
+- It should not redefine language semantics inside Python host tests.
+
+---
+
+## KILLER WORKFLOW ALIGNMENT
+
+Does this change directly strengthen Outcome-aware validated data pipelines?
+
+- [ ] Yes
+- [x] Indirectly
+- [ ] No
+
+Explanation:
+
+- R5 native-test boundary work indirectly strengthens the killer workflow by clarifying which Genia-facing data-pipeline behavior should be protected with native tests.
+- Strong native tests are appropriate for Outcome helpers, validation helpers, Flow/Seq visible behavior, Sheet helper behavior, and examples intended to demonstrate validated data pipelines.
+- The change does not add data-pipeline features directly; it improves test placement discipline so the pipeline surface can be protected without mixing in Python internals.
+
+Improves:
+
+- [x] Flow / Seq — by identifying visible behavior as native-test eligible
+- [x] Outcome — by identifying helper behavior as native-test eligible
+- [ ] record parsing
+- [x] validation — by identifying validation helpers/examples as native-test eligible
+- [x] diagnostics — by keeping user-facing diagnostics native-test eligible while host/internal formatting stays in pytest/specs as appropriate
+- [x] Sheets — by identifying Sheet helper behavior as native-test eligible
+- [x] CLI data processing — by preserving shared CLI specs for observable CLI outcomes
+- [x] value templates for validation/contracts/shapes — indirectly, if future value-template behavior becomes Genia-facing and testable in native tests
+
+Parking-lot check:
+
+- Not parking lot because the user explicitly requested R5 native-test-boundary work and R5 is the planned release for making the native-test / pytest split explicit.
+
+---
+
+## 11. PROMPT PLAN
+
+Pipeline:
+
+- [x] Preflight — this file
+- [ ] Contract — define the boundary text and authoritative categories
+- [ ] Design — identify exact file edits and semantic guardrails
+- [ ] Test — add doc/semantic guardrail tests if needed; add no implementation tests unless behavior changes
+- [ ] Implementation — likely no-op unless the issue body requires behavior changes
+- [ ] Docs — sync `GENIA_STATE.md` and any relevant docs to implemented/tested reality
+- [ ] Audit — verify contract/docs/tests alignment and no scope expansion
+- [ ] Distillation — remove/ignore process artifacts and keep durable docs only where appropriate
+
+Recommended next phase:
+
+- CONTRACT prompt.
+
+Contract phase should:
+
+- Read the same authoritative docs.
+- Define exactly what belongs in native Genia tests versus pytest/shared specs.
+- Avoid test implementation.
+- Avoid changing behavior.
+- Produce a contract artifact only.
+
+---
+
+## FINAL GO / NO-GO
+
+Ready to proceed?
+
+YES, for CONTRACT phase only.
+
+Missing:
+
+- Local branch/status verification.
+- Issue body verification, if issue #510 has additional details not present in the handoff prompt.
+- Local inspection of native-test files and docs to confirm current wording before contract is finalized.
+
+Post-process command:
+
+```bash
+(export GIT_PAGER=cat; git status; git diff ; git log --oneline main..HEAD; cat ${HANDOFF_DIR}/*) | pbcopy
+```

--- a/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/01-contract.md
+++ b/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/01-contract.md
@@ -1,0 +1,210 @@
+# === GENIA CONTRACT ===
+
+CHANGE NAME:
+issue #510 r5-native-test-boundary
+
+CHANGE SLUG:
+issue-510-r5-native-test-boundary
+
+Issue: #510
+Type: contract
+Release classification: R5 — Native Test Expansion / Pytest Migration Wave 1
+Branch: `contract/issue-510-r5-native-test-boundary`
+Handoff directory: `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/`
+
+Source pre-flight: `00-preflight.md` (present, GO for CONTRACT phase).
+
+`GENIA_STATE.md` is the final authority. If anything below conflicts with `GENIA_STATE.md`, `GENIA_STATE.md` wins and this contract must be corrected, not the state.
+
+This is a contract/docs boundary change. It defines a placement boundary; it does **not** add, remove, or change any executable behavior.
+
+---
+
+## 0. BRANCH CHECK
+
+- Must NOT be on `main`: confirmed — working branch is `contract/issue-510-r5-native-test-boundary`.
+- Must match pre-flight branch: confirmed — matches `00-preflight.md` expected branch.
+- Working tree: clean except untracked `.claude/settings.local.json` (unrelated tooling file; not part of this change).
+- No branch switch, merge, or rebase performed.
+
+---
+
+## 1. PURPOSE
+
+Define the authoritative boundary between **Genia-native tests** and **Python pytest / shared semantic specs**, so that future R5 test placement and migration decisions are unambiguous.
+
+The contract answers one question precisely: *given a behavior to protect with a test, where does that test belong?*
+
+It introduces no new test mechanism, no new annotation, no new runner behavior, and no change to discovery, execution, reporting, or diagnostics. It is a placement contract over the test surfaces that already exist per `GENIA_STATE.md` sections 9, 9.1, 9.1.1, 9.2, and 9.6.
+
+---
+
+## 2. SCOPE (FROM PRE-FLIGHT)
+
+Included:
+
+- A normative definition of which behaviors **belong in Genia-native tests**.
+- A normative definition of which behaviors **stay in Python pytest**.
+- A normative statement that **shared semantic specs remain authoritative** for portable observable CLI/eval/flow/error/parse/IR behavior where covered.
+- An explicit statement that native tests **complement** pytest and shared specs and replace neither.
+- An explicit Python-reference-host and Experimental maturity framing for native tests.
+
+Excluded:
+
+- No implementation, no test migration, no new native-test behavior.
+- No parser, lexer, IR, lowering, host adapter, CLI harness, spec runner, prelude, or runtime changes.
+- No setup/teardown, fixtures, parameterization, property tests, snapshot tests, parallel execution, filtering, broad directory discovery, or multi-host execution.
+- No R4 lifecycle-execution work; existing inert R4 lifecycle facts (section 9.6) constrain wording only.
+- No broad pytest migration plan or migration matrix.
+
+---
+
+## 3. BEHAVIOR
+
+This contract defines a **classification rule**, not runtime behavior. There are no new inputs, outputs, or state changes in the executable system.
+
+Inputs (to the classification rule, applied by a maintainer or agent):
+
+- A behavior or surface to be protected by a test.
+
+Outputs (of the classification rule):
+
+- A placement decision: **native test**, **pytest**, or **shared semantic spec**.
+
+State changes:
+
+- None in the runtime. The only artifacts changed by adopting this contract are documentation and the placement of future tests, handled in later phases.
+
+### 3.1 Native test placement (belongs in Genia-native tests)
+
+A behavior belongs in a Genia-native test when it is **Genia-facing** — expressible and verifiable in Genia source from the Genia user's perspective. This includes:
+
+- Outcome constructor / representation / predicate / inspection behavior (`some`, `none`, `err`, `display`, `debug_repr`, `some?`, `none?`, `absence_reason`, `absence_context`).
+- Validation helper behavior (`validate_record`, `validate_each`, `collect_validated`, and related Outcome-aware rules).
+- Flow / Seq behavior that is visible at the Genia source level.
+- Sheet helper behavior visible at the Genia source level.
+- Record-parsing helpers usable from Genia source (e.g. `parse_jsonl_record`).
+- Prelude utilities and user-facing examples intended to demonstrate the killer workflow.
+
+Native tests are authored with the existing `test(name, body)` form or `@test "description"` annotated zero-argument functions, run through the existing native test kernel, and report the existing normalized `PASS` / `FAIL` / `ERROR` outcomes (per `GENIA_STATE.md` 9.1, 9.2). This contract adds nothing to that mechanism.
+
+### 3.2 Pytest placement (stays in Python pytest)
+
+A behavior stays in Python pytest when it is an **implementation or host-internal** surface not expressible as Genia-level source behavior. This includes:
+
+- Parser / lexer / AST shape and Core IR normalization.
+- Host adapter plumbing and Python-specific exception/normalization behavior.
+- CLI harness internals and the spec runner implementation itself.
+- Native test stack internals (the kernel, the CLI/test-mode layer, discovery/duplicate-name machinery, and the inert R4 lifecycle descriptor/validation path) as Python units — e.g. the existing `tests/unit/test_native_test_kernel.py` and `tests/unit/test_native_test_cli.py`.
+
+### 3.3 Shared semantic spec placement (stays authoritative where covered)
+
+Shared semantic specs remain authoritative for **portable observable behavior** — CLI `stdout` / `stderr` / `exit_code`, eval, flow, error, parse, and IR behavior — wherever they already provide coverage, including the selected native test-runner passing, runtime-erroring, and discovery-error suite outcomes already in shared CLI coverage (`GENIA_STATE.md` line 133). Portable observable behavior must not be moved out of shared specs into native tests.
+
+---
+
+## 4. SEMANTICS
+
+Evaluation behavior: unchanged. This contract triggers no evaluation. `@test` annotations remain inert outside native test mode; the kernel and CLI layers behave exactly as documented in `GENIA_STATE.md` 9.1–9.2.
+
+Classification (the only "matching" behavior this contract introduces) resolves by the perspective of the behavior under test:
+
+- Genia-facing / user-visible source behavior → native test (3.1).
+- Python/host/parser/IR/runner internal behavior → pytest (3.2).
+- Portable observable CLI/eval/flow/error/parse/IR behavior with existing shared coverage → shared semantic spec (3.3).
+
+Edge cases:
+
+- A behavior with both a Genia-facing surface and a host-internal surface is split: the Genia-facing assertion goes to a native test, the internal assertion stays in pytest. It is not duplicated wholesale.
+- A behavior that is observable at the CLI **and** already covered by a shared spec stays in the shared spec; a native test is not added to re-assert the same observable outcome.
+- Native-test stack behavior (kernel/CLI/discovery/lifecycle descriptor) is host-internal (3.2) even though it concerns testing, because it asserts Python implementation rather than Genia source behavior.
+
+Error behavior: none introduced. No new diagnostics, exit codes, or report formats. Existing native-test discovery errors, duplicate-name errors, metadata-validation errors, and exit codes (`0` / `1` / `2`) are unchanged.
+
+---
+
+## 5. FAILURE
+
+What causes a violation of this contract (in later phases or future work):
+
+- Placing a test that asserts Python/parser/IR/host internals into a Genia-native test.
+- Removing or bypassing a shared semantic spec for portable observable behavior in favor of a native test.
+- Documentation that claims native tests are stable/complete, replace pytest, or support unimplemented features (setup/teardown, fixtures, parameterization, snapshots, property tests, parallelism, filtering, multi-host).
+
+Resulting error:
+
+- This is a contract/docs boundary, so violations surface as review/audit findings and (where guardrail tests exist) as failing doc/semantic-sync tests — not as new runtime errors.
+
+What does NOT happen:
+
+- No runtime error path changes.
+- No change to native-test discovery, execution, reporting, exit codes, or diagnostics.
+- No test is migrated, added, or deleted by this contract itself.
+
+---
+
+## 6. INVARIANTS
+
+- Native tests cover only Genia-facing behavior verifiable in Genia source.
+- Python host/parser/IR/runner/CLI-harness internals stay in pytest.
+- Shared semantic specs remain authoritative for portable observable behavior they already cover.
+- Native tests complement pytest and shared specs; they replace neither.
+- Native-test support remains Experimental and Python-reference-host only.
+- No observable test behavior (discovery, execution, reporting, diagnostics, exit codes) changes under this contract.
+- The native-test mechanism described in `GENIA_STATE.md` 9.1–9.2 and the inert R4 lifecycle facts in 9.6 are unchanged.
+- The contract claims no unimplemented native-test feature.
+
+---
+
+## 7. EXAMPLES
+
+Minimal:
+
+- Native test: a `@test "..."` zero-argument function asserting `assert_eq(display(some(1)), "...")` — Genia-facing Outcome behavior.
+- Pytest: a Python unit asserting the native test kernel normalizes a raised exception into an `error` result dict — host-internal.
+
+Real (all already present in the repo per `GENIA_STATE.md`):
+
+- Native test: `tests/native/outcome_rendering.genia` (validated by `tests/unit/test_outcome_native_tests.py`) and `tests/native/r1_validated_pipeline.genia` — Genia-facing helper/pipeline behavior. Correctly native.
+- Native test example: `examples/r3_validated_pipeline_native_tests.genia` — Genia-facing validated-pipeline surface. Correctly native.
+- Pytest: `tests/unit/test_native_test_kernel.py`, `tests/unit/test_native_test_cli.py` — native-test stack internals. Correctly pytest.
+- Shared spec: selected native test-runner passing / runtime-erroring / discovery-error suite outcomes in shared CLI coverage. Correctly shared.
+
+No new runnable examples are added in this phase.
+
+---
+
+## 8. NON-GOALS
+
+Explicitly NOT included:
+
+- Full or partial pytest-to-native migration execution.
+- A migration matrix or per-test migration plan.
+- Multi-host native-test execution.
+- Setup/teardown execution; `@setup` / `@teardown` annotations.
+- General fixture system; parameterized, snapshot, or property tests.
+- Parallel native-test execution; test filtering; broad directory discovery.
+- Native tests for parser / IR / host-adapter internals.
+- Native tests as a replacement for shared semantic specs.
+- Any R4 lifecycle-execution behavior.
+
+---
+
+## 9. DOC NOTES
+
+- `GENIA_STATE.md` should describe this as an R5 **native-test / pytest / shared-spec placement boundary**, layered on top of the existing native-test facts in sections 9, 9.1, 9.1.1, 9.2, and 9.6 — not as a new capability.
+- Maturity: **Experimental**, Python reference host only.
+- Wording must state that native tests complement pytest and shared specs and must avoid any implication of completeness, pytest replacement, multi-host support, or unimplemented lifecycle/fixture/parameterization/snapshot/property/parallel features.
+- The boundary description must keep portable native-test guidance separate from Python reference-host implementation detail.
+
+---
+
+## 10. FINAL CHECK
+
+- Precise and testable: YES — placement is decided by a stated rule with worked, repo-present examples.
+- No implementation details / no new behavior: YES — defines placement only.
+- No scope expansion beyond pre-flight: YES — matches `00-preflight.md` scope lock and non-goals.
+- Consistent with `GENIA_STATE.md`: YES — references and preserves sections 9, 9.1, 9.1.1, 9.2, 9.6; introduces no conflicting claim.
+- Killer-workflow alignment: indirect — protects Genia-facing Outcome / validation / Flow-Seq / Sheets / diagnostics surfaces with correctly-placed native tests without adding pipeline features.
+
+Ready to proceed to DESIGN phase.

--- a/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/02-design.md
+++ b/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/02-design.md
@@ -1,0 +1,192 @@
+# === GENIA DESIGN ===
+
+CHANGE NAME:
+issue #510 r5-native-test-boundary
+
+CHANGE SLUG:
+issue-510-r5-native-test-boundary
+
+Issue: #510
+Type: contract
+Release classification: R5 — Native Test Expansion / Pytest Migration Wave 1
+Branch: `contract/issue-510-r5-native-test-boundary`
+Handoff directory: `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/`
+
+Sources read: `00-preflight.md`, `01-contract.md` (both present).
+
+`GENIA_STATE.md` is the final authority. This design organizes a documentation/placement boundary. It introduces no code and no behavior.
+
+---
+
+## 0. BRANCH CHECK
+
+- Must NOT be on `main`: confirmed — `contract/issue-510-r5-native-test-boundary`.
+- Matches pre-flight/contract branch: confirmed.
+- No switch, merge, or rebase.
+
+---
+
+## 1. PURPOSE
+
+Translate the contract's placement rule into a concrete documentation structure and the guardrails that protect it. This is structure, not new behavior: it says *where the boundary is written down* and *how it is kept honest*, given that no runtime or test mechanism changes.
+
+---
+
+## 2. SCOPE LOCK
+
+Contract includes:
+
+- Documented placement rule: native test vs pytest vs shared semantic spec.
+- "Complement, not replace" statement.
+- Experimental / Python-reference-host framing.
+
+Contract excludes:
+
+- Any test migration, new native-test behavior, or runtime/parser/IR/host/CLI-harness/spec-runner/prelude change.
+- Lifecycle execution, fixtures, parameterization, snapshots, property tests, parallelism, filtering, broad discovery, multi-host.
+- A migration matrix or per-test migration plan.
+
+Do not expand scope. This design adds documentation and (optionally) doc-guardrail tests only.
+
+---
+
+## 3. ARCHITECTURE
+
+Where this fits:
+
+- The boundary is **documentation that sits above an unchanged native-test stack**. The stack already has four layers per `GENIA_STATE.md` 9.x: kernel core (`src/genia/test_kernel.py`), assertion helpers, CLI/test-mode layer (`src/genia/test_cli.py`), and the inert R4 lifecycle descriptor/validation path. None of these layers are touched.
+
+Affected components:
+
+- `GENIA_STATE.md` native-test sections (9, 9.1, 9.1.1, 9.2, 9.6) — gain a placement-boundary subsection.
+- Public testing guidance docs (README / testing docs / docs book section, if a current one exists and is incomplete or misleading on this point).
+- Optionally, doc-sync / semantic guardrail tests if any contract sentence becomes protected semantic text.
+
+Data flow:
+
+- None at runtime. The "flow" is editorial: contract wording → `GENIA_STATE.md` subsection → any downstream doc references → optional guardrail test asserting the wording stays present/consistent.
+
+Integration points:
+
+- The boundary subsection must cross-reference, not duplicate, the existing native-test facts already in `GENIA_STATE.md`.
+
+---
+
+## 4. FILE PLAN
+
+New files:
+
+- None required. (A dedicated `docs/contract/` note is possible but unnecessary; prefer extending `GENIA_STATE.md`. Do not add a new doc file unless the DOCS phase finds existing files cannot host the boundary cleanly.)
+
+Modified files (later phases — DOCS, and TEST only if a protected fact is introduced):
+
+- `GENIA_STATE.md` — add an R5 native-test/pytest/shared-spec **placement boundary** subsection adjacent to sections 9.2 / 9.6; keep it descriptive and maturity-labeled.
+- `docs/strategy/release-roadmap.md` — only if R5 positioning needs a one-line clarification; not required by the contract.
+- README or testing docs — only if current public native-test guidance is incomplete or misleading about the boundary.
+- `docs/contract/semantic_facts.json` — only if a sentence becomes a protected semantic fact.
+- `tests/doc/test_semantic_doc_sync.py` — only if semantic-sync guardrails need to cover a new protected fact.
+
+Removed files:
+
+- None.
+
+---
+
+## 5. DATA / INTERFACE DESIGN
+
+No runtime data shapes, value templates, variants, functions, classes, or interfaces change.
+
+The only "interface" introduced is an **editorial classification table** to live in the `GENIA_STATE.md` boundary subsection. Proposed shape (three columns, descriptive only):
+
+- *Surface* — the behavior under test (e.g. "Outcome `display` rendering", "kernel exception→error normalization", "native `--test` suite exit code").
+- *Placement* — `native test` | `pytest` | `shared spec`.
+- *Rationale* — Genia-facing source behavior | host/implementation internal | portable observable with existing shared coverage.
+
+Seed rows come directly from contract §7 (all already present in the repo): `tests/native/outcome_rendering.genia`, `tests/native/r1_validated_pipeline.genia`, `examples/r3_validated_pipeline_native_tests.genia` → native; `tests/unit/test_native_test_kernel.py`, `tests/unit/test_native_test_cli.py` → pytest; selected native test-runner suite outcomes → shared spec.
+
+No implementation logic. The table documents existing, correctly-placed artifacts; it is not a migration worklist.
+
+---
+
+## 6. CONTROL / ERROR FLOW
+
+Execution flow: none — nothing executes as a result of this change.
+
+Decision structure (the documented placement rule, restating contract §4 for design clarity):
+
+1. Is the behavior expressible/verifiable in Genia source from the user's perspective? → native test.
+2. Else, is it Python/parser/IR/host/runner/CLI-harness internal? → pytest.
+3. Is it portable observable CLI/eval/flow/error/parse/IR behavior already covered by a shared spec? → shared spec (and do not duplicate it as a native test).
+4. Mixed surface → split: Genia-facing assertion native, internal assertion pytest; do not duplicate wholesale.
+
+Where errors are detected:
+
+- Editorially, in review/audit: a misplaced test or an over-claiming sentence is a finding.
+- Mechanically, only if a guardrail/doc-sync test exists for a protected sentence; then drift fails that test. No new runtime error path.
+
+Boundaries that enforce correctness:
+
+- The contract invariants (§6) are the acceptance gate for DOCS/AUDIT.
+- `GENIA_STATE.md` remains the final authority; the boundary subsection must not contradict 9.x.
+
+Must match contract failure behavior: confirmed — no runtime errors introduced; violations are review/guardrail findings only.
+
+---
+
+## 7. TEST PLAN INPUT
+
+Invariants to test (DOCS/TEST phase, doc-level only):
+
+- Boundary subsection exists in `GENIA_STATE.md` and labels native tests Experimental / Python reference host.
+- Wording states native tests complement (do not replace) pytest and shared specs.
+- No claim of unimplemented features (setup/teardown, fixtures, parameterization, snapshots, property tests, parallelism, filtering, multi-host).
+
+Edge cases:
+
+- Mixed-surface behavior described as "split", not "duplicate".
+- Shared-spec-covered observable behavior not redirected to native tests.
+
+Regression risks:
+
+- Drift between the boundary subsection and existing 9.x native-test facts.
+- A future reader treating the placement table as a migration mandate.
+
+Test files / locations:
+
+- `tests/doc/test_semantic_doc_sync.py` — only if a sentence becomes a protected semantic fact.
+- No new `tests/unit/*` or `tests/native/*` — this change adds no behavior to assert.
+- No new shared spec cases.
+
+---
+
+## 8. DOC IMPACT
+
+- `GENIA_STATE.md` — REQUIRED in DOCS phase: add the placement-boundary subsection near 9.2/9.6.
+- `GENIA_RULES.md` — not needed.
+- `GENIA_REPL_README.md` — not needed.
+- `README.md` — only if current native-test guidance is incomplete/misleading on placement.
+- `docs/book` / testing docs — update only an existing native-test/testing section if present; do not create new structure speculatively.
+- `docs/strategy/release-roadmap.md` — optional one-line R5 clarification.
+
+---
+
+## 9. COMPLEXITY CHECK
+
+- [x] Minimal
+- [ ] Necessary
+- [ ] Over-engineered
+
+Explanation: the design adds one documentation subsection (plus an optional descriptive table and optional guardrail) over an unchanged stack. It reveals existing structure and reduces placement ambiguity without adding surface area — consistent with the pre-flight "Revealing structure" classification.
+
+---
+
+## 10. FINAL CHECK
+
+- Matches contract exactly: YES — organizes the §3/§4 placement rule and §6 invariants; adds nothing beyond.
+- No new behavior: YES — documentation/guardrail only; native-test stack untouched.
+- No host-specific assumptions: YES — boundary is portable; Python reference-host detail is kept explicitly separate, per contract §9.
+- Ready for implementation: YES — but note this issue is expected to be docs/contract-only; the IMPLEMENTATION phase is likely a no-op unless the issue body requires behavior changes.
+
+---
+
+OUTPUT: design complete. Recommended next phase: TEST (doc-guardrail only if a protected fact is introduced) → DOCS sync of `GENIA_STATE.md`.

--- a/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/03-failing-tests.md
+++ b/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/03-failing-tests.md
@@ -1,0 +1,125 @@
+# === GENIA FAILING TESTS ===
+
+CHANGE NAME:
+issue #510 r5-native-test-boundary
+
+CHANGE SLUG:
+issue-510-r5-native-test-boundary
+
+Issue: #510
+Type: contract
+Release classification: R5 — Native Test Expansion / Pytest Migration Wave 1
+Branch: `contract/issue-510-r5-native-test-boundary`
+Handoff directory: `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/`
+
+`GENIA_STATE.md` is final authority.
+
+This TEST phase adds a doc/semantic guardrail only. It does not change runtime behavior, add native Genia tests, migrate pytest tests, edit shared specs, or implement the documentation sync.
+
+---
+
+## 0. BRANCH CHECK
+
+- Must NOT be on `main`: confirmed — current branch is `contract/issue-510-r5-native-test-boundary`.
+- Expected branch: `contract/issue-510-r5-native-test-boundary`.
+- Branch matches pre-flight / contract / design handoffs.
+- No merge, rebase, or branch switch performed.
+
+---
+
+## 1. TEST PLAN
+
+Files updated:
+
+- `tests/doc/test_semantic_doc_sync.py`
+
+Behavior group tested:
+
+- `GENIA_STATE.md` must gain and preserve an explicit R5 native-test / pytest / shared-spec placement boundary before DOCS sync is considered complete.
+
+Contract invariants covered:
+
+- Native tests complement pytest and shared semantic specs.
+- Native tests do not replace pytest or shared semantic specs.
+- Native-test placement is for Genia-facing behavior.
+- Python pytest remains the placement for parser, Core IR, host adapter, CLI harness, spec runner, and other host/internal surfaces.
+- Shared semantic specs remain authoritative for covered portable observable behavior.
+- Native-test support remains Experimental and Python reference-host framed.
+- The boundary must not claim support for setup/teardown, fixtures, parameterized tests, snapshots, property tests, parallelism, filtering, broad discovery, or multi-host execution.
+
+Why a guardrail is appropriate:
+
+- The contract/design introduce a protected documentation boundary rather than executable behavior.
+- Existing `GENIA_STATE.md` has native-test layer and non-goal wording, but it does not yet contain the specific R5 placement boundary promised by the contract: native tests vs Python pytest vs shared semantic specs, including "complement, not replace."
+- The smallest useful guardrail is one doc-sync test against `GENIA_STATE.md`.
+
+---
+
+## 2. REQUIRED COVERAGE
+
+Happy path:
+
+- The future DOCS phase can satisfy the test by adding a concise `GENIA_STATE.md` section titled `Native test / pytest / shared-spec placement boundary` with the required contract wording.
+
+Edge / boundary cases:
+
+- The test checks all three placements: native tests, Python pytest, and shared semantic specs.
+- The test checks maturity/host framing: Experimental and Python reference host.
+- The test checks unsupported feature boundaries in the same section so future wording cannot silently imply current support.
+
+Failure cases:
+
+- Missing placement-boundary section fails.
+- Missing "complement / do not replace" wording fails.
+- Missing pytest/internal or shared-spec authority wording fails.
+- Missing unsupported-feature non-support wording fails.
+
+Nearby regression risk:
+
+- Existing native-test implementation-boundary docs could be mistaken for the new R5 placement boundary. This test requires the R5 boundary explicitly so DOCS sync cannot pass with only the older implementation-layer text.
+
+---
+
+## 3. EXECUTION
+
+Command run:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py::test_native_test_placement_boundary_stays_explicit_in_state
+```
+
+Result:
+
+- Failed as expected: `1 failed in 0.20s`.
+
+---
+
+## 4. FAILURE EVIDENCE
+
+Failing test:
+
+- `tests/doc/test_semantic_doc_sync.py::test_native_test_placement_boundary_stays_explicit_in_state`
+
+Failure summary:
+
+```text
+AssertionError: GENIA_STATE.md must document the R5 native-test / pytest / shared-spec placement boundary
+assert -1 != -1
+```
+
+Classification:
+
+- Expected failure, correct per contract/design.
+
+Why it fails:
+
+- `GENIA_STATE.md` does not yet contain the marker text `Native test / pytest / shared-spec placement boundary`.
+- That is the intended red signal for the later DOCS phase to add the authoritative boundary without changing runtime behavior.
+
+---
+
+## 5. AMBIGUITIES / BLOCKERS
+
+None.
+
+Stop after TEST. Do not implement docs sync in this phase.

--- a/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/04-implementation.md
+++ b/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/04-implementation.md
@@ -1,0 +1,111 @@
+# === GENIA IMPLEMENTATION ===
+
+CHANGE NAME:
+issue #510 r5-native-test-boundary
+
+CHANGE SLUG:
+issue-510-r5-native-test-boundary
+
+Issue: #510
+Type: contract
+Release classification: R5 - Native Test Expansion / Pytest Migration Wave 1
+Branch: `contract/issue-510-r5-native-test-boundary`
+Handoff directory: `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/`
+
+`GENIA_STATE.md` is final authority.
+
+This IMPLEMENTATION phase is docs/contract-only. It makes the approved failing doc guardrail pass and does not change runtime behavior, native-test behavior, parser behavior, IR behavior, CLI behavior, prelude behavior, host adapter behavior, spec runner behavior, shared specs, or native Genia tests.
+
+---
+
+## 0. BRANCH CHECK
+
+- Must NOT be on `main`: confirmed - current branch is `contract/issue-510-r5-native-test-boundary`.
+- Expected branch: `contract/issue-510-r5-native-test-boundary`.
+- Branch matches pre-flight / contract / design / failing-tests handoffs.
+- No merge, rebase, branch switch, or commit performed.
+
+---
+
+## 1. SUMMARY OF CHANGES
+
+Files changed:
+
+- `GENIA_STATE.md`
+- `tests/doc/test_semantic_doc_sync.py` (carried from TEST phase; unchanged by this implementation except now satisfied by `GENIA_STATE.md`)
+
+Section added:
+
+- `GENIA_STATE.md` near the existing native-test sections, immediately after the current native-test support limitations and before `## 9.1) Native test kernel core`.
+- Exact section heading: `### Native test / pytest / shared-spec placement boundary (Python reference host, Experimental)`.
+
+What the section states:
+
+- Native test support remains Experimental and backed by the Python reference host.
+- Native tests complement pytest and shared semantic specs.
+- Native tests do not replace pytest or shared semantic specs.
+- Genia-native tests belong to Genia-facing source behavior such as Outcome helpers, validation helpers, Flow/Seq visible behavior, Sheet helpers, user-facing examples, and similar prelude/source-level behavior.
+- Python pytest remains the home for parser, lexer, AST, Core IR, host/runtime internals, host adapter behavior, CLI harness internals, spec runner internals, Python-specific exception/normalization behavior, and native-test stack internals.
+- Shared semantic specs remain authoritative for portable observable CLI/eval/flow/error/parse/IR behavior where covered.
+- Unsupported native-test features remain unsupported: setup/teardown execution, setup/teardown, fixtures, parameterized tests, snapshots, property tests, parallelism, filtering, broad discovery, and multi-host execution.
+
+---
+
+## 2. SCOPE CONFIRMATION
+
+No runtime/native-test behavior changed.
+
+No edits were made to:
+
+- parser, lexer, AST, Core IR, lowering, evaluator, runtime, prelude, or builtins
+- CLI harness, native test kernel, native test CLI, or native test runner
+- host adapter or spec runner internals
+- shared spec YAML files
+- native Genia test fixtures
+
+No pytest tests were migrated. No native-test features were added.
+
+---
+
+## 3. VALIDATION
+
+Command:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py::test_native_test_placement_boundary_stays_explicit_in_state
+```
+
+Result:
+
+```text
+1 passed in 0.05s
+```
+
+Command:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py
+```
+
+Result:
+
+```text
+86 passed in 0.34s
+```
+
+---
+
+## 4. COMPLEXITY CHECK
+
+[x] Minimal and direct
+[ ] Broader than ideal but necessary
+[ ] Too broad
+
+The implementation is a single authoritative documentation subsection that satisfies the approved doc guardrail without touching behavior.
+
+---
+
+## 5. NOTES FOR LATER PHASES
+
+- Ignored handoff files under `.genia/process/tmp/` may need `git add -f` later if the process requires committing them.
+- Stop after IMPLEMENTATION. Do not proceed to DOC SYNC, AUDIT, or commit in this phase.

--- a/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/06-doc-sync.md
+++ b/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/06-doc-sync.md
@@ -1,0 +1,121 @@
+# === GENIA DOC SYNC ===
+
+CHANGE NAME:
+issue #510 r5-native-test-boundary
+
+CHANGE SLUG:
+issue-510-r5-native-test-boundary
+
+Issue: #510
+Type: contract
+Release classification: R5 — Native Test Expansion / Pytest Migration Wave 1
+Branch: `contract/issue-510-r5-native-test-boundary`
+Handoff directory: `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/`
+
+`GENIA_STATE.md` is final authority. This phase syncs documentation only; it changes no runtime, native-test, or test behavior.
+
+Process-file note: the LEAN doc-sync prompt (`docs/process/05-doc.md`) and the scaffolded handoff directory both designate `06-doc-sync.md` as the doc-sync output file. The `05-doc-sync.md` name in the invoking prompt was a typo; this is the canonical file.
+
+---
+
+## 0. BRANCH CHECK
+
+- Must NOT be on `main`: confirmed — current branch is `contract/issue-510-r5-native-test-boundary`.
+- Matches pre-flight / contract / design / test / implementation handoffs: confirmed.
+- No merge, rebase, or branch switch performed.
+- Uncommitted working-tree changes from earlier phases present (`GENIA_STATE.md`, `tests/doc/test_semantic_doc_sync.py`); untracked `.claude/settings.local.json` is unrelated tooling.
+
+---
+
+## 1. RESULT
+
+DOC SYNC is a **NO-OP for source files**. No documentation files were changed.
+
+The implementation-phase `GENIA_STATE.md` update (section added at line 2261: `### Native test / pytest / shared-spec placement boundary (Python reference host, Experimental)`) already fully satisfies documentation sync. Every other doc surface that mentions native tests, pytest, shared specs, R5, or test migration was inspected and found already consistent with that authoritative boundary. No surface needed even a pointer, because the surfaces that discuss the topic already either describe the same split (release roadmap) or already point to `GENIA_STATE.md` (architecture, REPL readme, parking lot).
+
+---
+
+## 2. DOCS INSPECTED
+
+Searched for `native test`, `pytest`, `shared spec`, `R5`, `migrat`, `@test`, `fixture`, `parameteriz`, `setup/teardown`, `multi-host`, `replace` across:
+
+- `README.md` — native-test CLI entry points (lines ~280–282) labeled Experimental / Python reference host; shared CLI coverage of selected native test-runner outcomes (line ~119); test-suite note that pytest keeps Python-host-substrate coverage and `tests/native/*` provides selected Genia-native coverage (lines ~417–421). Consistent. No claim that native tests replace pytest; no unsupported-feature claims.
+- `GENIA_REPL_README.md` — native-test mode and assertion helpers (lines ~65, 73), Experimental / Python reference host, already pointing to `GENIA_STATE.md` §9.1.1 / §9.2. Consistent.
+- `GENIA_RULES.md` — `@test` semantics and native-test metadata rules (lines ~132, 159–167). These are evaluation/semantics facts unchanged by this boundary; no semantics changed, so no edit (per doc-sync rule "update RULES only if semantics changed").
+- `docs/strategy/release-roadmap.md` — R5 section (lines 229–262) already states the same split: move candidates (Outcome/validation/Flow-Seq/Sheet/prelude/examples) vs keep-in-pytest (parser internals, IR normalization, host adapter, CLI harness, spec runner, Python-specific plumbing); exit criterion "Documentation explains what belongs in native tests vs pytest" is now satisfied by the new `GENIA_STATE.md` section. No contradiction. R5 correctly remains a not-yet-complete release (this one boundary doc does not complete all of R5).
+- `docs/architecture/lifecycle.md`, `docs/architecture/execution-mode-lifecycle.md`, `docs/architecture/core-ir-portability.md` — describe lifecycle as inert/proposal, explicitly state setup/teardown and multi-host execution are not implemented, and point to `GENIA_STATE.md` §9.4–9.6. Consistent.
+- `docs/parking-lot/native-test-ergonomics.md` — explicitly non-authoritative; labels fixtures/property/snapshot/JSON-JUnit-TAP etc. as future ideas and defers to `GENIA_STATE.md`. Consistent.
+- `docs/book` — not present in this repo (no directory). Nothing to inspect.
+
+---
+
+## 3. FILES CHANGED
+
+None.
+
+---
+
+## 4. REQUIRED-CHECK CONFIRMATIONS
+
+- No inspected doc contradicts `GENIA_STATE.md`.
+- No doc implies native tests replace pytest or shared semantic specs. README and roadmap explicitly keep Python/host-internal coverage in pytest; shared specs retain authority for covered portable observable behavior.
+- No doc claims unsupported native-test features (setup/teardown execution, fixtures, parameterization, snapshots, property tests, parallelism, filtering, broad discovery, multi-host) as implemented. Such features appear only as explicitly-labeled out-of-scope, inert-proposal, or parking-lot ideas.
+- The new `GENIA_STATE.md` section remains the single source of truth for the boundary; no other doc required a new pointer.
+
+---
+
+## 5. VALIDATION
+
+Intended command (from invoking prompt):
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py
+```
+
+`uv run` could not provision the pinned interpreter in this environment (no network access to the python-build-standalone release asset). Ran the equivalent against the repo source with the system interpreter instead:
+
+```bash
+PYTHONPATH=src python3 -m pytest -q tests/doc/test_semantic_doc_sync.py
+```
+
+Result:
+
+```text
+86 passed in 0.78s
+```
+
+This includes `test_native_test_placement_boundary_stays_explicit_in_state`, which the implementation phase added and made pass. Count matches the implementation-phase result (86 passed). No regressions in the doc-sync suite.
+
+Caveat: validation was executed with system `python3` (3.10) + `PYTHONPATH=src` rather than the project's pinned `uv` toolchain, due to the sandbox network restriction. The doc-sync suite is pure-Python doc assertions and is interpreter-agnostic, so the result is trustworthy; a maintainer should re-run the canonical `uv` command in a networked environment as a final confirmation.
+
+---
+
+## 6. RUNTIME / NATIVE-TEST BEHAVIOR CONFIRMATION
+
+No runtime or native-test behavior changed in this phase.
+
+- No edits to parser, lexer, IR, lowering, evaluator, runtime, prelude, builtins.
+- No edits to CLI harness, native test kernel, native test runner, native test CLI.
+- No edits to host adapter or spec runner internals, shared spec YAML, or native Genia tests.
+- No pytest tests migrated; no native-test features added; R5 scope not broadened.
+- DOC SYNC itself wrote only this handoff file.
+
+---
+
+## 7. PROCESS NOTE
+
+Handoff files under `.genia/process/tmp/` are intended to be ignored/non-committed. If the local process requires committing phase artifacts, they may need `git add -f`. This decision belongs to AUDIT/commit, not DOC SYNC.
+
+---
+
+## 8. COMPLEXITY CHECK
+
+- [x] Minimal and clear
+- [ ] Slightly expanded but justified
+- [ ] Too verbose
+
+No source files changed; the authoritative boundary already lives in one place (`GENIA_STATE.md`).
+
+---
+
+DOC SYNC complete (no-op). Proceeding to AUDIT per the standing instruction to complete the remaining phases.

--- a/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/07-audit.md
+++ b/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/07-audit.md
@@ -1,0 +1,160 @@
+# === GENIA AUDIT ===
+
+CHANGE NAME:
+issue #510 r5-native-test-boundary
+
+CHANGE SLUG:
+issue-510-r5-native-test-boundary
+
+Issue: #510
+Type: contract
+Release classification: R5 — Native Test Expansion / Pytest Migration Wave 1
+Branch: `contract/issue-510-r5-native-test-boundary`
+Handoff directory: `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/`
+
+`GENIA_STATE.md` is final authority. Audited assuming the change is wrong until proven correct.
+
+---
+
+## 0. BRANCH CHECK
+
+- Not on `main`: confirmed — `contract/issue-510-r5-native-test-boundary`.
+- Branch matches the change across all handoffs: confirmed.
+- Unrelated changes: only untracked `.claude/settings.local.json` (local tooling, not part of this change). The two tracked modifications (`GENIA_STATE.md`, `tests/doc/test_semantic_doc_sync.py`) are exactly the change surface. No stray edits.
+- Note: the change is uncommitted; there are zero commits on the branch vs `main`. Commits were deferred by each phase prompt (see §7).
+
+---
+
+## 1. SUMMARY
+
+Status:
+
+- [x] PASS
+- [ ] PASS WITH ISSUES
+- [ ] FAIL
+
+The change adds one authoritative `GENIA_STATE.md` subsection documenting the R5 native-test / pytest / shared-spec placement boundary, plus one doc-guardrail test that protects its required wording. It introduces no runtime, native-test, parser, IR, CLI, prelude, host-adapter, spec-runner, or shared-spec behavior, and matches the contract and design exactly. Two minor, non-blocking notes are recorded below.
+
+---
+
+## 2. CORE CHECKS
+
+Contract ↔ Implementation: MATCH.
+- Contract §3/§4 placement rule (Genia-facing → native; host/internal → pytest; portable observable covered → shared spec; complement-not-replace; Experimental / Python reference host) is reproduced precisely in the new `GENIA_STATE.md` section (lines ~2261–2281).
+- Contract §8 non-goals (setup/teardown, fixtures, parameterization, snapshots, property tests, parallelism, filtering, broad discovery, multi-host) are all present as explicit "not implemented" lines.
+
+Design ↔ Implementation: MATCH.
+- Design called for a descriptive, maturity-labeled boundary subsection adjacent to the existing native-test sections. Implementation placed it immediately after "Native test layer boundaries" and before "## 9.1) Native test kernel core" — an adjacent, sensible location consistent with the design's "near §9.2 / §9.6" intent.
+- Design marked the placement table and the doc guardrail as optional. The table was not added (acceptable). The guardrail was added in the TEST phase and made green in IMPLEMENTATION (the test-first flow). No deviation of substance.
+
+Tests ↔ Contract: COVERED.
+- `test_native_test_placement_boundary_stays_explicit_in_state` asserts concrete required wording: complement / do-not-replace phrasing, Genia-facing placement, the pytest-home surfaces (parser, Core IR, host adapter, CLI harness, spec runner), shared-spec authority, Experimental + Python reference host, and a per-feature "not implemented / no <feature>" check for every unsupported feature. This maps 1:1 to the contract invariants for a docs-only change.
+
+Docs ↔ behavior: TRUTHFUL.
+- The section documents placement guidance only and changes no behavior. Every claim is maturity-labeled and consistent with the surrounding §9.x native-test facts.
+
+No scope expansion: CONFIRMED. Diff is limited to the `GENIA_STATE.md` subsection and the one guardrail test.
+
+Edge cases: the contract's "mixed surface → split, not duplicate" and "covered observable behavior stays in shared specs" rules are represented in the section's pytest-home and shared-spec paragraphs.
+
+Mismatches: none material (see §7 minor notes).
+
+---
+
+## 3. TEST QUALITY
+
+- Covers core behavior: YES — asserts the boundary section exists and contains each required clause.
+- Covers failure case: YES — TEST-phase handoff recorded the expected red (`1 failed`, marker absent) before implementation; the marker-find assertion fails if the section is removed or renamed.
+- Asserts concrete results: YES — exact normalized substrings, not vague presence checks.
+- Fails on regression: YES — removing any required clause or any unsupported-feature disclaimer fails the test.
+
+Gaps / risks: low. The guardrail is wording-based (appropriate for a docs boundary). It does not, and need not, assert runtime behavior because none changed.
+
+---
+
+## 4. DOC TRUTH
+
+- Reflects implemented behavior only: YES — it is a placement/guidance boundary over the already-implemented native-test stack; it claims no new capability.
+- Partial features marked: YES — labeled Experimental, Python reference host.
+- Avoids implying future capability: YES — unsupported features are each explicitly "not implemented".
+- Examples: none added; none rely on unimplemented features.
+
+Violations: none.
+
+---
+
+## 5. CONSISTENCY
+
+Cross-doc alignment verified in DOC SYNC and re-confirmed here:
+- `GENIA_STATE.md` (authoritative section) — source of truth.
+- `docs/strategy/release-roadmap.md` R5 section — same split; consistent (planning doc).
+- `README.md`, `GENIA_REPL_README.md`, `GENIA_RULES.md`, `docs/architecture/*`, `docs/parking-lot/native-test-ergonomics.md` — consistent; either describe the same split or point to `GENIA_STATE.md`; none imply native tests replace pytest; none claim unsupported features as implemented.
+
+Drift: none found.
+
+Risk level:
+- [x] Low
+- [ ] Medium
+- [ ] High
+
+---
+
+## 6. COMPLEXITY
+
+- [x] Minimal and necessary
+- [ ] Slightly complex but justified
+- [ ] Over-engineered
+
+One documentation subsection plus one guardrail test. Reveals existing structure; adds no surface area.
+
+---
+
+## 7. ISSUES
+
+Issue 1 — process/commit hygiene
+- Severity: [x] Minor
+- File(s): branch state (no commits).
+- Problem: The full change is uncommitted; AGENTS.md expects phase commits with prefixes (`test(...)`, `feat`/`docs(...)`, etc.), the failing-test commit before implementation, and the implementation commit referencing the failing-test SHA. None exist yet.
+- Why it matters: phase-commit traceability is part of the repo's workflow discipline.
+- Minimal fix: handle at the explicit commit step (out of scope for DOC SYNC / AUDIT / DISTILLATION, which the phase prompts instructed not to commit). Not a correctness blocker.
+
+Issue 2 — cosmetic wording (do not "fix" casually)
+- Severity: [x] Minor
+- File(s): `GENIA_STATE.md` (new section), line ~2273: "setup/teardown execution and setup/teardown are not implemented".
+- Problem: reads slightly redundant.
+- Why it matters / caution: the phrasing is load-bearing for the guardrail, which looks for the substring "setup/teardown are not implemented" (or "is not implemented" / "no setup/teardown"). Tightening to "setup/teardown execution is not implemented" would break that exact-substring check. Leave as-is, or change the doc and the guardrail together in a future change.
+- Minimal fix: none recommended now.
+
+---
+
+## 8. RECOMMENDED FIXES
+
+1. None blocking. Proceed to DISTILLATION, then to the commit step where the phase-commit prefixes and failing-test → implementation SHA linkage should be established.
+
+---
+
+## 9. VALIDATION
+
+- Tests executed: YES.
+  - `PYTHONPATH=src python3 -m pytest -q tests/doc/test_semantic_doc_sync.py` → `86 passed`.
+  - `PYTHONPATH=src python3 -m pytest -q tests/doc/test_semantic_doc_sync.py tests/unit/test_native_test_kernel.py tests/unit/test_native_test_cli.py tests/unit/test_outcome_native_tests.py` → `116 passed`.
+  - Includes `test_native_test_placement_boundary_stays_explicit_in_state` (green).
+- Results observed: YES (above).
+- Examples verified: N/A (no examples added/changed).
+- Docs checked against behavior: YES (DOC SYNC sweep + diff review).
+- Caveat: the canonical `uv run pytest` command could not provision the pinned interpreter offline in this environment; ran with system `python3` (3.10) + `PYTHONPATH=src`. The doc-sync/native-test suites are interpreter-agnostic, so results are trustworthy; a maintainer should re-run the canonical `uv` command in a networked environment before merge.
+
+---
+
+## KILLER WORKFLOW DRIFT CHECK
+
+- Stayed aligned: YES — indirectly strengthens Outcome-aware validated data pipelines by clarifying that Genia-facing Outcome/validation/Flow-Seq/Sheet/diagnostics behavior is the home for native tests.
+- General-purpose machinery added: NO.
+- Premature actors/UI/lifecycle/multi-host/demo work: NO — the section explicitly disclaims lifecycle execution and multi-host.
+- Docs imply strategy is implemented behavior: NO — strategy/roadmap remain labeled as planning; the boundary is maturity-labeled.
+
+---
+
+## FINAL VERDICT
+
+Ready to merge? YES — pending the standard commit step (phase-prefixed commits, failing-test → implementation SHA linkage) and a final canonical `uv run pytest` confirmation in a networked environment. No correctness, scope, or truth blockers.

--- a/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/08-distillation.md
+++ b/.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/08-distillation.md
@@ -1,0 +1,108 @@
+# === GENIA DISTILLATION ===
+
+CHANGE NAME:
+issue #510 r5-native-test-boundary
+
+CHANGE SLUG:
+issue-510-r5-native-test-boundary
+
+Issue: #510
+Type: contract
+Release classification: R5 — Native Test Expansion / Pytest Migration Wave 1
+Branch: `contract/issue-510-r5-native-test-boundary`
+Handoff directory: `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/`
+
+`GENIA_STATE.md` is final authority.
+
+---
+
+## 0. BRANCH CHECK
+
+- Not on `main`: confirmed — `contract/issue-510-r5-native-test-boundary`.
+- Matches pre-flight branch: confirmed.
+- No merge/rebase/switch.
+
+---
+
+## 1. EXTRACTED DURABLE CONTENT
+
+The only durable, canonical artifact produced by this change is the **native-test / pytest / shared-spec placement boundary**. It is already written, in canonical form, in `GENIA_STATE.md`:
+
+Invariants (durable):
+- Native tests complement pytest and shared semantic specs; they do not replace either.
+- Genia-native tests are for Genia-facing behavior verifiable in Genia source (Outcome helpers, validation helpers, Flow/Seq visible behavior, Sheet helpers, user-facing examples, prelude/source-level behavior).
+- Python pytest is the home for parser, lexer, AST, Core IR, host/runtime internals, host adapter behavior, CLI harness internals, spec runner internals, Python-specific exception/normalization behavior, and native-test stack internals.
+- Shared semantic specs remain authoritative for covered portable observable CLI/eval/flow/error/parse/IR behavior and must not be displaced by native tests.
+
+Maturity (durable):
+- Experimental, Python reference host.
+
+Tested limitations (durable):
+- setup/teardown execution, fixtures, parameterized tests, snapshots, property tests, parallelism, filtering, broad discovery, and multi-host execution are not implemented.
+
+Everything else across the handoffs is phase/process text (planning, branch checks, validation logs, scope-lock restatements) and is intentionally discarded — not migrated into docs.
+
+---
+
+## 2. DESTINATION FOR EACH ITEM
+
+- Placement boundary invariants + maturity + limitations → `GENIA_STATE.md`, section `### Native test / pytest / shared-spec placement boundary (Python reference host, Experimental)` (already present, ~line 2261). No further edit required.
+- Wording guardrail → `tests/doc/test_semantic_doc_sync.py::test_native_test_placement_boundary_stays_explicit_in_state` (already present). Durable; keeps the section from drifting.
+- No content maps to `GENIA_RULES.md` (no semantics changed), `README.md`, `GENIA_REPL_README.md`, or `docs/design/*`. The roadmap (`docs/strategy/release-roadmap.md` R5) already carries an aligned planning-level description and needs no change.
+
+No new doc categories created.
+
+---
+
+## 3. FILES UPDATED
+
+- None in this phase. Durable content was already canonicalized during IMPLEMENTATION; DISTILLATION confirms it and adds nothing.
+
+---
+
+## 4. CONSISTENCY CHECK
+
+- `GENIA_STATE.md` ↔ `GENIA_RULES.md` ↔ `README.md` ↔ `GENIA_REPL_README.md` ↔ `docs/architecture/*` ↔ `docs/strategy/release-roadmap.md` ↔ examples: aligned (verified in DOC SYNC and AUDIT). No contradictions. No doc implies native tests replace pytest/shared specs or claims unsupported features as implemented.
+
+---
+
+## 5. CLEANUP
+
+Process-artifact containment:
+- The handoff directory `.genia/process/tmp/handoffs/issue-510-r5-native-test-boundary/` is matched by `.gitignore` line 83 (`.genia/process/tmp/`) and is currently untracked.
+- No change-specific handoff/process content leaked into `docs/`. (A grep of `docs/` for handoff terms matched only the legitimate, durable process templates under `docs/process/*`, e.g. `00-preflight.md`, `05-doc.md`; these are canonical process docs, not change artifacts.)
+
+Handoff directory status:
+- **Safe to delete.** All durable content has been extracted/confirmed into `GENIA_STATE.md` and the guardrail test; the handoff files hold only process state.
+- Repo-convention caveat: prior changes (e.g. `issue-450-*`, `issue-451-*`, `issue-452-*`) have their handoff files **tracked in git** despite the ignore rule, which means the established convention is to `git add -f` the handoff directory at commit time rather than delete it. Follow whichever the maintainer prefers — both are valid given the above. If retaining, force-add at the commit step; if not, the directory can be removed.
+- Handoff files were not migrated into `docs/`.
+
+---
+
+## 6. COMPLEXITY CHECK
+
+- [x] Minimal and clear
+- [ ] Slightly expanded but justified
+- [ ] Too verbose
+
+Durable content was already in the single authoritative location; distillation is confirmation plus cleanup guidance only.
+
+---
+
+## 7. OUTPUT SUMMARY
+
+1. Extracted durable content: the native-test / pytest / shared-spec placement boundary — invariants, Experimental / Python-reference-host maturity, and the list of unsupported features.
+2. Destination: `GENIA_STATE.md` boundary section (already present) + the doc-sync guardrail test (already present).
+3. Files updated this phase: none.
+4. Handoff directory: safe to delete (or `git add -f` per the existing repo convention for prior issues).
+5. Discarded content worth noting: all phase logs, branch checks, validation transcripts, and scope-lock restatements — intentionally not preserved, per distillation rules.
+
+---
+
+## 8. NOTES FOR THE COMMIT STEP (outside distillation scope)
+
+- The change is still uncommitted (`GENIA_STATE.md`, `tests/doc/test_semantic_doc_sync.py`). Per AGENTS.md, commit with phase-appropriate prefixes; the failing-test commit should precede implementation and the implementation commit should reference that SHA.
+- A stale `.git/index.lock` is present in this environment and could not be removed by this read-only session (`Operation not permitted`); it may need clearing before the next git write/commit.
+- `.claude/settings.local.json` is unrelated local tooling and should not be committed as part of this change.
+
+DISTILLATION complete. End of pipeline (DOC SYNC → AUDIT → DISTILLATION done; no commit performed, per phase rules).

--- a/GENIA_STATE.md
+++ b/GENIA_STATE.md
@@ -2258,6 +2258,28 @@ Current native test behavior distinguishes:
 
 Current native test support is not a complete test framework; lifecycle hooks, `@setup`/`@teardown` annotations, setup/teardown, fixtures, parameterized tests, broad directory discovery, and multi-host conformance are out of scope in this phase.
 
+### Native test / pytest / shared-spec placement boundary (Python reference host, Experimental)
+
+Native test support remains Experimental and backed by the Python reference host in this phase. Native tests complement pytest and shared semantic specs. Native tests do not replace pytest or shared semantic specs.
+
+Genia-native tests belong to Genia-facing behavior that can be expressed and verified in Genia source from the user's perspective. Appropriate native-test coverage includes Outcome helpers, validation helpers, Flow/Seq visible behavior, Sheet helpers, user-facing examples, and similar prelude/source-level behavior.
+
+Python pytest remains the home for parser, lexer, AST, Core IR, host/runtime internals, host adapter behavior, CLI harness internals, spec runner internals, Python-specific exception/normalization behavior, and native-test stack internals such as the kernel, CLI/test-mode layer, discovery validation, duplicate-name machinery, and inert lifecycle descriptor validation.
+
+Shared semantic specs remain authoritative for portable observable CLI/eval/flow/error/parse/IR behavior where covered. Covered portable observable behavior must stay in shared specs and must not be moved into native tests as a replacement.
+
+Unsupported native-test features remain unsupported in this phase:
+
+- setup/teardown execution and setup/teardown are not implemented
+- fixtures are not implemented
+- parameterized tests are not implemented
+- snapshots are not implemented
+- property tests are not implemented
+- parallelism is not implemented
+- filtering is not implemented
+- broad discovery is not implemented
+- multi-host execution is not implemented
+
 ## 9.1) Native test kernel core (Python reference host, Experimental)
 
 LANGUAGE CONTRACT:

--- a/tests/doc/test_semantic_doc_sync.py
+++ b/tests/doc/test_semantic_doc_sync.py
@@ -1061,3 +1061,59 @@ def test_r3_native_test_roadmap_stays_separate_from_r4_lifecycle_generalization(
     assert "setup/teardown lifecycle hooks" in state, (
         "GENIA_STATE.md must keep lifecycle non-goals visible"
     )
+
+
+def test_native_test_placement_boundary_stays_explicit_in_state() -> None:
+    state = read_text("GENIA_STATE.md")
+    marker = "Native test / pytest / shared-spec placement boundary"
+    start = state.find(marker)
+    assert start != -1, (
+        "GENIA_STATE.md must document the R5 native-test / pytest / shared-spec "
+        "placement boundary"
+    )
+
+    section_after = state[start:]
+    next_section = section_after.find("\n## ", 1)
+    section = section_after[:next_section] if next_section > 0 else section_after
+    normalized = normalize(section)
+
+    required = [
+        "native tests complement pytest and shared semantic specs",
+        "native tests do not replace pytest or shared semantic specs",
+        "genia-facing behavior",
+        "python pytest",
+        "parser",
+        "core ir",
+        "host adapter",
+        "cli harness",
+        "spec runner",
+        "shared semantic specs remain authoritative",
+        "experimental",
+        "python reference host",
+    ]
+    for excerpt in required:
+        assert normalize(excerpt) in normalized, (
+            "GENIA_STATE.md native-test placement boundary is missing required "
+            f"wording: {excerpt}"
+        )
+
+    unsupported_features = [
+        "setup/teardown",
+        "fixtures",
+        "parameterized tests",
+        "snapshots",
+        "property tests",
+        "parallelism",
+        "filtering",
+        "broad discovery",
+        "multi-host execution",
+    ]
+    for feature in unsupported_features:
+        assert (
+            normalize(f"{feature} are not implemented") in normalized
+            or normalize(f"{feature} is not implemented") in normalized
+            or normalize(f"no {feature}") in normalized
+        ), (
+            "GENIA_STATE.md native-test placement boundary must keep unsupported "
+            f"native-test feature out of current support claims: {feature}"
+        )


### PR DESCRIPTION
## Summary

Defines the R5 native-test placement boundary in `GENIA_STATE.md` and adds a doc-sync guardrail to keep it explicit.

This change clarifies that Genia-native tests are for Genia-facing source behavior, while Python pytest remains the home for parser/IR/host/runtime/spec-runner internals, and shared semantic specs remain authoritative for portable observable behavior where covered.

## What changed

* Added `GENIA_STATE.md` section:

  * `Native test / pytest / shared-spec placement boundary (Python reference host, Experimental)`
* Documented that native tests:

  * are Experimental and Python-reference-host backed
  * complement pytest and shared semantic specs
  * do not replace pytest or shared semantic specs
  * are appropriate for Outcome helpers, validation helpers, Flow/Seq visible behavior, Sheet helpers, user-facing examples, and similar Genia-facing source behavior
* Documented that pytest remains responsible for:

  * parser, lexer, AST, Core IR
  * host/runtime internals
  * host adapter behavior
  * CLI harness internals
  * spec runner internals
  * Python-specific exception/normalization behavior
  * native-test stack internals
* Documented that shared semantic specs remain authoritative for covered portable CLI/eval/flow/error/parse/IR behavior.
* Added a doc guardrail test in `tests/doc/test_semantic_doc_sync.py` to prevent the placement boundary from drifting or disappearing.

## Not included

* No runtime behavior changes
* No native-test behavior changes
* No pytest migration
* No new native Genia tests
* No parser, IR, CLI, prelude, host adapter, or spec-runner changes
* No setup/teardown, fixtures, parameterized tests, snapshots, property tests, parallelism, filtering, broad discovery, or multi-host execution

## Validation

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/doc/test_semantic_doc_sync.py
```

```text
86 passed
```

```bash
UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uv run pytest -q tests/unit/test_native_test_kernel.py tests/unit/test_native_test_cli.py tests/unit/test_outcome_native_tests.py
```

```text
passed
```

## Commits

* `edc9861 test(docs): guard native test placement boundary issue #510`
* `885f63b docs(tests): define native test placement boundary issue #510`

close #510